### PR TITLE
Dataproc Metastore service 

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,2 @@
 # Policy-Deployment-Engine
+<google/service/dataproc_metastore>

--- a/inputs/gcp/Dataproc Metastore/federation/deletion_protection/.terraform.lock.hcl
+++ b/inputs/gcp/Dataproc Metastore/federation/deletion_protection/.terraform.lock.hcl
@@ -1,0 +1,21 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/google" {
+  version = "6.48.0"
+  hashes = [
+    "h1:rfboi/oqg/pRsCmraLdZdNX2uGzuaOgaXkSWcS1nhTQ=",
+    "zh:3640317ada2141ab5b54b5c5c2b1d0f60af861fb9788f05808b5d5d7ac8d1819",
+    "zh:4ec6082c343d7ea097bf725c7f550978789860f43b442a7709e1a4ca209d10a7",
+    "zh:66dcb85612f82c464a682e03a20e9dfd479e743d63a7e9cf754dcf81fa6e442b",
+    "zh:88ce6cb6f2f5f3a356c27ca5923594d272ea25801ed81026e102a2dc24d347d3",
+    "zh:b62e3715bf35fe0322b2a56c5072ecfdea2dd25f1c794f432acd1dd0105112b5",
+    "zh:bc2a9397c6d9b71ccf74cea442e74d8bb5603d491aa4a7cd88d5c44693674e16",
+    "zh:c6710acbdbaeca8307467186b0cc5184c8223fd0efa8c52e7f81310f34c68c69",
+    "zh:ca077af69ab66444bf027b7663e1386f2d14699b50562d1674c84522316bf52a",
+    "zh:e1b74bcdacb20d73da0470f6874dc7ac38b58bfa738ec5e337fcc7c5a4f32663",
+    "zh:e9b2dcd583025b69b7e80c9ad0d9ee4ed91e731f2073db5b6516978cf7617017",
+    "zh:f0d4ef4a8ca749b9102b152aafc093fa7def2afbda771b6b26cbc873f4e6dfc8",
+    "zh:f569b65999264a9416862bca5cd2a6177d94ccb0424f3a4ef424428912b9cb3c",
+  ]
+}

--- a/inputs/gcp/Dataproc Metastore/federation/deletion_protection/c.tf
+++ b/inputs/gcp/Dataproc Metastore/federation/deletion_protection/c.tf
@@ -1,0 +1,16 @@
+# Describe your resource type here
+# Keep "c" as the name to indicate that this resource and its attributes are compliant
+
+resource "google_dataproc_metastore_federation" "c" {
+  version             = "3.1.2"   #compitable version type
+  federation_id       = "metastore-fed" # good format
+  deletion_protection = false
+  project = 1
+
+  backend_metastores {
+    rank           = 0
+    metastore_type = "DATAPROC_METASTORE" # allowed type
+    name           = "projects/acme-data-01/locations/australia-southeast2/services/hive-prod" # AU region, valid format
+  }
+}
+

--- a/inputs/gcp/Dataproc Metastore/federation/deletion_protection/config.tf
+++ b/inputs/gcp/Dataproc Metastore/federation/deletion_protection/config.tf
@@ -1,0 +1,11 @@
+##### DO NOT EDIT ######
+
+terraform {
+  required_providers {
+    google = {
+      source  = "hashicorp/google"
+    }
+  }
+}
+
+provider "google" {}

--- a/inputs/gcp/Dataproc Metastore/federation/deletion_protection/nc.tf
+++ b/inputs/gcp/Dataproc Metastore/federation/deletion_protection/nc.tf
@@ -1,0 +1,17 @@
+# Describe your resource type here
+# Keep "nc" as the name to indicate that this resource and its attributes are non compliant
+
+resource "google_dataproc_metastore_federation" "nc" {
+  version             = "3.0.0"   #not a compatable version type
+  federation_id       = "metastore-fed"
+  deletion_protection = false
+  project = 1 
+
+  backend_metastores {
+    rank           = 5
+    metastore_type = "METASTORE_TYPE_UNSPECIFIED" # not in whitelist
+    name           = "projects/acme-data-01/locations/us-central1/services/hive-test" # wrong region
+  }
+}
+
+

