### PR TITLE
gcp/service/BQ_data_transfer

### DIFF
--- a/inputs/gcp/bigquery_data_transfer/bigquery_data_transfer_config/destination_dataset_id/.terraform.lock.hcl
+++ b/inputs/gcp/bigquery_data_transfer/bigquery_data_transfer_config/destination_dataset_id/.terraform.lock.hcl
@@ -1,0 +1,21 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/google" {
+  version = "6.49.2"
+  hashes = [
+    "h1:Q1oDLBM6VLi58o0GuS8gk9pPqiYniQwrypqWSzMVMdI=",
+    "zh:04dbba38cc201d8f35f21c65fe5fe022b2ef30712c59d0b04df1182ee484ee29",
+    "zh:37478f37b696e214049a7c1e397a6ebcf6b10e3652a6275c5e99ef972a0cd17f",
+    "zh:3a68292e88e6612ed014e22d53a693859071337fcc49a244936094ae8f2b82d8",
+    "zh:4adc8c706652b6c170c520bd3815abba7e145aeec26a2abdfa8a98ae85fbfc0d",
+    "zh:5e8dbf922be32eb54c370260fd71e8124d4d7a3bddc2d0e6b47b15efc30a2224",
+    "zh:632bccc9396e61947242095738164ae27db060b1c172422b41e3b12e80236ecc",
+    "zh:66ee64a5621199868c8fa68492124d38b37e1d733d240508c595b124b5123cb7",
+    "zh:6843060f0673a4e556c248672171c8a29c7faeaee9954cdffeb19a55de7e5184",
+    "zh:87d3b0bd397de17ea6c8b34c898afb9f08eda28c6c6272d8dd75fe17ceef77f3",
+    "zh:9d2f0f93f4506dc0002c2dec1b2117626b6376c214653b71629a933ce77e3523",
+    "zh:e80ccae3d640dca17b496220e3f42f6f0cc4c6fb80ffae9e2bbaea446373c137",
+    "zh:f569b65999264a9416862bca5cd2a6177d94ccb0424f3a4ef424428912b9cb3c",
+  ]
+}

