### PR TITLE
Looker_core (11 security policies)

### DIFF
--- a/inputs/gcp/looker/core/cmek_required/.terraform.lock.hcl
+++ b/inputs/gcp/looker/core/cmek_required/.terraform.lock.hcl
@@ -1,0 +1,22 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/google" {
+  version     = "7.1.1"
+  constraints = "~> 7.1.1"
+  hashes = [
+    "h1:Hu/Gy8dB7TXsUyswqm6XJhr7esYmXk9Ea/Jo9VgT4LE=",
+    "zh:03ee9fdc0d157a606aba68658de6dc809fc3335cccb7c537373d8643412c1327",
+    "zh:110e8ffe81deb8c203ecf310a15c2dedca1dfc936473a247b8a4f98adebd86f5",
+    "zh:459e3419c004e7a475fb60cc52d47a34b3dc4e4de905eaa8e8f78ddbe550a9b5",
+    "zh:466cd31cee36877bc18aeabed80d1f4a22bac4e59a460be6e8bdb72dedca0e2b",
+    "zh:51d707eb2d854fa16dcbe21e29b01534eb893a2152a219ea84a15bbd87a4ff64",
+    "zh:69d6a1c83ffddd7f81273a98fb0ff7c13985a3c876565dd3df76c730c9929871",
+    "zh:9b5050da221735c7e8f75ed00d25578afaf8ed94a8c2f1f58f471eee98105d10",
+    "zh:ab01f2fd961ee86d99a55186093620d29f5323c0cd5613284d484e333679d70b",
+    "zh:d0f5b15774b15991baf71eb4a55a6831e3fb4b603f589f80b03393b46a9657a4",
+    "zh:dc198ec4b42435321f4fa12ca8d713cd350ff2f82d8749b87785b91b15b7c3ed",
+    "zh:e949c00ce89c92b7ed16cc0b0aed8e80d6416b240dc02047f9fa1de49aa4c44e",
+    "zh:f569b65999264a9416862bca5cd2a6177d94ccb0424f3a4ef424428912b9cb3c",
+  ]
+}

--- a/inputs/gcp/looker/core/cmek_required/c.tf
+++ b/inputs/gcp/looker/core/cmek_required/c.tf
@@ -1,0 +1,23 @@
+# Compliant Looker Core instance with CMEK enabled
+# This resource is compliant because encryption_config.kms_key_name is set
+
+resource "google_looker_instance" "c" {
+  name              = "looker-core-compliant-cmek"
+  platform_edition  = "LOOKER_CORE_STANDARD_ANNUAL"
+  region            = "us-central1"
+  public_ip_enabled = false
+  project           = var.project
+  encryption_config {
+    kms_key_name = "projects/test-project-123/locations/us-central1/keyRings/test-keyring/cryptoKeys/test-key"
+  }
+  
+  # Required fields for Looker Core
+  oauth_config {
+    client_id     = "test-client-id"
+    client_secret = "test-client-secret"
+  }
+}
+
+variable "project" {
+  type = string
+}

--- a/inputs/gcp/looker/core/cmek_required/c.tf
+++ b/inputs/gcp/looker/core/cmek_required/c.tf
@@ -1,23 +1,15 @@
-# Compliant Looker Core instance with CMEK enabled
-# This resource is compliant because encryption_config.kms_key_name is set
+variable "project" {
+  type = string
+}
 