--- a/inputs/gcp/Dataproc Metastore/federation/location/.terraform.lock.hcl
+++ b/inputs/gcp/Dataproc Metastore/federation/location/.terraform.lock.hcl
@@ -1,0 +1,21 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/google" {
+  version = "6.48.0"
+  hashes = [
+    "h1:rfboi/oqg/pRsCmraLdZdNX2uGzuaOgaXkSWcS1nhTQ=",
+    "zh:3640317ada2141ab5b54b5c5c2b1d0f60af861fb9788f05808b5d5d7ac8d1819",
+    "zh:4ec6082c343d7ea097bf725c7f550978789860f43b442a7709e1a4ca209d10a7",
+    "zh:66dcb85612f82c464a682e03a20e9dfd479e743d63a7e9cf754dcf81fa6e442b",
+    "zh:88ce6cb6f2f5f3a356c27ca5923594d272ea25801ed81026e102a2dc24d347d3",
+    "zh:b62e3715bf35fe0322b2a56c5072ecfdea2dd25f1c794f432acd1dd0105112b5",
+    "zh:bc2a9397c6d9b71ccf74cea442e74d8bb5603d491aa4a7cd88d5c44693674e16",
+    "zh:c6710acbdbaeca8307467186b0cc5184c8223fd0efa8c52e7f81310f34c68c69",
+    "zh:ca077af69ab66444bf027b7663e1386f2d14699b50562d1674c84522316bf52a",
+    "zh:e1b74bcdacb20d73da0470f6874dc7ac38b58bfa738ec5e337fcc7c5a4f32663",
+    "zh:e9b2dcd583025b69b7e80c9ad0d9ee4ed91e731f2073db5b6516978cf7617017",
+    "zh:f0d4ef4a8ca749b9102b152aafc093fa7def2afbda771b6b26cbc873f4e6dfc8",
+    "zh:f569b65999264a9416862bca5cd2a6177d94ccb0424f3a4ef424428912b9cb3c",
+  ]
+}

--- a/inputs/gcp/Dataproc Metastore/federation/location/c.tf
+++ b/inputs/gcp/Dataproc Metastore/federation/location/c.tf
@@ -1,0 +1,17 @@
+# Describe your resource type here
+# Keep "c" as the name to indicate that this resource and its attributes are compliant
+
+
+resource "google_dataproc_metastore_federation" "c" {
+  version             = "3.1.2"   # >= required minimum
+  federation_id       = "metastore-fed" # good format
+  location = "Global"
+  project = 1 
+
+  backend_metastores {
+    rank           = 0
+    metastore_type = "DATAPROC_METASTORE" # allowed type
+    name           = "projects/acme-data-01/locations/australia-southeast2/services/hive-prod" # AU region, valid format
+  }
+}
+

--- a/inputs/gcp/Dataproc Metastore/federation/location/config.tf
+++ b/inputs/gcp/Dataproc Metastore/federation/location/config.tf
@@ -1,0 +1,11 @@
+##### DO NOT EDIT ######
+
+terraform {
+  required_providers {
+    google = {
+      source  = "hashicorp/google"
+    }
+  }
+}
+
+provider "google" {}

--- a/inputs/gcp/Dataproc Metastore/federation/location/nc.tf
+++ b/inputs/gcp/Dataproc Metastore/federation/location/nc.tf
@@ -1,0 +1,16 @@
+# Describe your resource type here
+# Keep "nc" as the name to indicate that this resource and its attributes are non-compliant
+
+resource "google_dataproc_metastore_federation" "nc" {
+  version             = "3.0.0"   # less than 3.1.2
+  federation_id       = "metastore-fed"
+  deletion_protection = false
+  location = "US"
+  project = 1 
+
+  backend_metastores {
+    rank           = 5
+    metastore_type = "METASTORE_TYPE_UNSPECIFIED" # not in whitelist
+    name           = "projects/acme-data-01/locations/us-central1/services/hive-test" # wrong region
+  }
+}

--- a/inputs/gcp/Dataproc Metastore/service/database_type/.terraform.lock.hcl
+++ b/inputs/gcp/Dataproc Metastore/service/database_type/.terraform.lock.hcl
@@ -1,0 +1,21 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/google" {
+  version = "6.48.0"
+  hashes = [
+    "h1:rfboi/oqg/pRsCmraLdZdNX2uGzuaOgaXkSWcS1nhTQ=",
+    "zh:3640317ada2141ab5b54b5c5c2b1d0f60af861fb9788f05808b5d5d7ac8d1819",
+    "zh:4ec6082c343d7ea097bf725c7f550978789860f43b442a7709e1a4ca209d10a7",
+    "zh:66dcb85612f82c464a682e03a20e9dfd479e743d63a7e9cf754dcf81fa6e442b",
+    "zh:88ce6cb6f2f5f3a356c27ca5923594d272ea25801ed81026e102a2dc24d347d3",
+    "zh:b62e3715bf35fe0322b2a56c5072ecfdea2dd25f1c794f432acd1dd0105112b5",
+    "zh:bc2a9397c6d9b71ccf74cea442e74d8bb5603d491aa4a7cd88d5c44693674e16",
+    "zh:c6710acbdbaeca8307467186b0cc5184c8223fd0efa8c52e7f81310f34c68c69",
+    "zh:ca077af69ab66444bf027b7663e1386f2d14699b50562d1674c84522316bf52a",
+    "zh:e1b74bcdacb20d73da0470f6874dc7ac38b58bfa738ec5e337fcc7c5a4f32663",
+    "zh:e9b2dcd583025b69b7e80c9ad0d9ee4ed91e731f2073db5b6516978cf7617017",
+    "zh:f0d4ef4a8ca749b9102b152aafc093fa7def2afbda771b6b26cbc873f4e6dfc8",
+    "zh:f569b65999264a9416862bca5cd2a6177d94ccb0424f3a4ef424428912b9cb3c",
+  ]
+}