--- a/inputs/gcp/bigquery_data_transfer/bigquery_data_transfer_config/destination_dataset_id/c.tf
+++ b/inputs/gcp/bigquery_data_transfer/bigquery_data_transfer_config/destination_dataset_id/c.tf
@@ -1,8 +1,26 @@
-resource "google_bigquery_dataset" "my_dataset" "C" {
-  depends_on = [google_project_iam_member.permissions]
+variable "project_id" {
+  description = "GCP Project ID"
+  type        = string
+  default     = "civil-lightning-468910-m1"
+}
 
-  dataset_id    = "my_dataset"
-  friendly_name = "foo"
-  description   = "bar"
-  location      = "asia-northeast1"
+data "google_project" "project" {
+  project_id = var.project_id
+}
+
+resource "google_bigquery_data_transfer_config" "C" {
+  project                = "my_project_id"
+  display_name           = "Chhunly Data Transfer"
+  data_source_id         = "scheduled_query"
+  destination_dataset_id = "bq_customerdata"
+  schedule               = "every 24 hours"
+  location               = "australia-southeast1"
+
+  params = {
+    query                          = "SELECT CURRENT_DATE()"
+    destination_table_name_template = "output_table"
+    write_disposition              = "WRITE_TRUNCATE"
+  }
+
+  service_account_name = "service-${data.google_project.project.number}@gcp-sa-bigquerydatatransfer.iam.gserviceaccount.com"
 }

--- a/inputs/gcp/bigquery_data_transfer/bigquery_data_transfer_config/destination_dataset_id/c.tf
+++ b/inputs/gcp/bigquery_data_transfer/bigquery_data_transfer_config/destination_dataset_id/c.tf
@@ -1,0 +1,8 @@
+resource "google_bigquery_dataset" "my_dataset" "C" {
+  depends_on = [google_project_iam_member.permissions]
+
+  dataset_id    = "my_dataset"
+  friendly_name = "foo"
+  description   = "bar"
+  location      = "asia-northeast1"
+}

--- a/inputs/gcp/bigquery_data_transfer/bigquery_data_transfer_config/destination_dataset_id/config.tf
+++ b/inputs/gcp/bigquery_data_transfer/bigquery_data_transfer_config/destination_dataset_id/config.tf
@@ -1,0 +1,9 @@
+terraform {
+  required_providers {
+    google = {
+      source  = "hashicorp/google"
+    }
+  }
+}
+
+provider "google" {}

--- a/inputs/gcp/bigquery_data_transfer/bigquery_data_transfer_config/destination_dataset_id/nc.tf
+++ b/inputs/gcp/bigquery_data_transfer/bigquery_data_transfer_config/destination_dataset_id/nc.tf
@@ -1,0 +1,16 @@
+resource "google_bigquery_data_transfer_config" "NC" {
+  project                = "my_project_id"
+  display_name           = "Chhunly Data Transfer"
+  data_source_id         = "scheduled_query"
+  destination_dataset_id = "my_dataset"
+  schedule               = "every 24 hours"
+  location               = "us-central1"
+
+  params = {
+    query = "SELECT CURRENT_DATE()"
+    destination_table_name_template = "sample_output"
+    write_disposition               = "WRITE_TRUNCATE"
+  }
+
+  service_account_name = "service-1234567890@gcp-sa-bigquerydatatransfer.iam.gserviceaccount.com"
+}

--- a/inputs/gcp/bigquery_data_transfer/bigquery_data_transfer_config/encryption_configuration/.terraform.lock.hcl
+++ b/inputs/gcp/bigquery_data_transfer/bigquery_data_transfer_config/encryption_configuration/.terraform.lock.hcl
@@ -1,0 +1,21 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/google" {
+  version = "7.0.0"
+  hashes = [
+    "h1:UGZQpBqvTya6QY0X5mtTXg/nQR0OpIXB1sIgxOZFM44=",
+    "zh:006765cfabc014660550c09b75649b7a3795f932d45b1ec900edc83157ccddc3",
+    "zh:3af54215d25f3b77d75251c481e5fb5c229ce2d7ddb308b2999d9a45feb19cf7",
+    "zh:494aab76cf07e94f7d10cbe271f107c2c5fb9ccfef7db595c98bcd2abb52f812",
+    "zh:4c1f8c863cc3e27bda71800be0d7fc9cb9cc042f30297d3d4eed74b2e4d6eeae",
+    "zh:5f44834cbc21d7a3de77501f5124fa461ade594f28a56aabd203f0acfbf6754e",
+    "zh:6b699083095a73ef59e798aacdfc35cbf018296d3afc5d130409c59bd81398b1",
+    "zh:73bd5ec5952d7617095b1d48ac703c55745e35ab67f58621392f8b07bec2d226",
+    "zh:97515ae19204e49aa3bf148864ef4b1803fa2061f3ff9cd9f45fbb866984534a",
+    "zh:e35567aa33bdf3e2aebe11ccf3a3632e4b2834ce21d6eda71c7da06c1987d94f",
+    "zh:ea67bb3dad99756550dcbc44eb977842293daf30c88cbaf023cb734663bf2931",
+    "zh:f569b65999264a9416862bca5cd2a6177d94ccb0424f3a4ef424428912b9cb3c",
+    "zh:f79185a116cf02f61177b761929b59f55d0b8a0231333d63f669618953503533",
+  ]
+}

--- a/inputs/gcp/bigquery_data_transfer/bigquery_data_transfer_config/encryption_configuration/c.tf
+++ b/inputs/gcp/bigquery_data_transfer/bigquery_data_transfer_config/encryption_configuration/c.tf
@@ -1,0 +1,29 @@
+variable "project_id" {
+  description = "GCP Project ID"
+  type        = string
+  default     = "civil-lightning-468910-m1"
+}
+
+data "google_project" "project" {
+  project_id = var.project_id
+}
+
+resource "google_bigquery_data_transfer_config" "encryption_C" {
+  project                = "my_project_id"
+  display_name           = "Encrypted BQ Transfer"
+  data_source_id         = "scheduled_query"
+  destination_dataset_id = "my_dataset"
+  schedule               = "every 24 hours"
+
+  service_account_name = "service-${data.google_project.project.number}@gcp-sa-bigquerydatatransfer.iam.gserviceaccount.com"
+
+  encryption_configuration {
+    kms_key_name = "projects/your-project-id/locations/global/keyRings/your-keyring/cryptoKeys/your-key"
+  }
+
+  params = {
+    query                           = "SELECT CURRENT_DATE()"
+    destination_table_name_template = "my_table_$${run_time}"
+    write_disposition               = "WRITE_TRUNCATE"
+  }
+}