-resource "google_looker_instance" "c" {
-  name              = "looker-core-compliant-cmek"
-  platform_edition  = "LOOKER_CORE_STANDARD_ANNUAL"
-  region            = "us-central1"
-  public_ip_enabled = false
-  project           = var.project
+resource "google_looker_instance" "ok" {
+  name    = "ok"
+  project = var.project
   encryption_config {
     kms_key_name = "projects/test-project-123/locations/us-central1/keyRings/test-keyring/cryptoKeys/test-key"
   }
-  
-  # Required fields for Looker Core
   oauth_config {
     client_id     = "test-client-id"
     client_secret = "test-client-secret"
   }
-}
-
-variable "project" {
-  type = string
 }

--- a/inputs/gcp/looker/core/cmek_required/config.tf
+++ b/inputs/gcp/looker/core/cmek_required/config.tf
@@ -1,0 +1,9 @@
+terraform {
+  required_providers {
+    google = {
+      source  = "hashicorp/google"
+      version = "~> 7.1.1"
+    }
+  }
+  required_version = ">= 1.0"
+}

--- a/inputs/gcp/looker/core/cmek_required/nc.tf
+++ b/inputs/gcp/looker/core/cmek_required/nc.tf
@@ -1,0 +1,17 @@
+# Non-compliant Looker Core instance without CMEK
+# This resource is non-compliant because encryption_config block is missing
+
+resource "google_looker_instance" "nc" {
+  name              = "looker-core-noncompliant-no-cmek"
+  platform_edition  = "LOOKER_CORE_STANDARD_ANNUAL"
+  region            = "us-central1"
+  public_ip_enabled = false
+  project           = var.project
+  # Missing encryption_config block - uses default Google-managed encryption
+  
+  # Required fields for Looker Core
+  oauth_config {
+    client_id     = "test-client-id"
+    client_secret = "test-client-secret"
+  }
+}

--- a/inputs/gcp/looker/core/cmek_required/nc.tf
+++ b/inputs/gcp/looker/core/cmek_required/nc.tf
@@ -1,15 +1,11 @@
-# Non-compliant Looker Core instance without CMEK
-# This resource is non-compliant because encryption_config block is missing
+variable "project" {
+  type = string
+}
 
-resource "google_looker_instance" "nc" {
-  name              = "looker-core-noncompliant-no-cmek"
-  platform_edition  = "LOOKER_CORE_STANDARD_ANNUAL"
-  region            = "us-central1"
-  public_ip_enabled = false
-  project           = var.project
-  # Missing encryption_config block - uses default Google-managed encryption
-  
-  # Required fields for Looker Core
+resource "google_looker_instance" "bad" {
+  name    = "bad"
+  project = var.project
+  # encryption_config intentionally omitted to trigger failure
   oauth_config {
     client_id     = "test-client-id"
     client_secret = "test-client-secret"

--- a/inputs/gcp/looker/core/consumer_network_set/.terraform.lock.hcl
+++ b/inputs/gcp/looker/core/consumer_network_set/.terraform.lock.hcl
@@ -1,0 +1,22 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/google" {
+  version     = "7.1.1"
+  constraints = "~> 7.1.1"
+  hashes = [
+    "h1:Hu/Gy8dB7TXsUyswqm6XJhr7esYmXk9Ea/Jo9VgT4LE=",
+    "zh:03ee9fdc0d157a606aba68658de6dc809fc3335cccb7c537373d8643412c1327",
+    "zh:110e8ffe81deb8c203ecf310a15c2dedca1dfc936473a247b8a4f98adebd86f5",
+    "zh:459e3419c004e7a475fb60cc52d47a34b3dc4e4de905eaa8e8f78ddbe550a9b5",
+    "zh:466cd31cee36877bc18aeabed80d1f4a22bac4e59a460be6e8bdb72dedca0e2b",
+    "zh:51d707eb2d854fa16dcbe21e29b01534eb893a2152a219ea84a15bbd87a4ff64",
+    "zh:69d6a1c83ffddd7f81273a98fb0ff7c13985a3c876565dd3df76c730c9929871",
+    "zh:9b5050da221735c7e8f75ed00d25578afaf8ed94a8c2f1f58f471eee98105d10",
+    "zh:ab01f2fd961ee86d99a55186093620d29f5323c0cd5613284d484e333679d70b",
+    "zh:d0f5b15774b15991baf71eb4a55a6831e3fb4b603f589f80b03393b46a9657a4",
+    "zh:dc198ec4b42435321f4fa12ca8d713cd350ff2f82d8749b87785b91b15b7c3ed",
+    "zh:e949c00ce89c92b7ed16cc0b0aed8e80d6416b240dc02047f9fa1de49aa4c44e",
+    "zh:f569b65999264a9416862bca5cd2a6177d94ccb0424f3a4ef424428912b9cb3c",
+  ]
+}

--- a/inputs/gcp/looker/core/consumer_network_set/c.tf
+++ b/inputs/gcp/looker/core/consumer_network_set/c.tf
@@ -1,22 +1,13 @@
-# Compliant Looker Core instance with consumer network set
-# This resource is compliant because consumer_network is configured for private connectivity
+variable "project" {
+  type = string
+}
 
-resource "google_looker_instance" "c" {
-  name              = "looker-core-compliant-consumer-network"
-  platform_edition  = "LOOKER_CORE_STANDARD_ANNUAL"
-  region            = "us-central1"
-  public_ip_enabled = false
-  private_ip_enabled = true # Required for consumer_network
-  consumer_network  = "projects/test-project-123/global/networks/test-vpc"
-  project           = var.project
-  
-  # Required fields for Looker Core
+resource "google_looker_instance" "ok" {
+  name             = "ok"
+  project          = var.project
+  consumer_network = "projects/test-project-123/global/networks/test-vpc"
   oauth_config {
     client_id     = "test-client-id"
     client_secret = "test-client-secret"
   }
-}
-
-variable "project" {
-  type = string
 }

--- a/inputs/gcp/looker/core/consumer_network_set/c.tf
+++ b/inputs/gcp/looker/core/consumer_network_set/c.tf
@@ -1,0 +1,22 @@
+# Compliant Looker Core instance with consumer network set
+# This resource is compliant because consumer_network is configured for private connectivity
+
+resource "google_looker_instance" "c" {
+  name              = "looker-core-compliant-consumer-network"
+  platform_edition  = "LOOKER_CORE_STANDARD_ANNUAL"
+  region            = "us-central1"
+  public_ip_enabled = false
+  private_ip_enabled = true # Required for consumer_network
+  consumer_network  = "projects/test-project-123/global/networks/test-vpc"
+  project           = var.project
+  
+  # Required fields for Looker Core
+  oauth_config {
+    client_id     = "test-client-id"
+    client_secret = "test-client-secret"
+  }
+}
+
+variable "project" {
+  type = string
+}

--- a/inputs/gcp/looker/core/consumer_network_set/config.tf
+++ b/inputs/gcp/looker/core/consumer_network_set/config.tf
@@ -1,0 +1,9 @@
+terraform {
+  required_providers {
+    google = {
+      source  = "hashicorp/google"
+      version = "~> 7.1.1"
+    }
+  }
+  required_version = ">= 1.0"
+}

--- a/inputs/gcp/looker/core/consumer_network_set/nc.tf
+++ b/inputs/gcp/looker/core/consumer_network_set/nc.tf
@@ -1,16 +1,11 @@
-# Non-compliant Looker Core instance without consumer network
-# This resource is non-compliant because consumer_network is missing for private connectivity
+variable "project" {
+  type = string
+}
 
-resource "google_looker_instance" "nc" {
-  name              = "looker-core-noncompliant-no-consumer-network"
-  platform_edition  = "LOOKER_CORE_STANDARD_ANNUAL"
-  region            = "us-central1"
-  public_ip_enabled = false
-  private_ip_enabled = true # Private connectivity but no consumer_network
-  project           = var.project
-  # Missing consumer_network field
-  
-  # Required fields for Looker Core
+resource "google_looker_instance" "bad" {
+  name    = "bad"
+  project = var.project
+  # consumer_network intentionally omitted to trigger failure
   oauth_config {
     client_id     = "test-client-id"
     client_secret = "test-client-secret"

--- a/inputs/gcp/looker/core/consumer_network_set/nc.tf
+++ b/inputs/gcp/looker/core/consumer_network_set/nc.tf
@@ -1,0 +1,18 @@
+# Non-compliant Looker Core instance without consumer network
+# This resource is non-compliant because consumer_network is missing for private connectivity
+
+resource "google_looker_instance" "nc" {
+  name              = "looker-core-noncompliant-no-consumer-network"
+  platform_edition  = "LOOKER_CORE_STANDARD_ANNUAL"
+  region            = "us-central1"
+  public_ip_enabled = false
+  private_ip_enabled = true # Private connectivity but no consumer_network
+  project           = var.project
+  # Missing consumer_network field
+  
+  # Required fields for Looker Core
+  oauth_config {
+    client_id     = "test-client-id"
+    client_secret = "test-client-secret"
+  }
+}

--- a/inputs/gcp/looker/core/custom_domain_when_private/.terraform.lock.hcl
+++ b/inputs/gcp/looker/core/custom_domain_when_private/.terraform.lock.hcl
@@ -1,0 +1,22 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/google" {
+  version     = "7.1.1"
+  constraints = "~> 7.1.1"
+  hashes = [
+    "h1:Hu/Gy8dB7TXsUyswqm6XJhr7esYmXk9Ea/Jo9VgT4LE=",
+    "zh:03ee9fdc0d157a606aba68658de6dc809fc3335cccb7c537373d8643412c1327",
+    "zh:110e8ffe81deb8c203ecf310a15c2dedca1dfc936473a247b8a4f98adebd86f5",
+    "zh:459e3419c004e7a475fb60cc52d47a34b3dc4e4de905eaa8e8f78ddbe550a9b5",
+    "zh:466cd31cee36877bc18aeabed80d1f4a22bac4e59a460be6e8bdb72dedca0e2b",
+    "zh:51d707eb2d854fa16dcbe21e29b01534eb893a2152a219ea84a15bbd87a4ff64",
+    "zh:69d6a1c83ffddd7f81273a98fb0ff7c13985a3c876565dd3df76c730c9929871",
+    "zh:9b5050da221735c7e8f75ed00d25578afaf8ed94a8c2f1f58f471eee98105d10",
+    "zh:ab01f2fd961ee86d99a55186093620d29f5323c0cd5613284d484e333679d70b",
+    "zh:d0f5b15774b15991baf71eb4a55a6831e3fb4b603f589f80b03393b46a9657a4",
+    "zh:dc198ec4b42435321f4fa12ca8d713cd350ff2f82d8749b87785b91b15b7c3ed",
+    "zh:e949c00ce89c92b7ed16cc0b0aed8e80d6416b240dc02047f9fa1de49aa4c44e",
+    "zh:f569b65999264a9416862bca5cd2a6177d94ccb0424f3a4ef424428912b9cb3c",
+  ]
+}

--- a/inputs/gcp/looker/core/custom_domain_when_private/c.tf
+++ b/inputs/gcp/looker/core/custom_domain_when_private/c.tf
@@ -1,24 +1,16 @@
-# Compliant Looker Core instance with custom domain for private connectivity
-# This resource is compliant because custom_domain.domain is set when public_ip_enabled=false
+variable "project" {
+  type = string
+}
 
-resource "google_looker_instance" "c" {
-  name              = "looker-core-compliant-custom-domain"
-  platform_edition  = "LOOKER_CORE_STANDARD_ANNUAL"
-  region            = "us-central1"
-  public_ip_enabled = false
-  private_ip_enabled = true # Assuming private connectivity
+resource "google_looker_instance" "ok" {
+  name              = "ok"
   project           = var.project
+  public_ip_enabled = false
   custom_domain {
-    domain = "looker.internal.company.com"
+    domain = "looker.example.com"
   }
-  
-  # Required fields for Looker Core
   oauth_config {
     client_id     = "test-client-id"
     client_secret = "test-client-secret"
   }
-}
-
-variable "project" {
-  type = string
 }

--- a/inputs/gcp/looker/core/custom_domain_when_private/c.tf
+++ b/inputs/gcp/looker/core/custom_domain_when_private/c.tf
@@ -1,0 +1,24 @@
+# Compliant Looker Core instance with custom domain for private connectivity
+# This resource is compliant because custom_domain.domain is set when public_ip_enabled=false
+
+resource "google_looker_instance" "c" {
+  name              = "looker-core-compliant-custom-domain"
+  platform_edition  = "LOOKER_CORE_STANDARD_ANNUAL"
+  region            = "us-central1"
+  public_ip_enabled = false
+  private_ip_enabled = true # Assuming private connectivity
+  project           = var.project
+  custom_domain {
+    domain = "looker.internal.company.com"
+  }
+  
+  # Required fields for Looker Core
+  oauth_config {
+    client_id     = "test-client-id"
+    client_secret = "test-client-secret"
+  }
+}
+
+variable "project" {
+  type = string
+}

--- a/inputs/gcp/looker/core/custom_domain_when_private/config.tf
+++ b/inputs/gcp/looker/core/custom_domain_when_private/config.tf
@@ -1,0 +1,9 @@
+terraform {
+  required_providers {
+    google = {
+      source  = "hashicorp/google"
+      version = "~> 7.1.1"
+    }
+  }
+  required_version = ">= 1.0"
+}

--- a/inputs/gcp/looker/core/custom_domain_when_private/nc.tf
+++ b/inputs/gcp/looker/core/custom_domain_when_private/nc.tf
@@ -1,16 +1,12 @@
-# Non-compliant Looker Core instance without custom domain for private connectivity
-# This resource is non-compliant because custom_domain block is missing when public_ip_enabled=false
+variable "project" {
+  type = string
+}
 
-resource "google_looker_instance" "nc" {
-  name              = "looker-core-noncompliant-no-custom-domain"
-  platform_edition  = "LOOKER_CORE_STANDARD_ANNUAL"
-  region            = "us-central1"
-  public_ip_enabled = false
-  private_ip_enabled = true # Assuming private connectivity
+resource "google_looker_instance" "bad" {
+  name              = "bad"
   project           = var.project
-  # Missing custom_domain block
-  
-  # Required fields for Looker Core
+  public_ip_enabled = false
+  # custom_domain block intentionally omitted to trigger failure
   oauth_config {
     client_id     = "test-client-id"
     client_secret = "test-client-secret"

--- a/inputs/gcp/looker/core/custom_domain_when_private/nc.tf
+++ b/inputs/gcp/looker/core/custom_domain_when_private/nc.tf
@@ -1,0 +1,18 @@
+# Non-compliant Looker Core instance without custom domain for private connectivity
+# This resource is non-compliant because custom_domain block is missing when public_ip_enabled=false
+
+resource "google_looker_instance" "nc" {
+  name              = "looker-core-noncompliant-no-custom-domain"
+  platform_edition  = "LOOKER_CORE_STANDARD_ANNUAL"
+  region            = "us-central1"
+  public_ip_enabled = false
+  private_ip_enabled = true # Assuming private connectivity
+  project           = var.project
+  # Missing custom_domain block
+  
+  # Required fields for Looker Core
+  oauth_config {
+    client_id     = "test-client-id"
+    client_secret = "test-client-secret"
+  }
+}

--- a/inputs/gcp/looker/core/custom_domain_when_private/variables.tf
+++ b/inputs/gcp/looker/core/custom_domain_when_private/variables.tf
@@ -1,0 +1,3 @@
+variable "project" {
+  type = string
+}

--- a/inputs/gcp/looker/core/disallow_trial_editions/.terraform.lock.hcl
+++ b/inputs/gcp/looker/core/disallow_trial_editions/.terraform.lock.hcl
@@ -1,0 +1,22 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/google" {
+  version     = "7.1.1"
+  constraints = "~> 7.1.1"
+  hashes = [
+    "h1:Hu/Gy8dB7TXsUyswqm6XJhr7esYmXk9Ea/Jo9VgT4LE=",
+    "zh:03ee9fdc0d157a606aba68658de6dc809fc3335cccb7c537373d8643412c1327",
+    "zh:110e8ffe81deb8c203ecf310a15c2dedca1dfc936473a247b8a4f98adebd86f5",
+    "zh:459e3419c004e7a475fb60cc52d47a34b3dc4e4de905eaa8e8f78ddbe550a9b5",
+    "zh:466cd31cee36877bc18aeabed80d1f4a22bac4e59a460be6e8bdb72dedca0e2b",
+    "zh:51d707eb2d854fa16dcbe21e29b01534eb893a2152a219ea84a15bbd87a4ff64",
+    "zh:69d6a1c83ffddd7f81273a98fb0ff7c13985a3c876565dd3df76c730c9929871",
+    "zh:9b5050da221735c7e8f75ed00d25578afaf8ed94a8c2f1f58f471eee98105d10",
+    "zh:ab01f2fd961ee86d99a55186093620d29f5323c0cd5613284d484e333679d70b",
+    "zh:d0f5b15774b15991baf71eb4a55a6831e3fb4b603f589f80b03393b46a9657a4",
+    "zh:dc198ec4b42435321f4fa12ca8d713cd350ff2f82d8749b87785b91b15b7c3ed",
+    "zh:e949c00ce89c92b7ed16cc0b0aed8e80d6416b240dc02047f9fa1de49aa4c44e",
+    "zh:f569b65999264a9416862bca5cd2a6177d94ccb0424f3a4ef424428912b9cb3c",
+  ]
+}

--- a/inputs/gcp/looker/core/disallow_trial_editions/c.tf
+++ b/inputs/gcp/looker/core/disallow_trial_editions/c.tf
@@ -1,0 +1,20 @@
+# Compliant Looker Core instance with production platform edition
+# This resource is compliant because platform_edition is not a trial SKU
+
+resource "google_looker_instance" "c" {
+  name              = "looker-core-compliant-production-edition"
+  platform_edition  = "LOOKER_CORE_STANDARD_ANNUAL"
+  region            = "us-central1"
+  public_ip_enabled = false
+  project           = var.project
+  
+  # Required fields for Looker Core
+  oauth_config {
+    client_id     = "test-client-id"
+    client_secret = "test-client-secret"
+  }
+}
+
+variable "project" {
+  type = string
+}

--- a/inputs/gcp/looker/core/disallow_trial_editions/config.tf
+++ b/inputs/gcp/looker/core/disallow_trial_editions/config.tf
@@ -1,0 +1,9 @@
+terraform {
+  required_providers {
+    google = {
+      source  = "hashicorp/google"
+      version = "~> 7.1.1"
+    }
+  }
+  required_version = ">= 1.0"
+}

--- a/inputs/gcp/looker/core/disallow_trial_editions/nc.tf
+++ b/inputs/gcp/looker/core/disallow_trial_editions/nc.tf
@@ -1,14 +1,11 @@
-# Non-compliant Looker Core instance with trial platform edition
-# This resource is non-compliant because platform_edition is a trial SKU
+variable "project" {
+  type = string
+}
 
-resource "google_looker_instance" "nc" {
-  name              = "looker-core-noncompliant-trial-edition"
-  platform_edition  = "LOOKER_CORE_TRIAL"
-  region            = "us-central1"
-  public_ip_enabled = false
-  project           = var.project
-  
-  # Required fields for Looker Core
+resource "google_looker_instance" "bad" {
+  name             = "bad"
+  project          = var.project
+  platform_edition = "LOOKER_CORE_TRIAL"  # Trial edition to trigger failure
   oauth_config {
     client_id     = "test-client-id"
     client_secret = "test-client-secret"

--- a/inputs/gcp/looker/core/disallow_trial_editions/nc.tf
+++ b/inputs/gcp/looker/core/disallow_trial_editions/nc.tf
@@ -1,0 +1,16 @@
+# Non-compliant Looker Core instance with trial platform edition
+# This resource is non-compliant because platform_edition is a trial SKU
+
+resource "google_looker_instance" "nc" {
+  name              = "looker-core-noncompliant-trial-edition"
+  platform_edition  = "LOOKER_CORE_TRIAL"
+  region            = "us-central1"
+  public_ip_enabled = false
+  project           = var.project
+  
+  # Required fields for Looker Core
+  oauth_config {
+    client_id     = "test-client-id"
+    client_secret = "test-client-secret"
+  }
+}

--- a/inputs/gcp/looker/core/fips_required/.terraform.lock.hcl
+++ b/inputs/gcp/looker/core/fips_required/.terraform.lock.hcl
@@ -1,0 +1,22 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/google" {
+  version     = "7.1.1"
+  constraints = "~> 7.1.1"
+  hashes = [
+    "h1:Hu/Gy8dB7TXsUyswqm6XJhr7esYmXk9Ea/Jo9VgT4LE=",
+    "zh:03ee9fdc0d157a606aba68658de6dc809fc3335cccb7c537373d8643412c1327",
+    "zh:110e8ffe81deb8c203ecf310a15c2dedca1dfc936473a247b8a4f98adebd86f5",
+    "zh:459e3419c004e7a475fb60cc52d47a34b3dc4e4de905eaa8e8f78ddbe550a9b5",
+    "zh:466cd31cee36877bc18aeabed80d1f4a22bac4e59a460be6e8bdb72dedca0e2b",
+    "zh:51d707eb2d854fa16dcbe21e29b01534eb893a2152a219ea84a15bbd87a4ff64",
+    "zh:69d6a1c83ffddd7f81273a98fb0ff7c13985a3c876565dd3df76c730c9929871",
+    "zh:9b5050da221735c7e8f75ed00d25578afaf8ed94a8c2f1f58f471eee98105d10",
+    "zh:ab01f2fd961ee86d99a55186093620d29f5323c0cd5613284d484e333679d70b",
+    "zh:d0f5b15774b15991baf71eb4a55a6831e3fb4b603f589f80b03393b46a9657a4",
+    "zh:dc198ec4b42435321f4fa12ca8d713cd350ff2f82d8749b87785b91b15b7c3ed",
+    "zh:e949c00ce89c92b7ed16cc0b0aed8e80d6416b240dc02047f9fa1de49aa4c44e",
+    "zh:f569b65999264a9416862bca5cd2a6177d94ccb0424f3a4ef424428912b9cb3c",
+  ]
+}

--- a/inputs/gcp/looker/core/fips_required/c.tf
+++ b/inputs/gcp/looker/core/fips_required/c.tf
@@ -1,0 +1,21 @@
+# Compliant Looker Core instance with FIPS enabled
+# This resource is compliant because fips_enabled is set to true
+
+resource "google_looker_instance" "c" {
+  name              = "looker-core-compliant-fips-enabled"
+  platform_edition  = "LOOKER_CORE_STANDARD_ANNUAL"
+  region            = "us-central1"
+  public_ip_enabled = false
+  fips_enabled      = true
+  project           = var.project
+  
+  # Required fields for Looker Core
+  oauth_config {
+    client_id     = "test-client-id"
+    client_secret = "test-client-secret"
+  }
+}
+
+variable "project" {
+  type = string
+}

--- a/inputs/gcp/looker/core/fips_required/config.tf
+++ b/inputs/gcp/looker/core/fips_required/config.tf
@@ -1,0 +1,9 @@
+terraform {
+  required_providers {
+    google = {
+      source  = "hashicorp/google"
+      version = "~> 7.1.1"
+    }
+  }
+  required_version = ">= 1.0"
+}

--- a/inputs/gcp/looker/core/fips_required/nc.tf
+++ b/inputs/gcp/looker/core/fips_required/nc.tf
@@ -1,15 +1,11 @@
-# Non-compliant Looker Core instance without FIPS enabled
-# This resource is non-compliant because fips_enabled is set to false
+variable "project" {
+  type = string
+}
 
-resource "google_looker_instance" "nc" {
-  name              = "looker-core-noncompliant-fips-disabled"
-  platform_edition  = "LOOKER_CORE_STANDARD_ANNUAL"
-  region            = "us-central1"
-  public_ip_enabled = false
-  fips_enabled      = false
-  project           = var.project
-  
-  # Required fields for Looker Core
+resource "google_looker_instance" "bad" {
+  name         = "bad"
+  project      = var.project
+  fips_enabled = false  # FIPS disabled to trigger failure
   oauth_config {
     client_id     = "test-client-id"
     client_secret = "test-client-secret"

--- a/inputs/gcp/looker/core/fips_required/nc.tf
+++ b/inputs/gcp/looker/core/fips_required/nc.tf
@@ -1,0 +1,17 @@
+# Non-compliant Looker Core instance without FIPS enabled
+# This resource is non-compliant because fips_enabled is set to false
+
+resource "google_looker_instance" "nc" {
+  name              = "looker-core-noncompliant-fips-disabled"
+  platform_edition  = "LOOKER_CORE_STANDARD_ANNUAL"
+  region            = "us-central1"
+  public_ip_enabled = false
+  fips_enabled      = false
+  project           = var.project
+  
+  # Required fields for Looker Core
+  oauth_config {
+    client_id     = "test-client-id"
+    client_secret = "test-client-secret"
+  }
+}

--- a/inputs/gcp/looker/core/maintenance_window_set/.terraform.lock.hcl
+++ b/inputs/gcp/looker/core/maintenance_window_set/.terraform.lock.hcl
@@ -1,0 +1,22 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/google" {
+  version     = "7.1.1"
+  constraints = "~> 7.1.1"
+  hashes = [
+    "h1:Hu/Gy8dB7TXsUyswqm6XJhr7esYmXk9Ea/Jo9VgT4LE=",
+    "zh:03ee9fdc0d157a606aba68658de6dc809fc3335cccb7c537373d8643412c1327",
+    "zh:110e8ffe81deb8c203ecf310a15c2dedca1dfc936473a247b8a4f98adebd86f5",
+    "zh:459e3419c004e7a475fb60cc52d47a34b3dc4e4de905eaa8e8f78ddbe550a9b5",
+    "zh:466cd31cee36877bc18aeabed80d1f4a22bac4e59a460be6e8bdb72dedca0e2b",
+    "zh:51d707eb2d854fa16dcbe21e29b01534eb893a2152a219ea84a15bbd87a4ff64",
+    "zh:69d6a1c83ffddd7f81273a98fb0ff7c13985a3c876565dd3df76c730c9929871",
+    "zh:9b5050da221735c7e8f75ed00d25578afaf8ed94a8c2f1f58f471eee98105d10",
+    "zh:ab01f2fd961ee86d99a55186093620d29f5323c0cd5613284d484e333679d70b",
+    "zh:d0f5b15774b15991baf71eb4a55a6831e3fb4b603f589f80b03393b46a9657a4",
+    "zh:dc198ec4b42435321f4fa12ca8d713cd350ff2f82d8749b87785b91b15b7c3ed",
+    "zh:e949c00ce89c92b7ed16cc0b0aed8e80d6416b240dc02047f9fa1de49aa4c44e",
+    "zh:f569b65999264a9416862bca5cd2a6177d94ccb0424f3a4ef424428912b9cb3c",
+  ]
+}

--- a/inputs/gcp/looker/core/maintenance_window_set/c.tf
+++ b/inputs/gcp/looker/core/maintenance_window_set/c.tf
@@ -1,13 +1,10 @@
-# Compliant Looker Core instance with maintenance window set
-# This resource is compliant because maintenance_window block is configured
+variable "project" {
+  type = string
+}
 
-resource "google_looker_instance" "c" {
-  name              = "looker-core-compliant-maintenance-window"
-  platform_edition  = "LOOKER_CORE_STANDARD_ANNUAL"
-  region            = "us-central1"
-  public_ip_enabled = false
-  project           = var.project
-  
+resource "google_looker_instance" "ok" {
+  name    = "ok"
+  project = var.project
   maintenance_window {
     day_of_week = "SUNDAY"
     start_time {
@@ -17,14 +14,8 @@ resource "google_looker_instance" "c" {
       seconds = 0
     }
   }
-  
-  # Required fields for Looker Core
   oauth_config {
     client_id     = "test-client-id"
     client_secret = "test-client-secret"
   }
-}
-
-variable "project" {
-  type = string
 }

--- a/inputs/gcp/looker/core/maintenance_window_set/c.tf
+++ b/inputs/gcp/looker/core/maintenance_window_set/c.tf
@@ -1,0 +1,30 @@
+# Compliant Looker Core instance with maintenance window set
+# This resource is compliant because maintenance_window block is configured
+
+resource "google_looker_instance" "c" {
+  name              = "looker-core-compliant-maintenance-window"
+  platform_edition  = "LOOKER_CORE_STANDARD_ANNUAL"
+  region            = "us-central1"
+  public_ip_enabled = false
+  project           = var.project
+  
+  maintenance_window {
+    day_of_week = "SUNDAY"
+    start_time {
+      hours   = 2
+      minutes = 0
+      nanos   = 0
+      seconds = 0
+    }
+  }
+  
+  # Required fields for Looker Core
+  oauth_config {
+    client_id     = "test-client-id"
+    client_secret = "test-client-secret"
+  }
+}
+
+variable "project" {
+  type = string
+}

--- a/inputs/gcp/looker/core/maintenance_window_set/config.tf
+++ b/inputs/gcp/looker/core/maintenance_window_set/config.tf
@@ -1,0 +1,9 @@
+terraform {
+  required_providers {
+    google = {
+      source  = "hashicorp/google"
+      version = "~> 7.1.1"
+    }
+  }
+  required_version = ">= 1.0"
+}

--- a/inputs/gcp/looker/core/maintenance_window_set/nc.tf
+++ b/inputs/gcp/looker/core/maintenance_window_set/nc.tf
@@ -1,15 +1,11 @@
-# Non-compliant Looker Core instance without maintenance window
-# This resource is non-compliant because maintenance_window block is missing
+variable "project" {
+  type = string
+}
 
-resource "google_looker_instance" "nc" {
-  name              = "looker-core-noncompliant-no-maintenance-window"
-  platform_edition  = "LOOKER_CORE_STANDARD_ANNUAL"
-  region            = "us-central1"
-  public_ip_enabled = false
-  project           = var.project
-  # Missing maintenance_window block
-  
-  # Required fields for Looker Core
+resource "google_looker_instance" "bad" {
+  name    = "bad"
+  project = var.project
+  # maintenance_window intentionally omitted to trigger failure
   oauth_config {
     client_id     = "test-client-id"
     client_secret = "test-client-secret"

--- a/inputs/gcp/looker/core/maintenance_window_set/nc.tf
+++ b/inputs/gcp/looker/core/maintenance_window_set/nc.tf
@@ -1,0 +1,17 @@
+# Non-compliant Looker Core instance without maintenance window
+# This resource is non-compliant because maintenance_window block is missing
+
+resource "google_looker_instance" "nc" {
+  name              = "looker-core-noncompliant-no-maintenance-window"
+  platform_edition  = "LOOKER_CORE_STANDARD_ANNUAL"
+  region            = "us-central1"
+  public_ip_enabled = false
+  project           = var.project
+  # Missing maintenance_window block
+  
+  # Required fields for Looker Core
+  oauth_config {
+    client_id     = "test-client-id"
+    client_secret = "test-client-secret"
+  }
+}

--- a/inputs/gcp/looker/core/no_public_ip/.terraform.lock.hcl
+++ b/inputs/gcp/looker/core/no_public_ip/.terraform.lock.hcl
@@ -1,0 +1,22 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/google" {
+  version     = "7.1.1"
+  constraints = "~> 7.1.1"
+  hashes = [
+    "h1:Hu/Gy8dB7TXsUyswqm6XJhr7esYmXk9Ea/Jo9VgT4LE=",
+    "zh:03ee9fdc0d157a606aba68658de6dc809fc3335cccb7c537373d8643412c1327",
+    "zh:110e8ffe81deb8c203ecf310a15c2dedca1dfc936473a247b8a4f98adebd86f5",
+    "zh:459e3419c004e7a475fb60cc52d47a34b3dc4e4de905eaa8e8f78ddbe550a9b5",
+    "zh:466cd31cee36877bc18aeabed80d1f4a22bac4e59a460be6e8bdb72dedca0e2b",
+    "zh:51d707eb2d854fa16dcbe21e29b01534eb893a2152a219ea84a15bbd87a4ff64",
+    "zh:69d6a1c83ffddd7f81273a98fb0ff7c13985a3c876565dd3df76c730c9929871",
+    "zh:9b5050da221735c7e8f75ed00d25578afaf8ed94a8c2f1f58f471eee98105d10",
+    "zh:ab01f2fd961ee86d99a55186093620d29f5323c0cd5613284d484e333679d70b",
+    "zh:d0f5b15774b15991baf71eb4a55a6831e3fb4b603f589f80b03393b46a9657a4",
+    "zh:dc198ec4b42435321f4fa12ca8d713cd350ff2f82d8749b87785b91b15b7c3ed",
+    "zh:e949c00ce89c92b7ed16cc0b0aed8e80d6416b240dc02047f9fa1de49aa4c44e",
+    "zh:f569b65999264a9416862bca5cd2a6177d94ccb0424f3a4ef424428912b9cb3c",
+  ]
+}

--- a/inputs/gcp/looker/core/no_public_ip/c.tf
+++ b/inputs/gcp/looker/core/no_public_ip/c.tf
@@ -1,0 +1,20 @@
+# Compliant Looker Core instance with public IP disabled
+# This resource is compliant because public_ip_enabled is set to false
+
+resource "google_looker_instance" "c" {
+  name              = "looker-core-compliant-no-public-ip"
+  platform_edition  = "LOOKER_CORE_STANDARD_ANNUAL"
+  region            = "us-central1"
+  public_ip_enabled = false
+  project           = var.project
+  
+  # Required fields for Looker Core
+  oauth_config {
+    client_id     = "test-client-id"
+    client_secret = "test-client-secret"
+  }
+}
+
+variable "project" {
+  type = string
+}

--- a/inputs/gcp/looker/core/no_public_ip/config.tf
+++ b/inputs/gcp/looker/core/no_public_ip/config.tf
@@ -1,0 +1,9 @@
+terraform {
+  required_providers {
+    google = {
+      source  = "hashicorp/google"
+      version = "~> 7.1.1"
+    }
+  }
+  required_version = ">= 1.0"
+}

--- a/inputs/gcp/looker/core/no_public_ip/nc.tf
+++ b/inputs/gcp/looker/core/no_public_ip/nc.tf
@@ -1,14 +1,11 @@
-# Non-compliant Looker Core instance with public IP enabled
-# This resource is non-compliant because public_ip_enabled is set to true
+variable "project" {
+  type = string
+}
 
-resource "google_looker_instance" "nc" {
-  name              = "looker-core-noncompliant-public-ip"
-  platform_edition  = "LOOKER_CORE_STANDARD_ANNUAL"
-  region            = "us-central1"
-  public_ip_enabled = true
+resource "google_looker_instance" "bad" {
+  name              = "bad"
   project           = var.project
-  
-  # Required fields for Looker Core
+  public_ip_enabled = true  # Public IP enabled to trigger failure
   oauth_config {
     client_id     = "test-client-id"
     client_secret = "test-client-secret"

--- a/inputs/gcp/looker/core/no_public_ip/nc.tf
+++ b/inputs/gcp/looker/core/no_public_ip/nc.tf
@@ -1,0 +1,16 @@
+# Non-compliant Looker Core instance with public IP enabled
+# This resource is non-compliant because public_ip_enabled is set to true
+
+resource "google_looker_instance" "nc" {
+  name              = "looker-core-noncompliant-public-ip"
+  platform_edition  = "LOOKER_CORE_STANDARD_ANNUAL"
+  region            = "us-central1"
+  public_ip_enabled = true
+  project           = var.project
+  
+  # Required fields for Looker Core
+  oauth_config {
+    client_id     = "test-client-id"
+    client_secret = "test-client-secret"
+  }
+}

--- a/inputs/gcp/looker/core/oauth_config_present/.terraform.lock.hcl
+++ b/inputs/gcp/looker/core/oauth_config_present/.terraform.lock.hcl
@@ -1,0 +1,22 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/google" {
+  version     = "7.1.1"
+  constraints = "~> 7.1.1"
+  hashes = [
+    "h1:Hu/Gy8dB7TXsUyswqm6XJhr7esYmXk9Ea/Jo9VgT4LE=",
+    "zh:03ee9fdc0d157a606aba68658de6dc809fc3335cccb7c537373d8643412c1327",
+    "zh:110e8ffe81deb8c203ecf310a15c2dedca1dfc936473a247b8a4f98adebd86f5",
+    "zh:459e3419c004e7a475fb60cc52d47a34b3dc4e4de905eaa8e8f78ddbe550a9b5",
+    "zh:466cd31cee36877bc18aeabed80d1f4a22bac4e59a460be6e8bdb72dedca0e2b",
+    "zh:51d707eb2d854fa16dcbe21e29b01534eb893a2152a219ea84a15bbd87a4ff64",
+    "zh:69d6a1c83ffddd7f81273a98fb0ff7c13985a3c876565dd3df76c730c9929871",
+    "zh:9b5050da221735c7e8f75ed00d25578afaf8ed94a8c2f1f58f471eee98105d10",
+    "zh:ab01f2fd961ee86d99a55186093620d29f5323c0cd5613284d484e333679d70b",
+    "zh:d0f5b15774b15991baf71eb4a55a6831e3fb4b603f589f80b03393b46a9657a4",
+    "zh:dc198ec4b42435321f4fa12ca8d713cd350ff2f82d8749b87785b91b15b7c3ed",
+    "zh:e949c00ce89c92b7ed16cc0b0aed8e80d6416b240dc02047f9fa1de49aa4c44e",
+    "zh:f569b65999264a9416862bca5cd2a6177d94ccb0424f3a4ef424428912b9cb3c",
+  ]
+}

--- a/inputs/gcp/looker/core/oauth_config_present/c.tf
+++ b/inputs/gcp/looker/core/oauth_config_present/c.tf
@@ -1,0 +1,20 @@
+# Compliant Looker Core instance with OAuth config present
+# This resource is compliant because oauth_config block is properly configured
+
+resource "google_looker_instance" "c" {
+  name              = "looker-core-compliant-oauth-config"
+  platform_edition  = "LOOKER_CORE_STANDARD_ANNUAL"
+  region            = "us-central1"
+  public_ip_enabled = false
+  project           = var.project
+  
+  # Required fields for Looker Core
+  oauth_config {
+    client_id     = "test-client-id"
+    client_secret = "test-client-secret"
+  }
+}
+
+variable "project" {
+  type = string
+}

--- a/inputs/gcp/looker/core/oauth_config_present/c.tf
+++ b/inputs/gcp/looker/core/oauth_config_present/c.tf
@@ -1,20 +1,12 @@
-# Compliant Looker Core instance with OAuth config present
-# This resource is compliant because oauth_config block is properly configured
+variable "project" {
+  type = string
+}
 
-resource "google_looker_instance" "c" {
-  name              = "looker-core-compliant-oauth-config"
-  platform_edition  = "LOOKER_CORE_STANDARD_ANNUAL"
-  region            = "us-central1"
-  public_ip_enabled = false
-  project           = var.project
-  
-  # Required fields for Looker Core
+resource "google_looker_instance" "ok" {
+  name    = "ok"
+  project = var.project
   oauth_config {
     client_id     = "test-client-id"
     client_secret = "test-client-secret"
   }
-}
-
-variable "project" {
-  type = string
 }

--- a/inputs/gcp/looker/core/oauth_config_present/config.tf
+++ b/inputs/gcp/looker/core/oauth_config_present/config.tf
@@ -1,0 +1,9 @@
+terraform {
+  required_providers {
+    google = {
+      source  = "hashicorp/google"
+      version = "~> 7.1.1"
+    }
+  }
+  required_version = ">= 1.0"
+}

--- a/inputs/gcp/looker/core/oauth_config_present/nc.tf
+++ b/inputs/gcp/looker/core/oauth_config_present/nc.tf
@@ -1,16 +1,12 @@
-# Non-compliant Looker Core instance with minimal OAuth config
-# This resource is non-compliant because oauth_config has empty client_id and client_secret
+variable "project" {
+  type = string
+}
 
-resource "google_looker_instance" "nc" {
-  name              = "looker-core-noncompliant-no-oauth-config"
-  platform_edition  = "LOOKER_CORE_STANDARD_ANNUAL"
-  region            = "us-central1"
-  public_ip_enabled = false
-  project           = var.project
-  
-  # Minimal oauth_config block - violates policy (should be properly configured)
+resource "google_looker_instance" "bad" {
+  name    = "bad" 
+  project = var.project
   oauth_config {
-    client_id     = ""
-    client_secret = ""
+    client_id     = ""  # Empty client_id to trigger failure
+    client_secret = "test-client-secret"
   }
 }

--- a/inputs/gcp/looker/core/oauth_config_present/nc.tf
+++ b/inputs/gcp/looker/core/oauth_config_present/nc.tf
@@ -1,0 +1,16 @@
+# Non-compliant Looker Core instance with minimal OAuth config
+# This resource is non-compliant because oauth_config has empty client_id and client_secret
+
+resource "google_looker_instance" "nc" {
+  name              = "looker-core-noncompliant-no-oauth-config"
+  platform_edition  = "LOOKER_CORE_STANDARD_ANNUAL"
+  region            = "us-central1"
+  public_ip_enabled = false
+  project           = var.project
+  
+  # Minimal oauth_config block - violates policy (should be properly configured)
+  oauth_config {
+    client_id     = ""
+    client_secret = ""
+  }
+}

--- a/inputs/gcp/looker/core/private_connectivity_required/.terraform.lock.hcl
+++ b/inputs/gcp/looker/core/private_connectivity_required/.terraform.lock.hcl
@@ -1,0 +1,22 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/google" {
+  version     = "7.1.1"
+  constraints = "~> 7.1.1"
+  hashes = [
+    "h1:Hu/Gy8dB7TXsUyswqm6XJhr7esYmXk9Ea/Jo9VgT4LE=",
+    "zh:03ee9fdc0d157a606aba68658de6dc809fc3335cccb7c537373d8643412c1327",
+    "zh:110e8ffe81deb8c203ecf310a15c2dedca1dfc936473a247b8a4f98adebd86f5",
+    "zh:459e3419c004e7a475fb60cc52d47a34b3dc4e4de905eaa8e8f78ddbe550a9b5",
+    "zh:466cd31cee36877bc18aeabed80d1f4a22bac4e59a460be6e8bdb72dedca0e2b",
+    "zh:51d707eb2d854fa16dcbe21e29b01534eb893a2152a219ea84a15bbd87a4ff64",
+    "zh:69d6a1c83ffddd7f81273a98fb0ff7c13985a3c876565dd3df76c730c9929871",
+    "zh:9b5050da221735c7e8f75ed00d25578afaf8ed94a8c2f1f58f471eee98105d10",
+    "zh:ab01f2fd961ee86d99a55186093620d29f5323c0cd5613284d484e333679d70b",
+    "zh:d0f5b15774b15991baf71eb4a55a6831e3fb4b603f589f80b03393b46a9657a4",
+    "zh:dc198ec4b42435321f4fa12ca8d713cd350ff2f82d8749b87785b91b15b7c3ed",
+    "zh:e949c00ce89c92b7ed16cc0b0aed8e80d6416b240dc02047f9fa1de49aa4c44e",
+    "zh:f569b65999264a9416862bca5cd2a6177d94ccb0424f3a4ef424428912b9cb3c",
+  ]
+}

--- a/inputs/gcp/looker/core/private_connectivity_required/c.tf
+++ b/inputs/gcp/looker/core/private_connectivity_required/c.tf
@@ -1,0 +1,21 @@
+# Compliant Looker Core instance with private connectivity
+# This resource is compliant because private_ip_enabled=true and public_ip_enabled=false
+
+resource "google_looker_instance" "c" {
+  name               = "looker-core-compliant-private-connectivity"
+  platform_edition   = "LOOKER_CORE_STANDARD_ANNUAL"
+  region             = "us-central1"
+  private_ip_enabled = true
+  public_ip_enabled  = false
+  project            = var.project
+  
+  # Required fields for Looker Core
+  oauth_config {
+    client_id     = "test-client-id"
+    client_secret = "test-client-secret"
+  }
+}
+
+variable "project" {
+  type = string
+}

--- a/inputs/gcp/looker/core/private_connectivity_required/c.tf
+++ b/inputs/gcp/looker/core/private_connectivity_required/c.tf
@@ -1,21 +1,14 @@
-# Compliant Looker Core instance with private connectivity
-# This resource is compliant because private_ip_enabled=true and public_ip_enabled=false
+variable "project" {
+  type = string
+}
 
-resource "google_looker_instance" "c" {
-  name               = "looker-core-compliant-private-connectivity"
-  platform_edition   = "LOOKER_CORE_STANDARD_ANNUAL"
-  region             = "us-central1"
-  private_ip_enabled = true
-  public_ip_enabled  = false
-  project            = var.project
-  
-  # Required fields for Looker Core
+resource "google_looker_instance" "ok" {
+  name              = "ok"
+  project           = var.project
+  public_ip_enabled = false
+  psc_enabled       = true
   oauth_config {
     client_id     = "test-client-id"
     client_secret = "test-client-secret"
   }
-}
-
-variable "project" {
-  type = string
 }

--- a/inputs/gcp/looker/core/private_connectivity_required/config.tf
+++ b/inputs/gcp/looker/core/private_connectivity_required/config.tf
@@ -1,0 +1,9 @@
+terraform {
+  required_providers {
+    google = {
+      source  = "hashicorp/google"
+      version = "~> 7.1.1"
+    }
+  }
+  required_version = ">= 1.0"
+}

--- a/inputs/gcp/looker/core/private_connectivity_required/nc.tf
+++ b/inputs/gcp/looker/core/private_connectivity_required/nc.tf
@@ -1,0 +1,18 @@
+# Non-compliant Looker Core instance without proper private connectivity
+# This resource is non-compliant because it has public_ip_enabled=true and no private connectivity
+
+resource "google_looker_instance" "nc" {
+  name               = "looker-core-noncompliant-no-private-connectivity"
+  platform_edition   = "LOOKER_CORE_STANDARD_ANNUAL"
+  region             = "us-central1"
+  public_ip_enabled  = true # Changed from false to true to trigger public IP violation
+  private_ip_enabled = false
+  psc_enabled        = false
+  project            = var.project
+  
+  # Required fields for Looker Core
+  oauth_config {
+    client_id     = "test-client-id"
+    client_secret = "test-client-secret"
+  }
+}

--- a/inputs/gcp/looker/core/private_connectivity_required/nc.tf
+++ b/inputs/gcp/looker/core/private_connectivity_required/nc.tf
@@ -1,16 +1,13 @@
-# Non-compliant Looker Core instance without proper private connectivity
-# This resource is non-compliant because it has public_ip_enabled=true and no private connectivity
+variable "project" {
+  type = string
+}
 
-resource "google_looker_instance" "nc" {
-  name               = "looker-core-noncompliant-no-private-connectivity"
-  platform_edition   = "LOOKER_CORE_STANDARD_ANNUAL"
-  region             = "us-central1"
-  public_ip_enabled  = true # Changed from false to true to trigger public IP violation
-  private_ip_enabled = false
-  psc_enabled        = false
-  project            = var.project
-  
-  # Required fields for Looker Core
+resource "google_looker_instance" "bad" {
+  name              = "bad"
+  project           = var.project
+  public_ip_enabled = true
+  # private_ip_enabled = false (default/omitted)
+  # psc_enabled       = false (default/omitted)
   oauth_config {
     client_id     = "test-client-id"
     client_secret = "test-client-secret"

--- a/inputs/gcp/looker/core/private_connectivity_required/variables.tf
+++ b/inputs/gcp/looker/core/private_connectivity_required/variables.tf
@@ -1,0 +1,3 @@
+variable "project" {
+  type = string
+}

--- a/inputs/gcp/looker/core/psc_mode_hygiene/.terraform.lock.hcl
+++ b/inputs/gcp/looker/core/psc_mode_hygiene/.terraform.lock.hcl
@@ -1,0 +1,22 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/google" {
+  version     = "7.1.1"
+  constraints = "~> 7.1.1"
+  hashes = [
+    "h1:Hu/Gy8dB7TXsUyswqm6XJhr7esYmXk9Ea/Jo9VgT4LE=",
+    "zh:03ee9fdc0d157a606aba68658de6dc809fc3335cccb7c537373d8643412c1327",
+    "zh:110e8ffe81deb8c203ecf310a15c2dedca1dfc936473a247b8a4f98adebd86f5",
+    "zh:459e3419c004e7a475fb60cc52d47a34b3dc4e4de905eaa8e8f78ddbe550a9b5",
+    "zh:466cd31cee36877bc18aeabed80d1f4a22bac4e59a460be6e8bdb72dedca0e2b",
+    "zh:51d707eb2d854fa16dcbe21e29b01534eb893a2152a219ea84a15bbd87a4ff64",
+    "zh:69d6a1c83ffddd7f81273a98fb0ff7c13985a3c876565dd3df76c730c9929871",
+    "zh:9b5050da221735c7e8f75ed00d25578afaf8ed94a8c2f1f58f471eee98105d10",
+    "zh:ab01f2fd961ee86d99a55186093620d29f5323c0cd5613284d484e333679d70b",
+    "zh:d0f5b15774b15991baf71eb4a55a6831e3fb4b603f589f80b03393b46a9657a4",
+    "zh:dc198ec4b42435321f4fa12ca8d713cd350ff2f82d8749b87785b91b15b7c3ed",
+    "zh:e949c00ce89c92b7ed16cc0b0aed8e80d6416b240dc02047f9fa1de49aa4c44e",
+    "zh:f569b65999264a9416862bca5cd2a6177d94ccb0424f3a4ef424428912b9cb3c",
+  ]
+}

--- a/inputs/gcp/looker/core/psc_mode_hygiene/c.tf
+++ b/inputs/gcp/looker/core/psc_mode_hygiene/c.tf
@@ -1,0 +1,22 @@
+# Compliant Looker Core instance with PSC mode hygiene
+# This resource is compliant because psc_enabled=true with public_ip_enabled=false and private_ip_enabled=false
+
+resource "google_looker_instance" "c" {
+  name               = "looker-core-compliant-psc-hygiene"
+  platform_edition   = "LOOKER_CORE_STANDARD_ANNUAL"
+  region             = "us-central1"
+  psc_enabled        = true
+  public_ip_enabled  = false
+  private_ip_enabled = false
+  project            = var.project
+  
+  # Required fields for Looker Core
+  oauth_config {
+    client_id     = "test-client-id"
+    client_secret = "test-client-secret"
+  }
+}
+
+variable "project" {
+  type = string
+}

--- a/inputs/gcp/looker/core/psc_mode_hygiene/c.tf
+++ b/inputs/gcp/looker/core/psc_mode_hygiene/c.tf
@@ -1,22 +1,15 @@
-# Compliant Looker Core instance with PSC mode hygiene
-# This resource is compliant because psc_enabled=true with public_ip_enabled=false and private_ip_enabled=false
+variable "project" {
+  type = string
+}
 
-resource "google_looker_instance" "c" {
-  name               = "looker-core-compliant-psc-hygiene"
-  platform_edition   = "LOOKER_CORE_STANDARD_ANNUAL"
-  region             = "us-central1"
+resource "google_looker_instance" "ok" {
+  name               = "ok"
+  project            = var.project
   psc_enabled        = true
   public_ip_enabled  = false
   private_ip_enabled = false
-  project            = var.project
-  
-  # Required fields for Looker Core
   oauth_config {
     client_id     = "test-client-id"
     client_secret = "test-client-secret"
   }
-}
-
-variable "project" {
-  type = string
 }

--- a/inputs/gcp/looker/core/psc_mode_hygiene/config.tf
+++ b/inputs/gcp/looker/core/psc_mode_hygiene/config.tf
@@ -1,0 +1,9 @@
+terraform {
+  required_providers {
+    google = {
+      source  = "hashicorp/google"
+      version = "~> 7.1.1"
+    }
+  }
+  required_version = ">= 1.0"
+}

--- a/inputs/gcp/looker/core/psc_mode_hygiene/nc.tf
+++ b/inputs/gcp/looker/core/psc_mode_hygiene/nc.tf
@@ -1,0 +1,18 @@
+# Non-compliant Looker Core instance with PSC mode hygiene violation
+# This resource is non-compliant because psc_enabled=true with public_ip_enabled=true (violates PSC exclusivity)
+
+resource "google_looker_instance" "nc" {
+  name               = "looker-core-noncompliant-psc-hygiene"
+  platform_edition   = "LOOKER_CORE_STANDARD_ANNUAL"
+  region             = "us-central1"
+  psc_enabled        = true
+  public_ip_enabled  = true # Violates PSC exclusivity
+  private_ip_enabled = false
+  project            = var.project
+  
+  # Required fields for Looker Core
+  oauth_config {
+    client_id     = "test-client-id"
+    client_secret = "test-client-secret"
+  }
+}

--- a/inputs/gcp/looker/core/psc_mode_hygiene/nc.tf
+++ b/inputs/gcp/looker/core/psc_mode_hygiene/nc.tf
@@ -1,16 +1,13 @@
-# Non-compliant Looker Core instance with PSC mode hygiene violation
-# This resource is non-compliant because psc_enabled=true with public_ip_enabled=true (violates PSC exclusivity)
+variable "project" {
+  type = string
+}
 
-resource "google_looker_instance" "nc" {
-  name               = "looker-core-noncompliant-psc-hygiene"
-  platform_edition   = "LOOKER_CORE_STANDARD_ANNUAL"
-  region             = "us-central1"
-  psc_enabled        = true
-  public_ip_enabled  = true # Violates PSC exclusivity
-  private_ip_enabled = false
+resource "google_looker_instance" "bad" {
+  name               = "bad"
   project            = var.project
-  
-  # Required fields for Looker Core
+  psc_enabled        = true
+  public_ip_enabled  = true      # ← triggers Situation A
+  private_ip_enabled = false
   oauth_config {
     client_id     = "test-client-id"
     client_secret = "test-client-secret"

--- a/inputs/gcp/looker/core/psc_mode_hygiene/variables.tf
+++ b/inputs/gcp/looker/core/psc_mode_hygiene/variables.tf
@@ -1,0 +1,3 @@
+variable "project" {
+  type = string
+}

--- a/inputs/gcp/looker/core/reserved_range_for_psa_psc/.terraform.lock.hcl
+++ b/inputs/gcp/looker/core/reserved_range_for_psa_psc/.terraform.lock.hcl
@@ -1,0 +1,22 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/google" {
+  version     = "7.1.1"
+  constraints = "~> 7.1.1"
+  hashes = [
+    "h1:Hu/Gy8dB7TXsUyswqm6XJhr7esYmXk9Ea/Jo9VgT4LE=",
+    "zh:03ee9fdc0d157a606aba68658de6dc809fc3335cccb7c537373d8643412c1327",
+    "zh:110e8ffe81deb8c203ecf310a15c2dedca1dfc936473a247b8a4f98adebd86f5",
+    "zh:459e3419c004e7a475fb60cc52d47a34b3dc4e4de905eaa8e8f78ddbe550a9b5",
+    "zh:466cd31cee36877bc18aeabed80d1f4a22bac4e59a460be6e8bdb72dedca0e2b",
+    "zh:51d707eb2d854fa16dcbe21e29b01534eb893a2152a219ea84a15bbd87a4ff64",
+    "zh:69d6a1c83ffddd7f81273a98fb0ff7c13985a3c876565dd3df76c730c9929871",
+    "zh:9b5050da221735c7e8f75ed00d25578afaf8ed94a8c2f1f58f471eee98105d10",
+    "zh:ab01f2fd961ee86d99a55186093620d29f5323c0cd5613284d484e333679d70b",
+    "zh:d0f5b15774b15991baf71eb4a55a6831e3fb4b603f589f80b03393b46a9657a4",
+    "zh:dc198ec4b42435321f4fa12ca8d713cd350ff2f82d8749b87785b91b15b7c3ed",
+    "zh:e949c00ce89c92b7ed16cc0b0aed8e80d6416b240dc02047f9fa1de49aa4c44e",
+    "zh:f569b65999264a9416862bca5cd2a6177d94ccb0424f3a4ef424428912b9cb3c",
+  ]
+}

--- a/inputs/gcp/looker/core/reserved_range_for_psa_psc/c.tf
+++ b/inputs/gcp/looker/core/reserved_range_for_psa_psc/c.tf
@@ -1,0 +1,22 @@
+# Compliant Looker Core instance with reserved range for PSA/PSC
+# This resource is compliant because reserved_range is configured for private connectivity
+
+resource "google_looker_instance" "c" {
+  name              = "looker-core-compliant-reserved-range"
+  platform_edition  = "LOOKER_CORE_STANDARD_ANNUAL"
+  region            = "us-central1"
+  public_ip_enabled = false
+  private_ip_enabled = true # Required for reserved_range
+  reserved_range    = "projects/test-project-123/global/addresses/test-reserved-range"
+  project           = var.project
+  
+  # Required fields for Looker Core
+  oauth_config {
+    client_id     = "test-client-id"
+    client_secret = "test-client-secret"
+  }
+}
+
+variable "project" {
+  type = string
+}

--- a/inputs/gcp/looker/core/reserved_range_for_psa_psc/c.tf
+++ b/inputs/gcp/looker/core/reserved_range_for_psa_psc/c.tf
@@ -1,22 +1,13 @@
-# Compliant Looker Core instance with reserved range for PSA/PSC
-# This resource is compliant because reserved_range is configured for private connectivity
+variable "project" {
+  type = string
+}
 
-resource "google_looker_instance" "c" {
-  name              = "looker-core-compliant-reserved-range"
-  platform_edition  = "LOOKER_CORE_STANDARD_ANNUAL"
-  region            = "us-central1"
-  public_ip_enabled = false
-  private_ip_enabled = true # Required for reserved_range
-  reserved_range    = "projects/test-project-123/global/addresses/test-reserved-range"
-  project           = var.project
-  
-  # Required fields for Looker Core
+resource "google_looker_instance" "ok" {
+  name           = "ok"
+  project        = var.project
+  reserved_range = "projects/test-project-123/global/addresses/test-reserved-range"
   oauth_config {
     client_id     = "test-client-id"
     client_secret = "test-client-secret"
   }
-}
-
-variable "project" {
-  type = string
 }

--- a/inputs/gcp/looker/core/reserved_range_for_psa_psc/config.tf
+++ b/inputs/gcp/looker/core/reserved_range_for_psa_psc/config.tf
@@ -1,0 +1,9 @@
+terraform {
+  required_providers {
+    google = {
+      source  = "hashicorp/google"
+      version = "~> 7.1.1"
+    }
+  }
+  required_version = ">= 1.0"
+}

--- a/inputs/gcp/looker/core/reserved_range_for_psa_psc/nc.tf
+++ b/inputs/gcp/looker/core/reserved_range_for_psa_psc/nc.tf
@@ -1,16 +1,11 @@
-# Non-compliant Looker Core instance without reserved range
-# This resource is non-compliant because reserved_range is missing for private connectivity
+variable "project" {
+  type = string
+}
 
-resource "google_looker_instance" "nc" {
-  name              = "looker-core-noncompliant-no-reserved-range"
-  platform_edition  = "LOOKER_CORE_STANDARD_ANNUAL"
-  region            = "us-central1"
-  public_ip_enabled = false
-  private_ip_enabled = true # Private connectivity but no reserved_range
-  project           = var.project
-  # Missing reserved_range field
-  
-  # Required fields for Looker Core
+resource "google_looker_instance" "bad" {
+  name    = "bad"
+  project = var.project
+  # reserved_range intentionally omitted to trigger failure
   oauth_config {
     client_id     = "test-client-id"
     client_secret = "test-client-secret"

--- a/inputs/gcp/looker/core/reserved_range_for_psa_psc/nc.tf
+++ b/inputs/gcp/looker/core/reserved_range_for_psa_psc/nc.tf
@@ -1,0 +1,18 @@
+# Non-compliant Looker Core instance without reserved range
+# This resource is non-compliant because reserved_range is missing for private connectivity
+
+resource "google_looker_instance" "nc" {
+  name              = "looker-core-noncompliant-no-reserved-range"
+  platform_edition  = "LOOKER_CORE_STANDARD_ANNUAL"
+  region            = "us-central1"
+  public_ip_enabled = false
+  private_ip_enabled = true # Private connectivity but no reserved_range
+  project           = var.project
+  # Missing reserved_range field
+  
+  # Required fields for Looker Core
+  oauth_config {
+    client_id     = "test-client-id"
+    client_secret = "test-client-secret"
+  }
+}

--- a/policies/gcp/looker/core/cmek_required/policy.rego
+++ b/policies/gcp/looker/core/cmek_required/policy.rego
@@ -1,0 +1,25 @@
+package terraform.gcp.security.looker.core.cmek_required
+import data.terraform.gcp.helpers
+import data.terraform.gcp.security.looker.core.vars
+
+conditions := [
+  [
+    {
+      "situation_description": "CMEK (Customer-Managed Encryption Key) is required but not configured",
+      "remedies": [
+        "Configure encryption_config block with kms_key_name",
+        "Set kms_key_name to a valid KMS key resource path",
+        "Example: projects/PROJECT_ID/locations/LOCATION/keyRings/RING_NAME/cryptoKeys/KEY_NAME"
+      ]
+    },
+    {
+      "condition": "Require CMEK configuration (whitelist: encryption_config.kms_key_name must be non-empty)",
+      "attribute_path": ["encryption_config", 0, "kms_key_name"],
+      "values": ["*"], # Any non-empty string
+      "policy_type": "whitelist"
+    }
+  ]
+]
+
+message := helpers.get_multi_summary(conditions, vars.variables).message
+details := helpers.get_multi_summary(conditions, vars.variables).details

--- a/policies/gcp/looker/core/cmek_required/policy.rego
+++ b/policies/gcp/looker/core/cmek_required/policy.rego
@@ -13,10 +13,10 @@ conditions := [
       ]
     },
     {
-      "condition": "Require CMEK configuration (whitelist: encryption_config.kms_key_name must be non-empty)",
+      "condition": "encryption_config.kms_key_name must be set",
       "attribute_path": ["encryption_config", 0, "kms_key_name"],
-      "values": ["*"], # Any non-empty string
-      "policy_type": "whitelist"
+      "values": [null, ""], # Violates when missing or empty
+      "policy_type": "blacklist"
     }
   ]
 ]

--- a/policies/gcp/looker/core/consumer_network_set/policy.rego
+++ b/policies/gcp/looker/core/consumer_network_set/policy.rego
@@ -1,0 +1,25 @@
+package terraform.gcp.security.looker.core.consumer_network_set
+import data.terraform.gcp.helpers
+import data.terraform.gcp.security.looker.core.vars
+
+conditions := [
+  [
+    {
+      "situation_description": "Consumer network required for private/PSC connectivity but not configured",
+      "remedies": [
+        "Configure consumer_network field for private connectivity",
+        "Set consumer_network to a valid VPC network path",
+        "Example: projects/PROJECT_ID/global/networks/NETWORK_NAME"
+      ]
+    },
+    {
+      "condition": "Require consumer_network when using private connectivity (whitelist: consumerNetwork must be set)",
+      "attribute_path": ["consumer_network"],
+      "values": ["*"], # Any non-empty string
+      "policy_type": "whitelist"
+    }
+  ]
+]
+
+message := helpers.get_multi_summary(conditions, vars.variables).message
+details := helpers.get_multi_summary(conditions, vars.variables).details

--- a/policies/gcp/looker/core/consumer_network_set/policy.rego
+++ b/policies/gcp/looker/core/consumer_network_set/policy.rego
@@ -13,10 +13,10 @@ conditions := [
       ]
     },
     {
-      "condition": "Require consumer_network when using private connectivity (whitelist: consumerNetwork must be set)",
+      "condition": "consumer_network must be set",
       "attribute_path": ["consumer_network"],
-      "values": ["*"], # Any non-empty string
-      "policy_type": "whitelist"
+      "values": [null, ""], # Violates when missing or empty
+      "policy_type": "blacklist"
     }
   ]
 ]

--- a/policies/gcp/looker/core/custom_domain_when_private/policy.rego
+++ b/policies/gcp/looker/core/custom_domain_when_private/policy.rego
@@ -1,22 +1,33 @@
+# policies/gcp/looker/core/custom_domain_when_private/policy.rego
 package terraform.gcp.security.looker.core.custom_domain_when_private
+
 import data.terraform.gcp.helpers
 import data.terraform.gcp.security.looker.core.vars
 
+# IF public_ip_enabled == false THEN custom_domain.domain must be set
 conditions := [
   [
     {
       "situation_description": "Custom domain required for private/PSC connectivity but not configured",
       "remedies": [
-        "Configure custom_domain block with domain field",
+        "Configure a custom_domain block with a non-empty domain",
         "Set domain to a valid hostname for private access",
         "Ensure DNS is properly configured for the custom domain"
       ]
     },
+    # Guard: "public is OFF" → activate this situation when public_ip_enabled ≠ true (i.e., false/null)
     {
-      "condition": "Require custom_domain.domain when not public (publicIpEnabled=false)",
-      "attribute_path": ["public_ip_enabled", "custom_domain", 0, "domain"],
-      "values": [[false, "*"]], # public_ip_enabled=false AND custom_domain.domain is non-empty
-      "policy_type": "whitelist"
+      "condition": "Guard: public IP is OFF",
+      "attribute_path": ["public_ip_enabled"],
+      "policy_type": "whitelist",
+      "values": [true]
+    },
+    # Requirement: domain must be present → violate when missing/empty
+    {
+      "condition": "custom_domain.domain must be set",
+      "attribute_path": ["custom_domain", 0, "domain"],
+      "policy_type": "blacklist",
+      "values": [null, ""]
     }
   ]
 ]

--- a/policies/gcp/looker/core/custom_domain_when_private/policy.rego
+++ b/policies/gcp/looker/core/custom_domain_when_private/policy.rego
@@ -1,0 +1,25 @@
+package terraform.gcp.security.looker.core.custom_domain_when_private
+import data.terraform.gcp.helpers
+import data.terraform.gcp.security.looker.core.vars
+
+conditions := [
+  [
+    {
+      "situation_description": "Custom domain required for private/PSC connectivity but not configured",
+      "remedies": [
+        "Configure custom_domain block with domain field",
+        "Set domain to a valid hostname for private access",
+        "Ensure DNS is properly configured for the custom domain"
+      ]
+    },
+    {
+      "condition": "Require custom_domain.domain when not public (publicIpEnabled=false)",
+      "attribute_path": ["public_ip_enabled", "custom_domain", 0, "domain"],
+      "values": [[false, "*"]], # public_ip_enabled=false AND custom_domain.domain is non-empty
+      "policy_type": "whitelist"
+    }
+  ]
+]
+
+message := helpers.get_multi_summary(conditions, vars.variables).message
+details := helpers.get_multi_summary(conditions, vars.variables).details

--- a/policies/gcp/looker/core/disallow_trial_editions/policy.rego
+++ b/policies/gcp/looker/core/disallow_trial_editions/policy.rego
@@ -1,0 +1,25 @@
+package terraform.gcp.security.looker.core.disallow_trial_editions
+import data.terraform.gcp.helpers
+import data.terraform.gcp.security.looker.core.vars
+
+conditions := [
+  [
+    {
+      "situation_description": "Trial editions are not allowed in production environments",
+      "remedies": [
+        "Use production platform edition instead of trial",
+        "Set platform_edition to LOOKER_CORE_STANDARD_ANNUAL or similar production SKU",
+        "Avoid LOOKER_CORE_TRIAL* or TRIAL_* values"
+      ]
+    },
+    {
+      "condition": "Disallow trial platform editions",
+      "attribute_path": ["platform_edition"],
+      "values": ["LOOKER_CORE_TRIAL", "TRIAL_*"], # Blacklist specific trial SKUs
+      "policy_type": "blacklist"
+    }
+  ]
+]
+
+message := helpers.get_multi_summary(conditions, vars.variables).message
+details := helpers.get_multi_summary(conditions, vars.variables).details

--- a/policies/gcp/looker/core/fips_required/policy.rego
+++ b/policies/gcp/looker/core/fips_required/policy.rego
@@ -1,0 +1,25 @@
+package terraform.gcp.security.looker.core.fips_required
+import data.terraform.gcp.helpers
+import data.terraform.gcp.security.looker.core.vars
+
+conditions := [
+  [
+    {
+      "situation_description": "FIPS compliance is required but not enabled",
+      "remedies": [
+        "Enable FIPS compliance by setting fips_enabled to true",
+        "Ensure FIPS-validated cryptographic modules are used",
+        "Required for FedRAMP and regulated environments"
+      ]
+    },
+    {
+      "condition": "Require FIPS compliance (whitelist: fipsEnabled must be true)",
+      "attribute_path": ["fips_enabled"],
+      "values": [true],
+      "policy_type": "whitelist"
+    }
+  ]
+]
+
+message := helpers.get_multi_summary(conditions, vars.variables).message
+details := helpers.get_multi_summary(conditions, vars.variables).details

--- a/policies/gcp/looker/core/maintenance_window_set/policy.rego
+++ b/policies/gcp/looker/core/maintenance_window_set/policy.rego
@@ -13,10 +13,10 @@ conditions := [
       ]
     },
     {
-      "condition": "Require maintenance window configuration (whitelist: maintenanceWindow must be present)",
+      "condition": "maintenance_window.day_of_week must be set",
       "attribute_path": ["maintenance_window", 0, "day_of_week"],
-      "values": ["*"], # Any non-empty string
-      "policy_type": "whitelist"
+      "values": [null, ""], # Violates when missing or empty
+      "policy_type": "blacklist"
     }
   ]
 ]

--- a/policies/gcp/looker/core/maintenance_window_set/policy.rego
+++ b/policies/gcp/looker/core/maintenance_window_set/policy.rego
@@ -1,0 +1,25 @@
+package terraform.gcp.security.looker.core.maintenance_window_set
+import data.terraform.gcp.helpers
+import data.terraform.gcp.security.looker.core.vars
+
+conditions := [
+  [
+    {
+      "situation_description": "Maintenance window is required but not configured",
+      "remedies": [
+        "Configure maintenance_window block with day_of_week and start_time",
+        "Set predictable patching windows for system maintenance",
+        "Example: Sunday at 2:00 AM for minimal business impact"
+      ]
+    },
+    {
+      "condition": "Require maintenance window configuration (whitelist: maintenanceWindow must be present)",
+      "attribute_path": ["maintenance_window", 0, "day_of_week"],
+      "values": ["*"], # Any non-empty string
+      "policy_type": "whitelist"
+    }
+  ]
+]
+
+message := helpers.get_multi_summary(conditions, vars.variables).message
+details := helpers.get_multi_summary(conditions, vars.variables).details

--- a/policies/gcp/looker/core/no_public_ip/policy.rego
+++ b/policies/gcp/looker/core/no_public_ip/policy.rego
@@ -1,0 +1,24 @@
+package terraform.gcp.security.looker.core.no_public_ip
+import data.terraform.gcp.helpers
+import data.terraform.gcp.security.looker.core.vars
+
+conditions := [
+  [
+    {
+      "situation_description": "publicIpEnabled is true (public IP exposure increases security risk)",
+      "remedies": [
+        "Set public_ip_enabled to false",
+        "Use private networking or Private Service Connect (PSC) for secure access"
+      ]
+    },
+    {
+      "condition": "Disallow public IP exposure (blacklist publicIpEnabled=true)",
+      "attribute_path": ["public_ip_enabled"],
+      "values": [true],
+      "policy_type": "blacklist"
+    }
+  ]
+]
+
+message := helpers.get_multi_summary(conditions, vars.variables).message
+details := helpers.get_multi_summary(conditions, vars.variables).details

--- a/policies/gcp/looker/core/oauth_config_present/policy.rego
+++ b/policies/gcp/looker/core/oauth_config_present/policy.rego
@@ -13,10 +13,10 @@ conditions := [
       ]
     },
     {
-      "condition": "Require oauth_config block with non-empty client_id and client_secret",
+      "condition": "oauth_config.client_id must be set",
       "attribute_path": ["oauth_config", 0, "client_id"],
-      "values": ["*"], # Any non-empty string
-      "policy_type": "whitelist"
+      "values": [null, ""], # Violates when missing or empty
+      "policy_type": "blacklist"
     }
   ]
 ]

--- a/policies/gcp/looker/core/oauth_config_present/policy.rego
+++ b/policies/gcp/looker/core/oauth_config_present/policy.rego
@@ -1,0 +1,25 @@
+package terraform.gcp.security.looker.core.oauth_config_present
+import data.terraform.gcp.helpers
+import data.terraform.gcp.security.looker.core.vars
+
+conditions := [
+  [
+    {
+      "situation_description": "OAuth configuration is required but not present",
+      "remedies": [
+        "Configure oauth_config block with client_id and client_secret",
+        "Set up OIDC/SAML/OAuth integration for interactive authentication",
+        "Ensure proper authentication flow is configured"
+      ]
+    },
+    {
+      "condition": "Require oauth_config block with non-empty client_id and client_secret",
+      "attribute_path": ["oauth_config", 0, "client_id"],
+      "values": ["*"], # Any non-empty string
+      "policy_type": "whitelist"
+    }
+  ]
+]
+
+message := helpers.get_multi_summary(conditions, vars.variables).message
+details := helpers.get_multi_summary(conditions, vars.variables).details

--- a/policies/gcp/looker/core/private_connectivity_required/policy.rego
+++ b/policies/gcp/looker/core/private_connectivity_required/policy.rego
@@ -1,38 +1,58 @@
+# policies/gcp/looker/core/private_connectivity_required/policy.rego
 package terraform.gcp.security.looker.core.private_connectivity_required
+
 import data.terraform.gcp.helpers
 import data.terraform.gcp.security.looker.core.vars
 
+# Policy intent:
+#   1) Resource must have private connectivity: (private_ip_enabled == true) OR (psc_enabled == true)
+#   2) Public IP must be disabled: public_ip_enabled == false
+#
+# We express this as two OR situations:
+#   - Situation 1 flags when there's NO private connectivity (both private_ip_enabled != true AND psc_enabled != true)
+#   - Situation 2 flags when public_ip_enabled == true
+
 conditions := [
+  # --- Situation 1: No private connectivity configured ---
   [
     {
-      "situation_description": "Private connectivity not properly configured (requires privateIpEnabled=true OR pscEnabled=true, with publicIpEnabled=false)",
+      "situation_description": "Neither Private IP nor PSC is enabled; private connectivity is required",
       "remedies": [
-        "Enable private IP connectivity: set private_ip_enabled to true",
-        "OR enable Private Service Connect: set psc_enabled to true",
-        "Ensure public_ip_enabled is set to false",
-        "Configure consumer_network for private connectivity"
+        "Enable Private IP connectivity: set private_ip_enabled=true",
+        "OR enable Private Service Connect: set psc_enabled=true",
+        "If using PSC, configure consumer_network appropriately"
       ]
     },
+    # Violates when private_ip_enabled is NOT true (false or null)
     {
-      "condition": "Require private connectivity (whitelist: privateIpEnabled=true OR pscEnabled=true, AND publicIpEnabled=false)",
-      "attribute_path": ["private_ip_enabled", "psc_enabled", "public_ip_enabled"],
-      "values": [[true, null, false], [null, true, false], [false, true, false]], # private_ip_enabled=true, psc_enabled=null, public_ip_enabled=false OR psc_enabled=true, private_ip_enabled=null, public_ip_enabled=false
-      "policy_type": "whitelist"
+      "condition": "Guard: private_ip_enabled is not true",
+      "attribute_path": ["private_ip_enabled"],
+      "policy_type": "whitelist",
+      "values": [true]
+    },
+    # AND violates when psc_enabled is NOT true (false or null)
+    {
+      "condition": "Guard: psc_enabled is not true",
+      "attribute_path": ["psc_enabled"],
+      "policy_type": "whitelist",
+      "values": [true]
     }
   ],
+
+  # --- Situation 2: Public IP enabled (must be off when using private connectivity) ---
   [
     {
-      "situation_description": "Public IP must be disabled when using private connectivity",
+      "situation_description": "Public IP must be disabled when private connectivity is required",
       "remedies": [
-        "Set public_ip_enabled to false",
-        "Use private networking or Private Service Connect (PSC) for secure access"
+        "Set public_ip_enabled=false",
+        "Use private networking or Private Service Connect (PSC) for access"
       ]
     },
     {
-      "condition": "Disallow public IP when private connectivity is required (blacklist publicIpEnabled=true)",
+      "condition": "public_ip_enabled must be false",
       "attribute_path": ["public_ip_enabled"],
-      "values": [true],
-      "policy_type": "blacklist"
+      "policy_type": "blacklist",
+      "values": [true]
     }
   ]
 ]

--- a/policies/gcp/looker/core/private_connectivity_required/policy.rego
+++ b/policies/gcp/looker/core/private_connectivity_required/policy.rego
@@ -1,0 +1,41 @@
+package terraform.gcp.security.looker.core.private_connectivity_required
+import data.terraform.gcp.helpers
+import data.terraform.gcp.security.looker.core.vars
+
+conditions := [
+  [
+    {
+      "situation_description": "Private connectivity not properly configured (requires privateIpEnabled=true OR pscEnabled=true, with publicIpEnabled=false)",
+      "remedies": [
+        "Enable private IP connectivity: set private_ip_enabled to true",
+        "OR enable Private Service Connect: set psc_enabled to true",
+        "Ensure public_ip_enabled is set to false",
+        "Configure consumer_network for private connectivity"
+      ]
+    },
+    {
+      "condition": "Require private connectivity (whitelist: privateIpEnabled=true OR pscEnabled=true, AND publicIpEnabled=false)",
+      "attribute_path": ["private_ip_enabled", "psc_enabled", "public_ip_enabled"],
+      "values": [[true, null, false], [null, true, false], [false, true, false]], # private_ip_enabled=true, psc_enabled=null, public_ip_enabled=false OR psc_enabled=true, private_ip_enabled=null, public_ip_enabled=false
+      "policy_type": "whitelist"
+    }
+  ],
+  [
+    {
+      "situation_description": "Public IP must be disabled when using private connectivity",
+      "remedies": [
+        "Set public_ip_enabled to false",
+        "Use private networking or Private Service Connect (PSC) for secure access"
+      ]
+    },
+    {
+      "condition": "Disallow public IP when private connectivity is required (blacklist publicIpEnabled=true)",
+      "attribute_path": ["public_ip_enabled"],
+      "values": [true],
+      "policy_type": "blacklist"
+    }
+  ]
+]
+
+message := helpers.get_multi_summary(conditions, vars.variables).message
+details := helpers.get_multi_summary(conditions, vars.variables).details

--- a/policies/gcp/looker/core/psc_mode_hygiene/policy.rego
+++ b/policies/gcp/looker/core/psc_mode_hygiene/policy.rego
@@ -1,0 +1,40 @@
+package terraform.gcp.security.looker.core.psc_mode_hygiene
+import data.terraform.gcp.helpers
+import data.terraform.gcp.security.looker.core.vars
+
+conditions := [
+  [
+    {
+      "situation_description": "PSC mode hygiene violation: when pscEnabled=true, publicIpEnabled and privateIpEnabled must both be false",
+      "remedies": [
+        "When using PSC (psc_enabled=true), ensure public_ip_enabled is set to false",
+        "When using PSC (psc_enabled=true), ensure private_ip_enabled is set to false",
+        "PSC requires exclusivity - no other IP connectivity methods should be enabled"
+      ]
+    },
+    {
+      "condition": "Disallow public IP when PSC is enabled (blacklist: pscEnabled=true AND publicIpEnabled=true)",
+      "attribute_path": ["psc_enabled", "public_ip_enabled"],
+      "values": [[true, true]],
+      "policy_type": "blacklist"
+    }
+  ],
+  [
+    {
+      "situation_description": "PSC mode hygiene violation: when pscEnabled=true, privateIpEnabled must be false",
+      "remedies": [
+        "When using PSC (psc_enabled=true), ensure private_ip_enabled is set to false",
+        "PSC requires exclusivity - no other IP connectivity methods should be enabled"
+      ]
+    },
+    {
+      "condition": "Disallow private IP when PSC is enabled (blacklist: pscEnabled=true AND privateIpEnabled=true)",
+      "attribute_path": ["psc_enabled", "private_ip_enabled"],
+      "values": [[true, true]],
+      "policy_type": "blacklist"
+    }
+  ]
+]
+
+message := helpers.get_multi_summary(conditions, vars.variables).message
+details := helpers.get_multi_summary(conditions, vars.variables).details

--- a/policies/gcp/looker/core/psc_mode_hygiene/policy.rego
+++ b/policies/gcp/looker/core/psc_mode_hygiene/policy.rego
@@ -1,37 +1,55 @@
+# policies/gcp/looker/core/psc_mode_hygiene/policy.rego
 package terraform.gcp.security.looker.core.psc_mode_hygiene
+
 import data.terraform.gcp.helpers
 import data.terraform.gcp.security.looker.core.vars
 
+# Intent: If PSC is enabled, BOTH public_ip_enabled and private_ip_enabled must be false.
+
 conditions := [
+  # Situation A: PSC ON ∧ public_ip_enabled == true  → violation
   [
     {
-      "situation_description": "PSC mode hygiene violation: when pscEnabled=true, publicIpEnabled and privateIpEnabled must both be false",
+      "situation_description": "PSC enabled but Public IP is still enabled",
       "remedies": [
-        "When using PSC (psc_enabled=true), ensure public_ip_enabled is set to false",
-        "When using PSC (psc_enabled=true), ensure private_ip_enabled is set to false",
-        "PSC requires exclusivity - no other IP connectivity methods should be enabled"
+        "Set public_ip_enabled=false when psc_enabled=true",
+        "PSC requires exclusivity; disable other connectivity modes"
       ]
     },
     {
-      "condition": "Disallow public IP when PSC is enabled (blacklist: pscEnabled=true AND publicIpEnabled=true)",
-      "attribute_path": ["psc_enabled", "public_ip_enabled"],
-      "values": [[true, true]],
-      "policy_type": "blacklist"
+      "condition": "Guard: PSC is ON",
+      "attribute_path": ["psc_enabled"],
+      "policy_type": "blacklist",
+      "values": [true]
+    },
+    {
+      "condition": "Public IP must be OFF when PSC is ON",
+      "attribute_path": ["public_ip_enabled"],
+      "policy_type": "blacklist",
+      "values": [true]
     }
   ],
+
+  # Situation B: PSC ON ∧ private_ip_enabled == true → violation
   [
     {
-      "situation_description": "PSC mode hygiene violation: when pscEnabled=true, privateIpEnabled must be false",
+      "situation_description": "PSC enabled but Private IP is still enabled",
       "remedies": [
-        "When using PSC (psc_enabled=true), ensure private_ip_enabled is set to false",
-        "PSC requires exclusivity - no other IP connectivity methods should be enabled"
+        "Set private_ip_enabled=false when psc_enabled=true",
+        "PSC requires exclusivity; disable other connectivity modes"
       ]
     },
     {
-      "condition": "Disallow private IP when PSC is enabled (blacklist: pscEnabled=true AND privateIpEnabled=true)",
-      "attribute_path": ["psc_enabled", "private_ip_enabled"],
-      "values": [[true, true]],
-      "policy_type": "blacklist"
+      "condition": "Guard: PSC is ON",
+      "attribute_path": ["psc_enabled"],
+      "policy_type": "blacklist",
+      "values": [true]
+    },
+    {
+      "condition": "Private IP must be OFF when PSC is ON",
+      "attribute_path": ["private_ip_enabled"],
+      "policy_type": "blacklist",
+      "values": [true]
     }
   ]
 ]

--- a/policies/gcp/looker/core/reserved_range_for_psa_psc/policy.rego
+++ b/policies/gcp/looker/core/reserved_range_for_psa_psc/policy.rego
@@ -13,10 +13,10 @@ conditions := [
       ]
     },
     {
-      "condition": "Require reserved_range when using private connectivity (whitelist: reservedRange must be set)",
+      "condition": "reserved_range must be set",
       "attribute_path": ["reserved_range"],
-      "values": ["*"], # Any non-empty string
-      "policy_type": "whitelist"
+      "values": [null, ""], # Violates when missing or empty
+      "policy_type": "blacklist"
     }
   ]
 ]

--- a/policies/gcp/looker/core/reserved_range_for_psa_psc/policy.rego
+++ b/policies/gcp/looker/core/reserved_range_for_psa_psc/policy.rego
@@ -1,0 +1,25 @@
+package terraform.gcp.security.looker.core.reserved_range_for_psa_psc
+import data.terraform.gcp.helpers
+import data.terraform.gcp.security.looker.core.vars
+
+conditions := [
+  [
+    {
+      "situation_description": "Reserved range required for Private Service Access/PSC but not configured",
+      "remedies": [
+        "Configure reserved_range field for private connectivity",
+        "Set reserved_range to a valid reserved IP range path",
+        "Example: projects/PROJECT_ID/global/addresses/RESERVED_RANGE_NAME"
+      ]
+    },
+    {
+      "condition": "Require reserved_range when using private connectivity (whitelist: reservedRange must be set)",
+      "attribute_path": ["reserved_range"],
+      "values": ["*"], # Any non-empty string
+      "policy_type": "whitelist"
+    }
+  ]
+]
+
+message := helpers.get_multi_summary(conditions, vars.variables).message
+details := helpers.get_multi_summary(conditions, vars.variables).details

--- a/policies/gcp/looker/core/vars.rego
+++ b/policies/gcp/looker/core/vars.rego
@@ -1,0 +1,7 @@
+package terraform.gcp.security.looker.core.vars
+
+variables := {
+    "friendly_resource_name": "Looker Core Instance", # eg., "GCS Bucket",
+    "resource_type":  "google_looker_instance",        # eg., "google_storage_bucket"
+    "resource_value_name" : "name"                      # eg., "name"
+}


### PR DESCRIPTION
Policies 

no_public_ip — blacklist public_ip_enabled=true

private_connectivity_required — require private_ip_enabled=true or psc_enabled=true, with public_ip_enabled=false

psc_mode_hygiene — when psc_enabled=true, both public_ip_enabled=false and private_ip_enabled=false

cmek_required — require encryption_config.kms_key_name

custom_domain_when_private — require custom_domain.domain when not public/PSC

oauth_config_present — require oauth_config with non-empty client_id/client_secret

consumer_network_set — require consumer_network for private/PSC

reserved_range_for_psa_psc — require reserved_range for private/PSC

disallow_trial_editions — blacklist trial SKUs

fips_required — require fips_enabled=true

maintenance_window_set — require maintenance_window (day + start time)