--- a/inputs/gcp/Dataproc Metastore/service/database_type/c.tf
+++ b/inputs/gcp/Dataproc Metastore/service/database_type/c.tf
@@ -1,0 +1,10 @@
+# Describe your resource type here
+# Keep "c" as the name to indicate that this resource and its attributes are compliant
+
+resource "google_dataproc_metastore_service" "c" {
+  service_id = "metastore-srv"
+  database_type = "MYSQL"
+  project = 1
+
+
+}

--- a/inputs/gcp/Dataproc Metastore/service/database_type/config.tf
+++ b/inputs/gcp/Dataproc Metastore/service/database_type/config.tf
@@ -1,0 +1,11 @@
+##### DO NOT EDIT ######
+
+terraform {
+  required_providers {
+    google = {
+      source  = "hashicorp/google"
+    }
+  }
+}
+
+provider "google" {}

--- a/inputs/gcp/Dataproc Metastore/service/database_type/nc.tf
+++ b/inputs/gcp/Dataproc Metastore/service/database_type/nc.tf
@@ -1,0 +1,11 @@
+# Describe your resource type here
+# Keep "nc" as the name to indicate that this resource and its attributes are non-compliant
+
+
+resource "google_dataproc_metastore_service" "nc" {
+  service_id = "_metastore-srv"
+  database_type = "SPANNER" #not a compliant database type
+  project = 1
+
+
+}

--- a/inputs/gcp/Dataproc Metastore/service/deletion_protection/.terraform.lock.hcl
+++ b/inputs/gcp/Dataproc Metastore/service/deletion_protection/.terraform.lock.hcl
@@ -1,0 +1,21 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/google" {
+  version = "6.48.0"
+  hashes = [
+    "h1:rfboi/oqg/pRsCmraLdZdNX2uGzuaOgaXkSWcS1nhTQ=",
+    "zh:3640317ada2141ab5b54b5c5c2b1d0f60af861fb9788f05808b5d5d7ac8d1819",
+    "zh:4ec6082c343d7ea097bf725c7f550978789860f43b442a7709e1a4ca209d10a7",
+    "zh:66dcb85612f82c464a682e03a20e9dfd479e743d63a7e9cf754dcf81fa6e442b",
+    "zh:88ce6cb6f2f5f3a356c27ca5923594d272ea25801ed81026e102a2dc24d347d3",
+    "zh:b62e3715bf35fe0322b2a56c5072ecfdea2dd25f1c794f432acd1dd0105112b5",
+    "zh:bc2a9397c6d9b71ccf74cea442e74d8bb5603d491aa4a7cd88d5c44693674e16",
+    "zh:c6710acbdbaeca8307467186b0cc5184c8223fd0efa8c52e7f81310f34c68c69",
+    "zh:ca077af69ab66444bf027b7663e1386f2d14699b50562d1674c84522316bf52a",
+    "zh:e1b74bcdacb20d73da0470f6874dc7ac38b58bfa738ec5e337fcc7c5a4f32663",
+    "zh:e9b2dcd583025b69b7e80c9ad0d9ee4ed91e731f2073db5b6516978cf7617017",
+    "zh:f0d4ef4a8ca749b9102b152aafc093fa7def2afbda771b6b26cbc873f4e6dfc8",
+    "zh:f569b65999264a9416862bca5cd2a6177d94ccb0424f3a4ef424428912b9cb3c",
+  ]
+}

--- a/inputs/gcp/Dataproc Metastore/service/deletion_protection/c.tf
+++ b/inputs/gcp/Dataproc Metastore/service/deletion_protection/c.tf
@@ -1,0 +1,10 @@
+# Describe your resource type here
+# Keep "c" as the name to indicate that this resource and its attributes are compliant
+
+resource "google_dataproc_metastore_service" "c" {
+  service_id = "metastore-srv"
+  deletion_protection = true
+  project = 1
+
+
+}