--- a/inputs/gcp/bigquery_data_transfer/bigquery_data_transfer_config/encryption_configuration/config.tf
+++ b/inputs/gcp/bigquery_data_transfer/bigquery_data_transfer_config/encryption_configuration/config.tf
@@ -1,0 +1,9 @@
+terraform {
+  required_providers {
+    google = {
+      source  = "hashicorp/google"
+    }
+  }
+}
+
+provider "google" {}

--- a/inputs/gcp/bigquery_data_transfer/bigquery_data_transfer_config/encryption_configuration/nc.tf
+++ b/inputs/gcp/bigquery_data_transfer/bigquery_data_transfer_config/encryption_configuration/nc.tf
@@ -1,0 +1,16 @@
+resource "google_bigquery_data_transfer_config" "encryption_NC" {
+
+  project                = "my_project_id"
+  display_name           = "Not BQ Transfer"
+  data_source_id         = "scheduled_query"
+  destination_dataset_id = "my_dataset"
+  schedule               = "every 24 hours"
+
+  service_account_name = "service-123456789012@gcp-sa-bigquerydatatransfer.iam.gserviceaccount.com"
+
+  params = {
+    query                            = "SELECT 'insecure';"
+    destination_table_name_template  = "bad_table_$${run_time}"
+    write_disposition                = "WRITE_APPEND"
+  }
+}

--- a/inputs/gcp/bigquery_data_transfer/bigquery_data_transfer_config/location/.terraform.lock.hcl
+++ b/inputs/gcp/bigquery_data_transfer/bigquery_data_transfer_config/location/.terraform.lock.hcl
@@ -1,0 +1,21 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/google" {
+  version = "6.49.1"
+  hashes = [
+    "h1:4mkZPor+3lHkvp8AnTX/D1cvBOHppNYpP5k7K5UEoyc=",
+    "zh:0fca29d64bee30984645a9c88076a5e26213b3f54b75a89ae64ca3148ea9fcd9",
+    "zh:2496949c284d0d0982a8d53ac18f5c3d8f52beb0b94109098847944a74f455be",
+    "zh:4ef9a757a13ec3b09779295ae5ee260dd230d430a1b1232152b0cef0f4e8d85d",
+    "zh:4f3ee24bb269fc959fbc667a90623753a8f2e11b37a0ce4cce3a12b3850e135c",
+    "zh:8f19463126b7343bef3ba6e544f3f97fb6e7b5f7a23efe4cb5f43089638c347d",
+    "zh:9555a8e37e9134f551a80e8bfb163a809dfe910deacf627b3e7ef00443b33761",
+    "zh:b88106d18d0fc6b5f146edecd51dc609edb5b7465628fb20f1d16b6e3b2cc31d",
+    "zh:bef2ee733f781b653b392b2d0a760ba806ba82468998fbdebe5a54eb90606d25",
+    "zh:cbd8664d1a3f86d53e45719ae7be0287ea17a506478ee3f1709efb603f42b84c",
+    "zh:dd06e17e62f38b5034bf120c13abee23786fc5445f77c5a03b5d85fa451319bb",
+    "zh:defd72f391ae8e83b74ef7ede6673c389d522f3e19b90ff5eb2d2971ac72a313",
+    "zh:f569b65999264a9416862bca5cd2a6177d94ccb0424f3a4ef424428912b9cb3c",
+  ]
+}

--- a/inputs/gcp/bigquery_data_transfer/bigquery_data_transfer_config/location/c.tf
+++ b/inputs/gcp/bigquery_data_transfer/bigquery_data_transfer_config/location/c.tf
@@ -1,0 +1,15 @@
+resource "google_bigquery_data_transfer_config" "C" {
+
+  display_name           = "my-query"
+  location               = "australia-southeast1"
+  data_source_id         = "scheduled_query"
+  schedule               = "first sunday of quarter 00:00"
+  destination_dataset_id = "my_dataset"
+  project                = "my_project_id"
+
+  params = {
+    destination_table_name_template = "my_table"
+    write_disposition               = "WRITE_APPEND"
+    query                           = "SELECT name FROM tabl WHERE x = 'y'"
+  }
+}

