### PR TITLE
completed script for updating terraform version

### DIFF
--- a/script.py
+++ b/script.py
@@ -1,0 +1,70 @@
+#!/usr/bin/env python3
+import os
+import re
+import argparse
+
+def strip_version_lines_from_file(file_path):
+    """
+    Open the given file, remove any line that sets `version = ...`,
+    and overwrite the file if any such lines were found.
+
+    Returns:
+        bool: True if we removed at least one version line (and rewrote the file),
+              False otherwise.
+    """
+    # A regex that matches lines like:    version = "1.2.3"
+    version_line_regex = re.compile(r'^\s*version\s*=.*$')
+
+    # Read in the entire file
+    with open(file_path, 'r', encoding='utf-8') as f:
+        original_lines = f.readlines()
+
+    # Keep only lines that do NOT match our "version =" pattern
+    filtered_lines = [
+        line for line in original_lines
+        if not version_line_regex.match(line)
+    ]
+
+    # If anything changed, write the cleaned content back out
+    if len(filtered_lines) != len(original_lines):
+        with open(file_path, 'w', encoding='utf-8') as f:
+            f.writelines(filtered_lines)
+        print(f"Removed version lines in: {file_path}")
+        return True
+
+    # No changes needed
+    return False
+
+def remove_versions_in_configs(root_folder):
+    """
+    Walk through every subdirectory starting at `root_folder`,
+    find files named exactly 'config.tf', and strip out any
+    version lines from them.
+    """
+    files_touched = 0
+
+    print(f"Scanning for config.tf files under: {root_folder}")
+    for current_dir, _, filenames in os.walk(root_folder):
+        for filename in filenames:
+            if filename.lower() == 'config.tf':
+                full_path = os.path.join(current_dir, filename)
+                if strip_version_lines_from_file(full_path):
+                    files_touched += 1
+
+    print(f"\nDone! Updated {files_touched} config.tf file(s).")
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Scan for all config.tf files and remove any 'version = …' lines."
+    )
+    parser.add_argument(
+        '--root',
+        default='.',
+        help="Directory to start scanning from (default: current folder)."
+    )
+    args = parser.parse_args()
+
+    remove_versions_in_configs(args.root)
+
+if __name__ == "__main__":
+    main()

--- a/update_tf_versions.py
+++ b/update_tf_versions.py
@@ -1,0 +1,76 @@
+#!/usr/bin/env python3
+import os
+import re
+import sys
+import json
+import argparse
+from urllib.request import urlopen, Request
+
+# Terraform Registry API URL for hashicorp/google provider versions
+REGISTRY_URL = "https://registry.terraform.io/v1/providers/hashicorp/google/versions"
+
+def get_latest_google_version():
+    """Fetch the latest hashicorp/google provider version from Terraform Registry."""
+    try:
+        req = Request(REGISTRY_URL, headers={"User-Agent": "python-urllib"})
+        with urlopen(req, timeout=10) as resp:
+            data = json.load(resp)
+    except Exception as e:
+        sys.exit(f" Failed to fetch registry data: {e}")
+    latest = data["versions"][0]["version"]
+    print(f"→ Latest hashicorp/google provider version: {latest}")
+    return latest
+
+def update_file(path, latest_version):
+    """
+    Replace any 'version = "old"' with the new latest_version in the given file.
+    Returns True if the file was changed.
+    """
+    pattern = re.compile(r'(version\s*=\s*")[^"]+(")')
+    changed = False
+
+    with open(path, 'r', encoding='utf-8') as f:
+        lines = f.readlines()
+
+    new_lines = []
+    for line in lines:
+        def repl(m):
+            return f"{m.group(1)}{latest_version}{m.group(2)}"
+        new_line = pattern.sub(repl, line)
+        if new_line != line:
+            changed = True
+        new_lines.append(new_line)
+
+    if changed:
+        with open(path, 'w', encoding='utf-8') as f:
+            f.writelines(new_lines)
+        print(f" Updated {path}")
+    return changed
+
+def walk_and_update(root, latest_version):
+    """Walk through root directory, updating any .tf files found."""
+    total = 0
+    for dirpath, _, filenames in os.walk(root):
+        for fn in filenames:
+            if fn.endswith('.tf'):
+                full = os.path.join(dirpath, fn)
+                if update_file(full, latest_version):
+                    total += 1
+    print(f"\n Completed: updated {total} file(s).")
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Update Terraform provider versions in all .tf files to the latest hashicorp/google provider."
+    )
+    parser.add_argument(
+        "--root",
+        default=".",
+        help="Root directory to begin searching (default: entire repo)."
+    )
+    args = parser.parse_args()
+
+    latest = get_latest_google_version()
+    walk_and_update(args.root, latest)
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Two quick Python scripts to keep your `.tf` files fresh:

- **update_tf_versions.py**  
  Finds every `.tf` file under the current directory and bumps your `hashicorp/google` provider to whatever’s newest on the Terraform Registry.  
  ```bash
  python update_tf_versions.py
  ````
- **script.py**
  Goes into your `config.tf` and nukes any `required_version = "x.y.z"` line so you aren’t locked into a specific Terraform version.

    ```bash
    python script.py
    ```