--- a/inputs/gcp/Dataproc Metastore/service/deletion_protection/config.tf
+++ b/inputs/gcp/Dataproc Metastore/service/deletion_protection/config.tf
@@ -1,0 +1,11 @@
+##### DO NOT EDIT ######
+
+terraform {
+  required_providers {
+    google = {
+      source  = "hashicorp/google"
+    }
+  }
+}
+
+provider "google" {}

--- a/inputs/gcp/Dataproc Metastore/service/deletion_protection/nc.tf
+++ b/inputs/gcp/Dataproc Metastore/service/deletion_protection/nc.tf
@@ -1,0 +1,9 @@
+# Describe your resource type here
+# Keep "nc" as the name to indicate that this resource and its attributes are non-compliant
+
+resource "google_dataproc_metastore_service" "nc" {
+  service_id = "_metastore-srv"
+  deletion_protection = false
+  project = 1
+
+}

--- a/inputs/gcp/Dataproc Metastore/service/location/.terraform.lock.hcl
+++ b/inputs/gcp/Dataproc Metastore/service/location/.terraform.lock.hcl
@@ -1,0 +1,21 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/google" {
+  version = "6.49.2"
+  hashes = [
+    "h1:mQ3VZqZyDmfbfzqU3egFMEiVyk8nv3CNubNBi2xo2Jo=",
+    "zh:04dbba38cc201d8f35f21c65fe5fe022b2ef30712c59d0b04df1182ee484ee29",
+    "zh:37478f37b696e214049a7c1e397a6ebcf6b10e3652a6275c5e99ef972a0cd17f",
+    "zh:3a68292e88e6612ed014e22d53a693859071337fcc49a244936094ae8f2b82d8",
+    "zh:4adc8c706652b6c170c520bd3815abba7e145aeec26a2abdfa8a98ae85fbfc0d",
+    "zh:5e8dbf922be32eb54c370260fd71e8124d4d7a3bddc2d0e6b47b15efc30a2224",
+    "zh:632bccc9396e61947242095738164ae27db060b1c172422b41e3b12e80236ecc",
+    "zh:66ee64a5621199868c8fa68492124d38b37e1d733d240508c595b124b5123cb7",
+    "zh:6843060f0673a4e556c248672171c8a29c7faeaee9954cdffeb19a55de7e5184",
+    "zh:87d3b0bd397de17ea6c8b34c898afb9f08eda28c6c6272d8dd75fe17ceef77f3",
+    "zh:9d2f0f93f4506dc0002c2dec1b2117626b6376c214653b71629a933ce77e3523",
+    "zh:e80ccae3d640dca17b496220e3f42f6f0cc4c6fb80ffae9e2bbaea446373c137",
+    "zh:f569b65999264a9416862bca5cd2a6177d94ccb0424f3a4ef424428912b9cb3c",
+  ]
+}

--- a/inputs/gcp/Dataproc Metastore/service/location/c.tf
+++ b/inputs/gcp/Dataproc Metastore/service/location/c.tf
@@ -1,0 +1,10 @@
+# Describe your resource type here
+# Keep "c" as the name to indicate that this resource and its attributes are compliant
+
+resource "google_dataproc_metastore_service" "c" {
+  service_id = "metastore-srv"
+  location = "global"
+  project = 1
+
+
+}

--- a/inputs/gcp/Dataproc Metastore/service/location/config.tf
+++ b/inputs/gcp/Dataproc Metastore/service/location/config.tf
@@ -1,0 +1,11 @@
+##### DO NOT EDIT ######
+
+terraform {
+  required_providers {
+    google = {
+      source  = "hashicorp/google"
+    }
+  }
+}
+
+provider "google" {}

--- a/inputs/gcp/Dataproc Metastore/service/location/nc.tf
+++ b/inputs/gcp/Dataproc Metastore/service/location/nc.tf
@@ -1,0 +1,10 @@
+# Describe your resource type here
+# Keep "nc" as the name to indicate that this resource and its attributes are non-compliant
+
+resource "google_dataproc_metastore_service" "nc" {
+  service_id = "metastore-srv"
+  location = "null"
+  project = 1
+
+
+}