--- a/inputs/gcp/bigquery_data_transfer/bigquery_data_transfer_config/location/config.tf
+++ b/inputs/gcp/bigquery_data_transfer/bigquery_data_transfer_config/location/config.tf
@@ -1,0 +1,9 @@
+terraform {
+  required_providers {
+    google = {
+      source  = "hashicorp/google"
+    }
+  }
+}
+
+provider "google" {}

--- a/inputs/gcp/bigquery_data_transfer/bigquery_data_transfer_config/location/nc.tf
+++ b/inputs/gcp/bigquery_data_transfer/bigquery_data_transfer_config/location/nc.tf
@@ -1,0 +1,14 @@
+resource "google_bigquery_data_transfer_config" "NC" {
+  display_name           = "my-query"
+  data_source_id         = "scheduled_query"
+  location               = "asia-east1"  
+  schedule               = "first sunday of quarter 00:00"
+  destination_dataset_id = "my_dataset"
+  project                = "my_project_id"
+
+  params = {
+    query            = "SELECT CURRENT_DATE();"
+    destination_table_name_template = "daily_summary"
+    write_disposition = "WRITE_TRUNCATE"
+  }
+}

--- a/inputs/gcp/bigquery_data_transfer/bigquery_data_transfer_config/project/.terraform.lock.hcl
+++ b/inputs/gcp/bigquery_data_transfer/bigquery_data_transfer_config/project/.terraform.lock.hcl
@@ -1,0 +1,21 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/google" {
+  version = "7.0.0"
+  hashes = [
+    "h1:UGZQpBqvTya6QY0X5mtTXg/nQR0OpIXB1sIgxOZFM44=",
+    "zh:006765cfabc014660550c09b75649b7a3795f932d45b1ec900edc83157ccddc3",
+    "zh:3af54215d25f3b77d75251c481e5fb5c229ce2d7ddb308b2999d9a45feb19cf7",
+    "zh:494aab76cf07e94f7d10cbe271f107c2c5fb9ccfef7db595c98bcd2abb52f812",
+    "zh:4c1f8c863cc3e27bda71800be0d7fc9cb9cc042f30297d3d4eed74b2e4d6eeae",
+    "zh:5f44834cbc21d7a3de77501f5124fa461ade594f28a56aabd203f0acfbf6754e",
+    "zh:6b699083095a73ef59e798aacdfc35cbf018296d3afc5d130409c59bd81398b1",
+    "zh:73bd5ec5952d7617095b1d48ac703c55745e35ab67f58621392f8b07bec2d226",
+    "zh:97515ae19204e49aa3bf148864ef4b1803fa2061f3ff9cd9f45fbb866984534a",
+    "zh:e35567aa33bdf3e2aebe11ccf3a3632e4b2834ce21d6eda71c7da06c1987d94f",
+    "zh:ea67bb3dad99756550dcbc44eb977842293daf30c88cbaf023cb734663bf2931",
+    "zh:f569b65999264a9416862bca5cd2a6177d94ccb0424f3a4ef424428912b9cb3c",
+    "zh:f79185a116cf02f61177b761929b59f55d0b8a0231333d63f669618953503533",
+  ]
+}

--- a/inputs/gcp/bigquery_data_transfer/bigquery_data_transfer_config/project/c.tf
+++ b/inputs/gcp/bigquery_data_transfer/bigquery_data_transfer_config/project/c.tf
@@ -1,0 +1,15 @@
+variable "project_id" {
+  description = "GCP Project ID"
+  type        = string
+  default     = "civil-lightning-468910-m1"
+}
+
+data "google_project" "project" {
+  project_id = var.project_id
+}
+
+resource "google_project_iam_member" "permissions_C" {
+  project = var.project_id
+  role    = "roles/iam.serviceAccountTokenCreator"
+  member  = "serviceAccount:service-${data.google_project.project.number}@gcp-sa-bigquerydatatransfer.iam.gserviceaccount.com"
+}

--- a/inputs/gcp/bigquery_data_transfer/bigquery_data_transfer_config/project/config.tf
+++ b/inputs/gcp/bigquery_data_transfer/bigquery_data_transfer_config/project/config.tf
@@ -1,0 +1,9 @@
+terraform {
+  required_providers {
+    google = {
+      source  = "hashicorp/google"
+    }
+  }
+}
+
+provider "google" {}

