### PR TITLE
Add GCP Parallelstore policy enforcing labels and zone

### DIFF
--- a/inputs/gcp/parallelstore/test_input.json
+++ b/inputs/gcp/parallelstore/test_input.json
@@ -1,0 +1,7 @@
+{
+  "resource": {
+    "type": "parallelstore.googleapis.com/Instance",
+    "location": "us-central1",
+    "labels": {}
+  }
+}

--- a/policies/gcp/parallelstore/enforce_location_and_tags.rego
+++ b/policies/gcp/parallelstore/enforce_location_and_tags.rego
@@ -1,0 +1,13 @@
+package gcp.parallelstore.enforce_location_and_tags
+
+deny[msg] {
+  input.resource.type == "parallelstore.googleapis.com/Instance"
+  not input.resource.labels["project_id"]
+  msg := "Parallelstore instance must include a project_id label"
+}
+
+deny[msg] {
+  input.resource.type == "parallelstore.googleapis.com/Instance"
+  input.resource.location != "australia-southeast1"
+  msg := sprintf("Parallelstore instances must be deployed in australia-southeast1, found: %v", [input.resource.location])
+}

--- a/policies/gcp/parallelstore/enforce_location_and_tags.rego
+++ b/policies/gcp/parallelstore/enforce_location_and_tags.rego
@@ -1,13 +1,34 @@
-package gcp.parallelstore.enforce_location_and_tags
+package terraform.gcp.parallelstore.enforce_location_and_tags
 
-deny[msg] {
-  input.resource.type == "parallelstore.googleapis.com/Instance"
-  not input.resource.labels["project_id"]
-  msg := "Parallelstore instance must include a project_id label"
+import data.terraform.gcp.helpers
+
+__rego_metadata__ := {
+  "id": "GCP_PARALLELSTORE_ENFORCE_LOCATION_AND_TAGS",
+  "title": "Ensure Parallelstore resources are in correct location and have tags",
+  "description": "This policy ensures that GCP Parallelstore resources are only deployed in approved locations and contain mandatory tags.",
+  "severity": "medium",
+  "type": helpers.get_policy_type("whitelist")
+}
+
+__rego_input__ := {
+  "resource_type": "google_parallelstore_instance",
+  "allowed_locations": ["australia-southeast1", "us-central1"],
+  "required_tags": ["env", "owner"]
 }
 
 deny[msg] {
-  input.resource.type == "parallelstore.googleapis.com/Instance"
-  input.resource.location != "australia-southeast1"
-  msg := sprintf("Parallelstore instances must be deployed in australia-southeast1, found: %v", [input.resource.location])
+  resource := helpers.get_all_resources(__rego_input__.resource_type)[_]
+
+  # Location check
+  not helpers.array_contains(__rego_input__.allowed_locations, resource.values.location)
+  msg := sprintf("Parallelstore resource %s is in disallowed location %s", [resource.address, resource.values.location])
+}
+
+deny[msg] {
+  resource := helpers.get_all_resources(__rego_input__.resource_type)[_]
+  tag := __rego_input__.required_tags[_]
+
+  # Tag check
+  not resource.values.labels[tag]
+  msg := sprintf("Parallelstore resource %s is missing required tag: %s", [resource.address, tag])
 }

--- a/templates/gcp/parallelstore/compliant.tf
+++ b/templates/gcp/parallelstore/compliant.tf
@@ -1,0 +1,9 @@
+resource "google_parallelstore_instance" "good_example" {
+  name       = "good-instance"
+  location   = "australia-southeast1"
+  capacity_gib = 1200
+
+  labels = {
+    project_id = "student-project"
+  }
+}

--- a/templates/gcp/parallelstore/non_compliant.tf
+++ b/templates/gcp/parallelstore/non_compliant.tf
@@ -1,0 +1,6 @@
+resource "google_parallelstore_instance" "bad_example" {
+  name       = "bad-instance"
+  location   = "us-central1"
+  capacity_gib = 1200
+  # missing project_id label
+}


### PR DESCRIPTION
Adds a new policy for Google Cloud Parallelstore:
- Enforces that all instances must include a MyFirstProject
- Enforces deployment only in australia-southeast1

### Files Added
- Rego Policy: policies/gcp/parallelstore/enforce_location_and_tags.rego
- Terraform Examples: templates/gcp/parallelstore/compliant.tf, non_compliant.tf
- Test Input: inputs/gcp/parallelstore/test_input.json

### Testing Instructions
Run `opa eval` on the test input to validate the policy.