--- a/inputs/gcp/Dataproc Metastore/service/port/.terraform.lock.hcl
+++ b/inputs/gcp/Dataproc Metastore/service/port/.terraform.lock.hcl
@@ -1,0 +1,21 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/google" {
+  version = "6.48.0"
+  hashes = [
+    "h1:rfboi/oqg/pRsCmraLdZdNX2uGzuaOgaXkSWcS1nhTQ=",
+    "zh:3640317ada2141ab5b54b5c5c2b1d0f60af861fb9788f05808b5d5d7ac8d1819",
+    "zh:4ec6082c343d7ea097bf725c7f550978789860f43b442a7709e1a4ca209d10a7",
+    "zh:66dcb85612f82c464a682e03a20e9dfd479e743d63a7e9cf754dcf81fa6e442b",
+    "zh:88ce6cb6f2f5f3a356c27ca5923594d272ea25801ed81026e102a2dc24d347d3",
+    "zh:b62e3715bf35fe0322b2a56c5072ecfdea2dd25f1c794f432acd1dd0105112b5",
+    "zh:bc2a9397c6d9b71ccf74cea442e74d8bb5603d491aa4a7cd88d5c44693674e16",
+    "zh:c6710acbdbaeca8307467186b0cc5184c8223fd0efa8c52e7f81310f34c68c69",
+    "zh:ca077af69ab66444bf027b7663e1386f2d14699b50562d1674c84522316bf52a",
+    "zh:e1b74bcdacb20d73da0470f6874dc7ac38b58bfa738ec5e337fcc7c5a4f32663",
+    "zh:e9b2dcd583025b69b7e80c9ad0d9ee4ed91e731f2073db5b6516978cf7617017",
+    "zh:f0d4ef4a8ca749b9102b152aafc093fa7def2afbda771b6b26cbc873f4e6dfc8",
+    "zh:f569b65999264a9416862bca5cd2a6177d94ccb0424f3a4ef424428912b9cb3c",
+  ]
+}

--- a/inputs/gcp/Dataproc Metastore/service/port/c.tf
+++ b/inputs/gcp/Dataproc Metastore/service/port/c.tf
@@ -1,0 +1,11 @@
+# Describe your resource type here
+# Keep "c" as the name to indicate that this resource and its attributes are compliant
+
+resource "google_dataproc_metastore_service" "c" {
+    service_id = "metastore-srv"
+    port = 9083
+    project = 1
+
+
+  
+}

--- a/inputs/gcp/Dataproc Metastore/service/port/config.tf
+++ b/inputs/gcp/Dataproc Metastore/service/port/config.tf
@@ -1,0 +1,11 @@
+##### DO NOT EDIT ######
+
+terraform {
+  required_providers {
+    google = {
+      source  = "hashicorp/google"
+    }
+  }
+}
+
+provider "google" {}

--- a/inputs/gcp/Dataproc Metastore/service/port/nc.tf
+++ b/inputs/gcp/Dataproc Metastore/service/port/nc.tf
@@ -1,0 +1,11 @@
+# Describe your resource type here
+# Keep "nc" as the name to indicate that this resource and its attributes are non-compliant
+
+
+resource "google_dataproc_metastore_service" "nc" {
+    service_id = "_metastore-srv"
+    port = 9084
+    project = 1
+
+  
+}

--- a/inputs/gcp/Dataproc Metastore/service/scheduled_backup/.terraform.lock.hcl
+++ b/inputs/gcp/Dataproc Metastore/service/scheduled_backup/.terraform.lock.hcl
@@ -1,0 +1,21 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/google" {
+  version = "6.48.0"
+  hashes = [
+    "h1:rfboi/oqg/pRsCmraLdZdNX2uGzuaOgaXkSWcS1nhTQ=",
+    "zh:3640317ada2141ab5b54b5c5c2b1d0f60af861fb9788f05808b5d5d7ac8d1819",
+    "zh:4ec6082c343d7ea097bf725c7f550978789860f43b442a7709e1a4ca209d10a7",
+    "zh:66dcb85612f82c464a682e03a20e9dfd479e743d63a7e9cf754dcf81fa6e442b",
+    "zh:88ce6cb6f2f5f3a356c27ca5923594d272ea25801ed81026e102a2dc24d347d3",
+    "zh:b62e3715bf35fe0322b2a56c5072ecfdea2dd25f1c794f432acd1dd0105112b5",
+    "zh:bc2a9397c6d9b71ccf74cea442e74d8bb5603d491aa4a7cd88d5c44693674e16",
+    "zh:c6710acbdbaeca8307467186b0cc5184c8223fd0efa8c52e7f81310f34c68c69",
+    "zh:ca077af69ab66444bf027b7663e1386f2d14699b50562d1674c84522316bf52a",
+    "zh:e1b74bcdacb20d73da0470f6874dc7ac38b58bfa738ec5e337fcc7c5a4f32663",
+    "zh:e9b2dcd583025b69b7e80c9ad0d9ee4ed91e731f2073db5b6516978cf7617017",
+    "zh:f0d4ef4a8ca749b9102b152aafc093fa7def2afbda771b6b26cbc873f4e6dfc8",
+    "zh:f569b65999264a9416862bca5cd2a6177d94ccb0424f3a4ef424428912b9cb3c",
+  ]
+}