--- a/inputs/gcp/bigquery_data_transfer/bigquery_data_transfer_config/project/nc.tf
+++ b/inputs/gcp/bigquery_data_transfer/bigquery_data_transfer_config/project/nc.tf
@@ -1,0 +1,6 @@
+resource "google_project_iam_member" "permissions_NC" {
+  project = "civil-lightning-468910-m1"  
+  role    = "roles/iam.serviceAccountTokenCreator"
+
+  member  = "serviceAccount:service-123456789012@gcp-sa-bigquerydatatransfer.iam.gserviceaccount.com"
+}

--- a/inputs/gcp/bigquery_data_transfer/bigquery_data_transfer_config/sensitive_params/.terraform.lock.hcl
+++ b/inputs/gcp/bigquery_data_transfer/bigquery_data_transfer_config/sensitive_params/.terraform.lock.hcl
@@ -1,0 +1,21 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/google" {
+  version = "7.0.1"
+  hashes = [
+    "h1:XS8MqGSQCMCAPCwkrxPDVM+HIVUvCLO36JnItB59EBs=",
+    "zh:1409f70a7757de222023d5859b1dbcab8f3bc744a81a4d7c39aac4cf249e16ad",
+    "zh:24ca670db87d5d075852b0df8fc0d198415b02d465e853d93a18e78b4dc2b8f9",
+    "zh:52b8139dc3acda118576c2cccd228fd8b85e20e1240b5002c0a8ee96a3ea6e9a",
+    "zh:59ea80da070ed2bd41361f86deb69c3ffd858f4fa797fff417594a74a01df661",
+    "zh:72e83d46ff2554282b2cec0532854d96eefb30feb36bcb09a64a30a16b1a0af0",
+    "zh:77e4f570fd4c82246ffff74a017037894442261ceb0c10d508fe2fd0dfcb44e3",
+    "zh:7d89312d3d6d07df563c297e0acc077c2eaf40c855d89dcd03872784a71cd627",
+    "zh:9bfc2947a9a77350ca0a4f221e7957f409effb7ff2375f7937622982c5abde92",
+    "zh:a026350f3e4f2edcae02faf8f49420e257ac6bd979fa9442e146f3fdc4a9becd",
+    "zh:a6c160c90f5ef3894ea904000ddf24a752b55bf8eabe5c0ba0d9db70e44a63d3",
+    "zh:c61eeb9d379e3759236073f91d908cd01f810556278a9db8d8b1864d474f2f78",
+    "zh:f569b65999264a9416862bca5cd2a6177d94ccb0424f3a4ef424428912b9cb3c",
+  ]
+}

--- a/inputs/gcp/bigquery_data_transfer/bigquery_data_transfer_config/sensitive_params/c.tf
+++ b/inputs/gcp/bigquery_data_transfer/bigquery_data_transfer_config/sensitive_params/c.tf
@@ -1,0 +1,30 @@
+variable "project_id" {
+  type        = string
+  default     = "civil-lightning-468910-m1"
+}
+
+variable "aws_access_key_id" {
+  type        = string
+  sensitive   = true
+}
+
+variable "aws_secret_access_key" {
+  type        = string
+  sensitive   = true
+}
+
+resource "google_bigquery_data_transfer_config" "C_transfer" {
+  project                = "my_project_id"
+  display_name           = "Secure S3 Transfer"
+  data_source_id         = "amazon_s3"
+  destination_dataset_id = "secure_dataset"
+  schedule               = "every 24 hours"
+
+  params = {
+    destination_table_name_template = "secure_table"
+    file_format                     = "CSV"
+    data_path                       = "s3://my-bucket/secure/"
+    aws_access_key_id               = var.aws_access_key_id
+    aws_secret_access_key           = var.aws_secret_access_key
+  }
+}

--- a/inputs/gcp/bigquery_data_transfer/bigquery_data_transfer_config/sensitive_params/config.tf
+++ b/inputs/gcp/bigquery_data_transfer/bigquery_data_transfer_config/sensitive_params/config.tf
@@ -1,0 +1,9 @@
+terraform {
+  required_providers {
+    google = {
+      source  = "hashicorp/google"
+    }
+  }
+}
+
+provider "google" {}