--- a/inputs/gcp/Dataproc Metastore/service/scheduled_backup/c.tf
+++ b/inputs/gcp/Dataproc Metastore/service/scheduled_backup/c.tf
@@ -1,0 +1,12 @@
+# Describe your resource type here
+# Keep "c" as the name to indicate that this resource and its attributes are compliant
+
+resource "google_dataproc_metastore_service" "c" {
+  service_id = "metastore-srv"
+  project = 1
+
+  scheduled_backup {
+    backup_location = "gs://metastore-backup-123" # compliant example
+    enabled         = false # default is false
+  }
+}

--- a/inputs/gcp/Dataproc Metastore/service/scheduled_backup/config.tf
+++ b/inputs/gcp/Dataproc Metastore/service/scheduled_backup/config.tf
@@ -1,0 +1,11 @@
+##### DO NOT EDIT ######
+
+terraform {
+  required_providers {
+    google = {
+      source  = "hashicorp/google"
+    }
+  }
+}
+
+provider "google" {}

--- a/inputs/gcp/Dataproc Metastore/service/scheduled_backup/nc.tf
+++ b/inputs/gcp/Dataproc Metastore/service/scheduled_backup/nc.tf
@@ -1,0 +1,12 @@
+# Describe your resource type here
+# Keep "nc" as the name to indicate that this resource and its attributes are non-compliant
+
+resource "google_dataproc_metastore_service" "nc" {
+  service_id = "_metastore-srv"
+  project = 1
+
+  scheduled_backup {
+    backup_location = "invalid-location"  # non-compliant: not a gs:// URI
+    enabled         = true                # non-compliant for your rule
+  }
+}

--- a/policies/gcp/Dataproc Metastore/federation/deletion_protection/policy.rego
+++ b/policies/gcp/Dataproc Metastore/federation/deletion_protection/policy.rego
@@ -1,0 +1,52 @@
+package terraform.gcp.security.dataproc_metastore.federation.deletion_protection
+
+import data.terraform.gcp.helpers
+import data.terraform.gcp.security.dataproc_metastore.federation.vars
+
+conditions := [
+  [
+    {
+      "situation_description": "Check that the federation Hive metastore version is supported.",
+      "remedies": ["Update version to one of the supported values."]
+    },
+    {
+      "condition": "Test version of Apache Hive metastore",
+      "attribute_path": ["version"],
+      "values": ["3.1.2", "2.3.6", "2.2.0", "1.2.2"],
+      "policy_type": "whitelist"
+    }
+  ],
+  [
+    {
+      "situation_description": "Deletion protection is enabled, which may block necessary cleanup operations.",
+      "remedies": ["Set deletion_protection to false to allow resources to be deleted when required."]
+    },
+    {
+      "condition": "Checks that deletion_protection is disabled.",
+      "attribute_path": ["deletion_protection"],
+      "values": [false],
+      "policy_type": "blacklist"
+    }
+  ],
+  [
+    {
+      "situation_description": "Metastore type is not one of the approved types (DATAPROC_METASTORE or BIGQUERY).",
+      "remedies": ["Set metastore_type to DATAPROC_METASTORE or BIGQUERY."]
+    },
+    {
+      "condition": "Checks that metastore_type is in the approved list.",
+      "attribute_path": ["backend_metastore", 0, "metastore_type"  ],
+      "values": ["DATAPROC_METASTORE", "BIGQUERY"],
+      "policy_type": "whitelist"
+    }
+  ]
+]
+
+# Displays a general message about policy compliance
+# Use 'opa eval ... "data.terraform.gcp.security.<service>.<resource_type>.<policy_name>.message"
+message := helpers.get_multi_summary(conditions, vars.variables).message
+
+# Displays a detailed summary of each resources compliance to every condition and situation
+# Useful for debugging
+# Use 'opa eval ... "data.terraform.gcp.security.<service>.<resource_type>.<policy_name>.details"
+details := helpers.get_multi_summary(conditions, vars.variables).details