--- a/inputs/gcp/bigquery_data_transfer/bigquery_data_transfer_config/sensitive_params/nc.tf
+++ b/inputs/gcp/bigquery_data_transfer/bigquery_data_transfer_config/sensitive_params/nc.tf
@@ -1,0 +1,17 @@
+resource "google_bigquery_data_transfer_config" "NC_transfer" {
+  project                = "civil-lightning-468910-m1"
+  display_name           = "Noncompliant Amazon S3 Transfer"
+  data_source_id         = "amazon_s3"
+  destination_dataset_id = "insecure_dataset"
+  schedule               = "every 24 hours"
+  service_account_name   = "service-123456789012@gcp-sa-bigquerydatatransfer.iam.gserviceaccount.com"
+
+  params = {
+    destination_table_name_template = "test_table"
+    file_format                     = "CSV"
+    data_path                       = "s3://test-bucket/tmp/"
+
+    aws_access_key_id     = "EXAMPLEKEY"
+    aws_secret_access_key = "hardcoded-secret" 
+  }
+}

--- a/policies/gcp/bigquery_data_transfer/bigquery_data_transfer_config/destination_dataset_id/policy.rego
+++ b/policies/gcp/bigquery_data_transfer/bigquery_data_transfer_config/destination_dataset_id/policy.rego
@@ -1,0 +1,24 @@
+package terraform.gcp.security.bigquery_data_transfer.bigquery_data_transfer_config.destination_dataset_id
+import data.terraform.gcp.helpers
+import data.terraform.gcp.security.bigquery_data_transfer.bigquery_data_transfer_config.vars
+
+conditions := [
+  [
+    {
+      "situation_description": "The destination_dataset_id uses a weak, generic, or non-sense name such as 'my_', 'test', or 'foo'.",
+      "remedies": [
+        "Use a descriptive and production-ready dataset ID such as 'bq_customerdata' or 'prod_analytics'.",
+        "Avoid test names or placeholders in configurations."
+      ]
+    },
+    {
+      "condition": "Check if destination_dataset_id contains banned prefixes name",
+      "attribute_path": ["destination_dataset_id"],
+      "values": ["test", "foo", "bar", "my_", "temp", "default"],
+      "policy_type": "pattern blacklist"
+    }
+  ]
+]
+
+message := helpers.get_multi_summary(conditions, vars.variables).message
+details := helpers.get_multi_summary(conditions, vars.variables).details

--- a/policies/gcp/bigquery_data_transfer/bigquery_data_transfer_config/encryption_configuration/policy.rego
+++ b/policies/gcp/bigquery_data_transfer/bigquery_data_transfer_config/encryption_configuration/policy.rego
@@ -1,0 +1,23 @@
+package terraform.gcp.security.bigquery_data_transfer.bigquery_data_transfer_config.encryption_configuration
+import data.terraform.gcp.helpers
+import data.terraform.gcp.security.bigquery_data_transfer.bigquery_data_transfer_config.vars
+
+conditions := [
+  [
+    {
+      "situation_description": "The BigQuery Data Transfer config is missing customer-managed encryption.",
+      "remedies": [
+        "Add an encryption_configuration block with a valid kms_key_name.",
+      ]
+    },
+    {
+      "condition": "Check if kms_key_name is present",
+      "attribute_path": ["encryption_configuration", "kms_key_name"],
+      "values": [""],
+      "policy_type": "blacklist"
+    }
+  ]
+]
+
+message := helpers.get_multi_summary(conditions, vars.variables).message
+details := helpers.get_multi_summary(conditions, vars.variables).details

--- a/policies/gcp/bigquery_data_transfer/bigquery_data_transfer_config/location/policy.rego
+++ b/policies/gcp/bigquery_data_transfer/bigquery_data_transfer_config/location/policy.rego
@@ -1,0 +1,21 @@
+package terraform.gcp.security.bigquery_data_transfer.bigquery_data_transfer_config.location
+
+import data.terraform.gcp.helpers
+import data.terraform.gcp.security.bigquery_data_transfer.bigquery_data_transfer_config.vars
+
+# conditions describes: allow only australia-southeast1
+conditions := [[
+  {
+    "situation_description": "Location must be australia-southeast1 (Australia).",
+    "remedies": ["Set google_bigquery_data_transfer_config.location to \"australia-southeast1\"."]
+  },
+  {
+    "condition": "Location is not australia-southeast1",
+    "attribute_path": ["location"],                 # <-- STRING key, not a variable
+    "values": ["australia-southeast1"],             # <-- STRING value, not a variable
+    "policy_type": "whitelist"
+  }
+]]
+
+message := helpers.get_multi_summary(conditions, vars.variables).message
+details := helpers.get_multi_summary(conditions, vars.variables).details

--- a/policies/gcp/bigquery_data_transfer/bigquery_data_transfer_config/location/policy.rego
+++ b/policies/gcp/bigquery_data_transfer/bigquery_data_transfer_config/location/policy.rego
@@ -1,9 +1,7 @@
 package terraform.gcp.security.bigquery_data_transfer.bigquery_data_transfer_config.location
-
 import data.terraform.gcp.helpers
 import data.terraform.gcp.security.bigquery_data_transfer.bigquery_data_transfer_config.vars
 
-# conditions describes: allow only australia-southeast1
 conditions := [[
   {
     "situation_description": "Location must be australia-southeast1 (Australia).",

--- a/policies/gcp/bigquery_data_transfer/bigquery_data_transfer_config/project/policy.rego
+++ b/policies/gcp/bigquery_data_transfer/bigquery_data_transfer_config/project/policy.rego
@@ -1,0 +1,19 @@
+package terraform.gcp.security.bigquery_data_transfer.bigquery_data_transfer_config.project
+import data.terraform.gcp.helpers
+import data.terraform.gcp.security.bigquery_data_transfer.bigquery_data_transfer_config.vars
+
+conditions := [
+  [
+    {"situation_description": "IAM role assignment is hardcoded to a specific project",
+     "remedies": [ "Use a variable for project_id instead of a hardcoded string" ]},
+    {
+      "condition": "Project attribute must reference a variable, not a hardcoded string",
+      "attribute_path": ["project"],
+      "values": ["civil-lightning-468910-m1"],
+      "policy_type": "blacklist"
+    }
+  ],
+]
+
+message := helpers.get_multi_summary(conditions, vars.variables).message
+details := helpers.get_multi_summary(conditions, vars.variables).details

--- a/policies/gcp/bigquery_data_transfer/bigquery_data_transfer_config/sensitive_params/policy.rego
+++ b/policies/gcp/bigquery_data_transfer/bigquery_data_transfer_config/sensitive_params/policy.rego
@@ -1,0 +1,24 @@
+package terraform.gcp.security.bigquery_data_transfer.bigquery_data_transfer_config.sensitive_params
+import data.terraform.gcp.helpers
+import data.terraform.gcp.security.bigquery_data_transfer.bigquery_data_transfer_config.vars
+
+conditions := [
+  [
+    {
+      "situation_description": "Sensitive credentials such as AWS Access Key or Secret are hardcoded in the params block.",
+      "remedies": [
+        "Use Terraform variables marked as sensitive and avoid hardcoding credentials.",
+        "Store secrets in a secret manager and inject securely."
+      ]
+    },
+    {
+      "condition": "Detect hardcoded sensitive values like aws_access_key_id or aws_secret_access_key",
+      "attribute_path": ["change", "after", "params"],
+      "values": ["aws_access_key_id", "aws_secret_access_key"],
+      "policy_type": "blacklist"
+    }
+  ]
+]
+
+message := helpers.get_multi_summary(conditions, vars.variables).message
+details := helpers.get_multi_summary(conditions, vars.variables).details

--- a/policies/gcp/bigquery_data_transfer/vars.rego
+++ b/policies/gcp/bigquery_data_transfer/vars.rego
@@ -1,0 +1,8 @@
+package terraform.gcp.security.bigquery_data_transfer.bigquery_data_transfer_config.vars
+
+
+variables := {
+    "friendly_resource_name": "bigquery_data_transfer",  # eg., "GCS Bucket",
+    "resource_type":  "bigquery_data_transfer_config",   # eg., "google_storage_bucket"
+    "resource_value_name" : "name",                      # eg., "name"
+}


### PR DESCRIPTION
I have written a policy for

- destination_dataset_id to check for naming that does not make sense, like "test", "foo", "bar", "my_", "temp", "default".
- encryption_configuration check for customer-managed encryption key(CMEK) to tell Google not to use the default encryption key.
- location check for a valid location defined in the complaint
- project check if the project has my Google console ID in there or not
- sensitive_params check to detect hardcoded sensitive parameters (like AWS credentials) inside the params block of a google_bigquery_data_transfer_config Terraform resource.