--- a/policies/gcp/Dataproc Metastore/federation/location/policy.rego
+++ b/policies/gcp/Dataproc Metastore/federation/location/policy.rego
@@ -1,0 +1,59 @@
+package terraform.gcp.security.dataproc_metastore.federation.location
+
+import data.terraform.gcp.helpers
+import data.terraform.gcp.security.dataproc_metastore.federation.vars
+
+conditions := [
+  [
+    {
+      "situation_description": "Check that the federation Hive metastore version is supported.",
+      "remedies": ["Update version to one of the supported values."]
+    },
+    {
+      "condition": "Test version of Apache Hive metastore",
+      "attribute_path": ["version"],
+      "values": ["3.1.2","2.3.6","2.2.0","1.2.2"],
+      "policy_type": "whitelist"
+    }
+  ],
+  [
+    {
+      "situation_description": "Metastore type is not one of the approved types (DATAPROC_METASTORE or BIGQUERY).",
+      "remedies": ["Set metastore_type to DATAPROC_METASTORE or BIGQUERY."]
+    },
+    {
+      "condition": "Checks that metastore_type is in the approved list.",
+      "attribute_path": ["backend_metastores",0,"metastore_type"],
+      "values": ["DATAPROC_METASTORE","BIGQUERY"],
+      "policy_type": "whitelist"
+    }
+  ],
+  [
+    {
+      "situation_description": "Location must be set to Australia (AU).",
+      "remedies": ["Set location to Global"]
+    },
+    {
+      "condition": "Checks location is Global",
+      "attribute_path": ["location"],
+      "values": ["Global"],
+      "policy_type": "whitelist"
+    }
+  ],
+  [
+    {
+      "situation_description": "Deletion protection is enabled, which may block necessary cleanup operations.",
+      "remedies": ["Set deletion_protection to false to allow resources to be deleted when required."]
+    },
+    {
+      "condition": "Checks that deletion_protection is disabled.",
+      "attribute_path": ["deletion_protection"],
+      "values": [false],
+      "policy_type": "whitelist"
+    }
+  ]
+]
+
+
+message := helpers.get_multi_summary(conditions, vars.variables).message
+details := helpers.get_multi_summary(conditions, vars.variables).details

--- a/policies/gcp/Dataproc Metastore/federation/vars.rego
+++ b/policies/gcp/Dataproc Metastore/federation/vars.rego
@@ -1,0 +1,7 @@
+package terraform.gcp.security.dataproc_metastore.federation.vars
+
+variables := {
+    "friendly_resource_name": "DPM federation", # eg., "GCS Bucket",
+    "resource_type":  "google_dataproc_metastore_federation", # eg., "google_storage_bucket"
+    "resource_value_name" : "federation_id"
+}

--- a/policies/gcp/Dataproc Metastore/service/database_type/policy.rego
+++ b/policies/gcp/Dataproc Metastore/service/database_type/policy.rego
@@ -1,0 +1,33 @@
+#package terraform.gcp.security.data.dataproc_metastore.service.database_type # Edit here 
+#import data.terraform.gcp.helpers
+#import data.terraform.gcp.security.metastore.service.vars
+
+package terraform.gcp.security.dataproc_metastore.service.database_type
+import data.terraform.gcp.helpers
+import data.terraform.gcp.security.dataproc_metastore.service.vars
+
+
+conditions := [
+  [
+    {
+      "situation_description": "Check that the database meets requirements",
+      "remedies": ["Database type must be MYSQL or SPANNER"]
+    },
+    {
+      "condition": "check database type is compliant",
+      "attribute_path": ["database_type"],
+      "values": ["MYSQL","SPANNER"],
+      "policy_type": "whitelist"
+    }
+  ]
+]
+
+
+# Displays a general message about policy compliance
+# Use 'opa eval ... "data.terraform.gcp.security.<service>.<resource_type>.<policy_name>.message"
+message := helpers.get_multi_summary(conditions, vars.variables).message
+
+# Displays a detailed summary of each resources compliance to every condition and situation
+# Useful for debugging
+# Use 'opa eval ... "data.terraform.gcp.security.<service>.<resource_type>.<policy_name>.details"
+details := helpers.get_multi_summary(conditions, vars.variables).details

--- a/policies/gcp/Dataproc Metastore/service/deletion_protection/policy.rego
+++ b/policies/gcp/Dataproc Metastore/service/deletion_protection/policy.rego
@@ -1,0 +1,28 @@
+package terraform.gcp.security.dataproc_metastore.service.deletion_protection
+import data.terraform.gcp.helpers
+import data.terraform.gcp.security.metastore.service.vars
+
+
+conditions := [
+[
+  {
+    "situation_description": "Metastore is not protected against accidental deletions.",
+    "remedies": ["Turn on deletion protection to prevent this"],
+  },
+  {
+    "condition": "Check if the metastore is protected against accidental deletion.",
+    "attribute_path": ["resources", "values", 0, "deletion_protection"],
+    "values": [true],
+    "policy_type": "whitelist"
+  }
+]
+]
+
+# Displays a general message about policy compliance
+# Use 'opa eval ... "data.terraform.gcp.security.<service>.<resource_type>.<policy_name>.message"
+message := helpers.get_multi_summary(conditions, vars.variables).message
+
+# Displays a detailed summary of each resources compliance to every condition and situation
+# Useful for debugging
+# Use 'opa eval ... "data.terraform.gcp.security.<service>.<resource_type>.<policy_name>.details"
+details := helpers.get_multi_summary(conditions, vars.variables).details

--- a/policies/gcp/Dataproc Metastore/service/location/policy.rego
+++ b/policies/gcp/Dataproc Metastore/service/location/policy.rego
@@ -1,0 +1,27 @@
+package terraform.gcp.security.dataproc_metastore.service.location
+import data.terraform.gcp.helpers
+import data.terraform.gcp.security.dataproc_metastore.service.vars
+
+conditions := [
+    [
+        {
+            "situation_description": "Location must be set to an approved value",
+            "remedies": ["Use an approved location (global)."]
+        },
+        {
+             "condition": "location is in the allow list",
+             "attribute_path": ["location"],
+             "values": ["global"],
+             "policy_type": "whitelist"
+        }
+    ]
+]
+
+# Displays a general message about policy compliance
+# Use 'opa eval ... "data.terraform.gcp.security.<service>.<resource_type>.<policy_name>.message"
+message := helpers.get_multi_summary(conditions, vars.variables).message
+
+# Displays a detailed summary of each resources compliance to every condition and situation
+# Useful for debugging
+# Use 'opa eval ... "data.terraform.gcp.security.<service>.<resource_type>.<policy_name>.details"
+details := helpers.get_multi_summary(conditions, vars.variables).details

--- a/policies/gcp/Dataproc Metastore/service/port/policy.rego
+++ b/policies/gcp/Dataproc Metastore/service/port/policy.rego
@@ -1,0 +1,27 @@
+package terraform.gcp.security.dataproc_metastore.service.port
+import data.terraform.gcp.helpers
+import data.terraform.gcp.security.dataproc_metastore.service.vars
+
+conditions := [
+    [
+        {
+            "situation_description": "Metastore is not using the default port.",
+            "remedies": ["Set port to 9083"]
+        },
+        {
+            "condition": "Check if the metastore port is set to the default (9083).",
+            "attribute_path": ["port"],
+            "values": [9083],
+            "policy_type": "whitelist"
+        }
+    ]
+]
+
+# Displays a general message about policy compliance
+# Use 'opa eval ... "data.terraform.gcp.security.<service>.<resource_type>.<policy_name>.message"
+message := helpers.get_multi_summary(conditions, vars.variables).message
+
+# Displays a detailed summary of each resources compliance to every condition and situation
+# Useful for debugging
+# Use 'opa eval ... "data.terraform.gcp.security.<service>.<resource_type>.<policy_name>.details"
+details := helpers.get_multi_summary(conditions, vars.variables).details

--- a/policies/gcp/Dataproc Metastore/service/scheduled_backup/policy.rego
+++ b/policies/gcp/Dataproc Metastore/service/scheduled_backup/policy.rego
@@ -1,0 +1,28 @@
+package terraform.gcp.security.dataproc_metastore.service.scheduled_backup
+
+import data.terraform.gcp.helpers
+import data.terraform.gcp.security.dataproc_metastore.service.vars
+
+conditions := [
+  [
+    {
+      "situation_description": "Scheduled backups are enabled when they should be disabled by policy.",
+      "remedies": ["Set scheduled_backup.enabled to false."]
+    },
+    {
+      "condition": "Checks that scheduled backups are disabled.",
+      "attribute_path": ["scheduled_backup", 0, "enabled"],
+      "values": [false],
+      "policy_type": "whitelist"
+    }
+  ]
+]
+
+# Displays a general message about policy compliance
+# Use 'opa eval ... "data.terraform.gcp.security.<service>.<resource_type>.<policy_name>.message"
+message := helpers.get_multi_summary(conditions, vars.variables).message
+
+# Displays a detailed summary of each resources compliance to every condition and situation
+# Useful for debugging
+# Use 'opa eval ... "data.terraform.gcp.security.<service>.<resource_type>.<policy_name>.details"
+details := helpers.get_multi_summary(conditions, vars.variables).details

--- a/policies/gcp/Dataproc Metastore/service/vars.rego
+++ b/policies/gcp/Dataproc Metastore/service/vars.rego
@@ -1,0 +1,8 @@
+
+package terraform.gcp.security.dataproc_metastore.service.vars
+
+variables := {
+    "friendly_resource_name": "DPM service", # eg., "GCS Bucket",
+    "resource_type":  "google_dataproc_metastore_service", # eg., "google_storage_bucket"
+    "resource_value_name" : "service_id"
+}


### PR DESCRIPTION
Policies written for dataproc_metastore_federation and dataproc_metastore_service these include deletion_protection, database_type, scheduled_backup, and location. 