### PR TITLE
Gcp/service/managed kafka (#128)

### DIFF
--- a/inputs/gcp/managed_kafka/google_managed_kafka_acl/global_acls/.terraform.lock.hcl
+++ b/inputs/gcp/managed_kafka/google_managed_kafka_acl/global_acls/.terraform.lock.hcl
@@ -1,0 +1,21 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/google" {
+  version = "7.2.0"
+  hashes = [
+    "h1:n9j0rZHrmXEay4dYo0D+RGS7X8eQr+YZ0MupX8GaMfI=",
+    "zh:0f036e400c90ae45289b948afb49ca938d169fb4a31d7560b345fd0ae5121407",
+    "zh:28a7c683656178456dc7942f051df46052150cee74da7535e7ca8748a83baf30",
+    "zh:2994083c634cff44de626b4bfca3e5e8ed5b2a08baa6f4c4fa4b217d5f49559a",
+    "zh:3c0d98921944c39f2e9d7f42122f44bcf07418ee9ee5faf81e6357cecbac4870",
+    "zh:4f869f574ab7e5970e9ec543fccd4c773e41a111f9bedc7075b725217f3c6fd2",
+    "zh:65479468ab9f6735d267bb593af8d139561790467ba6f8f99c3ba3be25b3a8e9",
+    "zh:827cb00f8dc4bba03afce2ff5d11bcd2d0528fc4624ea05b70354a1fa18b59fb",
+    "zh:a087e5155bd73d59f9dc6df65c1b38944de06cb2a5ead2439b31ad10a18da5a7",
+    "zh:db714b0e7a4365b3d93c17df2abc2bc883c89b15524111433af05aea176680c1",
+    "zh:e5444fde901cfefe7f66c8e9a1d9915d403fc2a6ebe87eaa2a262d2a50ee0a10",
+    "zh:f360342aa2bad7f6123c959b2129abaed99e26891dcd0b0719fec55252bb44b9",
+    "zh:f569b65999264a9416862bca5cd2a6177d94ccb0424f3a4ef424428912b9cb3c",
+  ]
+}

--- a/inputs/gcp/managed_kafka/google_managed_kafka_acl/global_acls/c.tf
+++ b/inputs/gcp/managed_kafka/google_managed_kafka_acl/global_acls/c.tf
@@ -1,0 +1,31 @@
+# Describe your resource type here
+# Keep "c" as the name to indicate that this resource and its attributes are compliant
+
+resource "google_managed_kafka_acl" "c1" {
+  acl_id   = "c1"
+  cluster  = "projects/my-project/locations/australia-southeast2/clusters/example-cluster"
+  location = "us-central1"
+  project  = "123"
+
+  acl_entries {
+    principal       = "User:producer-client@my-project.iam.gserviceaccount.com"
+    permission_type = "ALLOW"
+    operation       = "WRITE"
+    host            = "*"
+  }
+}
+
+resource "google_managed_kafka_acl" "c2" {
+  acl_id   = "c2"
+  cluster  = "projects/my-project/locations/australia-southeast2/clusters/example-cluster"
+  location = "us-central1"
+  project  = "123"
+
+  acl_entries {
+    principal       = "User:consumer-app@my-project.iam.gserviceaccount.com"
+    permission_type = "ALLOW"
+    operation       = "READ"
+    host            = "*"
+  }
+}
+

--- a/inputs/gcp/managed_kafka/google_managed_kafka_acl/global_acls/config.tf
+++ b/inputs/gcp/managed_kafka/google_managed_kafka_acl/global_acls/config.tf
@@ -1,0 +1,11 @@
+##### DO NOT EDIT ######
+
+terraform {
+  required_providers {
+    google = {
+      source  = "hashicorp/google"
+    }
+  }
+}
+
+provider "google" {}

--- a/inputs/gcp/managed_kafka/google_managed_kafka_acl/global_acls/nc.tf
+++ b/inputs/gcp/managed_kafka/google_managed_kafka_acl/global_acls/nc.tf
@@ -1,0 +1,30 @@
+# Describe your resource type here
+# Keep "nc" as the name to indicate that this resource and its attributes are non-compliant
+
+resource "google_managed_kafka_acl" "nc1" {
+  acl_id   = "nc1"
+  cluster  = "projects/my-project/locations/australia-southeast2/clusters/example-cluster"
+  location = "us-central1"
+  project  = "123"
+
+  acl_entries {
+    principal       = "User:*"
+    permission_type = "ALLOW"
+    operation       = "ALL"
+    host            = "*"
+  }
+}
+
+resource "google_managed_kafka_acl" "nc2" {
+  acl_id   = "nc2"
+  cluster  = "projects/my-project/locations/australia-southeast2/clusters/example-cluster"
+  location = "us-central1"
+  project  = "123"
+
+  acl_entries {
+    principal       = "User:*"
+    permission_type = "ALLOW"
+    operation       = "ALL"
+    host            = "*"
+  }
+}

--- a/inputs/gcp/managed_kafka/google_managed_kafka_acl/secured_acl_entries/.terraform.lock.hcl
+++ b/inputs/gcp/managed_kafka/google_managed_kafka_acl/secured_acl_entries/.terraform.lock.hcl
@@ -1,0 +1,22 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/google" {
+  version     = "7.1.0"
+  constraints = "7.1.0"
+  hashes = [
+    "h1:1Asv8wk8g/aYL/eCbsWCSjaI16sFalhn+uoN1U8riyA=",
+    "zh:271095580776620d5fa21dd60859a12d9c1d83a60e116069001e3206b78f01c3",
+    "zh:303b7aa8c040a6d1c37792e3fb298e5311635ad0c81e3f8c31e6bb6d762c3cb0",
+    "zh:59d31f5bf617423126d9e4a297509fe08a57ba83ae7a947ba417c3f6dd10ccc0",
+    "zh:803a178250832d773afb0f16050eb164d58fcacf17981da85169165afa6dc2f7",
+    "zh:a2db4da218f1546f3d33ce9a100afd9c1b9e8da833f144bcb1fbfe4b2383f66d",
+    "zh:ac1e2fc293ade42d3955fcb1bd6f25767de28210e0314f755656d4e735ec0983",
+    "zh:adb034cd384d9f55555d58fb0e6ceb8e7b562121769721bcc22403cebe2e67fc",
+    "zh:ccf2c397d2788fc5358f5080d55fb4379c27656bccaf0db24b3814b34ffa0019",
+    "zh:d11850d7b9ce005501ba993fe55cbae878016e2c7a5ddc8e3f3113392f254e41",
+    "zh:e4ef4e036c9d5fb823e2b28f770cb941cccdde896e9cacf0df4e85bdf7d66461",
+    "zh:f569b65999264a9416862bca5cd2a6177d94ccb0424f3a4ef424428912b9cb3c",
+    "zh:f7b37c8fc194aeb24c341dd9f34919b2a0eac8302a3220929310d2fbe60e7832",
+  ]
+}

--- a/inputs/gcp/managed_kafka/google_managed_kafka_acl/secured_acl_entries/c.tf
+++ b/inputs/gcp/managed_kafka/google_managed_kafka_acl/secured_acl_entries/c.tf
@@ -1,0 +1,14 @@
+resource "google_managed_kafka_acl" "c1" {
+  acl_id   = "c1"
+  cluster       = "projects/my-project/locations/australia-southeast2/clusters/example-cluster"
+  location = "us-central1"
+  project = "123"
+  
+  acl_entries {
+    principal       = "User:producer-client@my-project.iam.gserviceaccount.com"
+    permission_type = "ALLOW"
+    operation       = "WRITE"
+    host            = "*"
+  }
+}
+

--- a/inputs/gcp/managed_kafka/google_managed_kafka_acl/secured_acl_entries/config.tf
+++ b/inputs/gcp/managed_kafka/google_managed_kafka_acl/secured_acl_entries/config.tf
@@ -1,0 +1,12 @@
+##### DO NOT EDIT ######
+
+terraform {
+  required_providers {
+    google = {
+      source = "hashicorp/google"
+      version = "7.1.0"
+    }
+  }
+}
+
+provider "google" {}

--- a/inputs/gcp/managed_kafka/google_managed_kafka_acl/secured_acl_entries/nc.tf
+++ b/inputs/gcp/managed_kafka/google_managed_kafka_acl/secured_acl_entries/nc.tf
@@ -1,0 +1,14 @@
+resource "google_managed_kafka_acl" "nc1" {
+  acl_id   = "nc1"
+  cluster       = "projects/my-project/locations/australia-southeast2/clusters/example-cluster"
+  location = "us-central1"
+  project = "123"
+  
+  acl_entries {
+    principal       = "User:producer-client@my-project.iam.gserviceaccount.com"
+    permission_type = "ALLOW"
+    operation       = "ALL"
+    host            = "*"
+  }
+}
+

--- a/inputs/gcp/managed_kafka/google_managed_kafka_acl/wildcard_principals/.terraform.lock.hcl
+++ b/inputs/gcp/managed_kafka/google_managed_kafka_acl/wildcard_principals/.terraform.lock.hcl
@@ -1,0 +1,21 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/google" {
+  version = "7.1.1"
+  hashes = [
+    "h1:Hu/Gy8dB7TXsUyswqm6XJhr7esYmXk9Ea/Jo9VgT4LE=",
+    "zh:03ee9fdc0d157a606aba68658de6dc809fc3335cccb7c537373d8643412c1327",
+    "zh:110e8ffe81deb8c203ecf310a15c2dedca1dfc936473a247b8a4f98adebd86f5",
+    "zh:459e3419c004e7a475fb60cc52d47a34b3dc4e4de905eaa8e8f78ddbe550a9b5",
+    "zh:466cd31cee36877bc18aeabed80d1f4a22bac4e59a460be6e8bdb72dedca0e2b",
+    "zh:51d707eb2d854fa16dcbe21e29b01534eb893a2152a219ea84a15bbd87a4ff64",
+    "zh:69d6a1c83ffddd7f81273a98fb0ff7c13985a3c876565dd3df76c730c9929871",
+    "zh:9b5050da221735c7e8f75ed00d25578afaf8ed94a8c2f1f58f471eee98105d10",
+    "zh:ab01f2fd961ee86d99a55186093620d29f5323c0cd5613284d484e333679d70b",
+    "zh:d0f5b15774b15991baf71eb4a55a6831e3fb4b603f589f80b03393b46a9657a4",
+    "zh:dc198ec4b42435321f4fa12ca8d713cd350ff2f82d8749b87785b91b15b7c3ed",
+    "zh:e949c00ce89c92b7ed16cc0b0aed8e80d6416b240dc02047f9fa1de49aa4c44e",
+    "zh:f569b65999264a9416862bca5cd2a6177d94ccb0424f3a4ef424428912b9cb3c",
+  ]
+}

--- a/inputs/gcp/managed_kafka/google_managed_kafka_acl/wildcard_principals/c.tf
+++ b/inputs/gcp/managed_kafka/google_managed_kafka_acl/wildcard_principals/c.tf
@@ -1,0 +1,17 @@
+# Describe your resource type here
+# Keep "c" as the name to indicate that this resource and its attributes are compliant
+
+resource "google_managed_kafka_acl" "compliant_acl" {
+  acl_id   = "compliant-acl"
+  cluster  = "projects/my-project/locations/australia-southeast2/clusters/example-cluster"
+  location = "us-central1"
+  project  = "123"
+
+  acl_entries {
+    principal       = "User:producer-client@my-project.iam.gserviceaccount.com"  # Ensure principal is not a wildcard
+    permission_type = "ALLOW"
+    operation       = "WRITE"
+    host            = "*"
+  }
+}
+

--- a/inputs/gcp/managed_kafka/google_managed_kafka_acl/wildcard_principals/config.tf
+++ b/inputs/gcp/managed_kafka/google_managed_kafka_acl/wildcard_principals/config.tf
@@ -1,0 +1,11 @@
+##### DO NOT EDIT ######
+
+terraform {
+  required_providers {
+    google = {
+      source  = "hashicorp/google"
+    }
+  }
+}
+
+provider "google" {}

--- a/inputs/gcp/managed_kafka/google_managed_kafka_acl/wildcard_principals/nc.tf
+++ b/inputs/gcp/managed_kafka/google_managed_kafka_acl/wildcard_principals/nc.tf
@@ -1,0 +1,16 @@
+# Describe your resource type here
+# Keep "nc" as the name to indicate that this resource and its attributes are non-compliant
+
+resource "google_managed_kafka_acl" "non_compliant_acl" {
+  acl_id   = "non-compliant-acl"
+  cluster  = "projects/my-project/locations/australia-southeast2/clusters/example-cluster"
+  location = "us-central1"
+  project  = "123"
+
+  acl_entries {
+    principal       = "User:*"  
+    permission_type = "ALLOW"
+    operation       = "ALL"
+    host            = "*"
+  }
+}

--- a/inputs/gcp/managed_kafka/google_managed_kafka_cluster/kafka_cluster/.terraform.lock.hcl
+++ b/inputs/gcp/managed_kafka/google_managed_kafka_cluster/kafka_cluster/.terraform.lock.hcl
@@ -1,0 +1,21 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/google" {
+  version = "7.1.1"
+  hashes = [
+    "h1:Hu/Gy8dB7TXsUyswqm6XJhr7esYmXk9Ea/Jo9VgT4LE=",
+    "zh:03ee9fdc0d157a606aba68658de6dc809fc3335cccb7c537373d8643412c1327",
+    "zh:110e8ffe81deb8c203ecf310a15c2dedca1dfc936473a247b8a4f98adebd86f5",
+    "zh:459e3419c004e7a475fb60cc52d47a34b3dc4e4de905eaa8e8f78ddbe550a9b5",
+    "zh:466cd31cee36877bc18aeabed80d1f4a22bac4e59a460be6e8bdb72dedca0e2b",
+    "zh:51d707eb2d854fa16dcbe21e29b01534eb893a2152a219ea84a15bbd87a4ff64",
+    "zh:69d6a1c83ffddd7f81273a98fb0ff7c13985a3c876565dd3df76c730c9929871",
+    "zh:9b5050da221735c7e8f75ed00d25578afaf8ed94a8c2f1f58f471eee98105d10",
+    "zh:ab01f2fd961ee86d99a55186093620d29f5323c0cd5613284d484e333679d70b",
+    "zh:d0f5b15774b15991baf71eb4a55a6831e3fb4b603f589f80b03393b46a9657a4",
+    "zh:dc198ec4b42435321f4fa12ca8d713cd350ff2f82d8749b87785b91b15b7c3ed",
+    "zh:e949c00ce89c92b7ed16cc0b0aed8e80d6416b240dc02047f9fa1de49aa4c44e",
+    "zh:f569b65999264a9416862bca5cd2a6177d94ccb0424f3a4ef424428912b9cb3c",
+  ]
+}

--- a/inputs/gcp/managed_kafka/google_managed_kafka_cluster/kafka_cluster/c.tf
+++ b/inputs/gcp/managed_kafka/google_managed_kafka_cluster/kafka_cluster/c.tf
@@ -1,0 +1,33 @@
+# Describe your resource type here
+# Keep "c" as the name to indicate that this resource and its attributes are compliant
+
+resource "google_managed_kafka_cluster" "secure_cluster" {
+  cluster_id = "secure-cluster"
+  location   = "us-central1"
+  project    = "my-project"
+
+  capacity_config {
+    vcpu_count   = 3
+    memory_bytes = 3221225472
+  }
+
+  gcp_config {
+    access_config {
+      network_configs {
+        subnet = "projects/my-project/regions/us-central1/subnetworks/private-subnet" # ✅ Private subnet
+      }
+    }
+    kms_key = google_kms_crypto_key.key.id
+  }
+}
+
+resource "google_kms_key_ring" "key_ring" {
+  name     = "secure-key-ring"
+  location = "us-central1"
+  project  = "my-project"
+}
+
+resource "google_kms_crypto_key" "key" {
+  name     = "secure-key"
+  key_ring = google_kms_key_ring.key_ring.id
+}

--- a/inputs/gcp/managed_kafka/google_managed_kafka_cluster/kafka_cluster/config.tf
+++ b/inputs/gcp/managed_kafka/google_managed_kafka_cluster/kafka_cluster/config.tf
@@ -1,0 +1,11 @@
+##### DO NOT EDIT ######
+
+terraform {
+  required_providers {
+    google = {
+      source  = "hashicorp/google"
+    }
+  }
+}
+
+provider "google" {}

--- a/inputs/gcp/managed_kafka/google_managed_kafka_cluster/kafka_cluster/nc.tf
+++ b/inputs/gcp/managed_kafka/google_managed_kafka_cluster/kafka_cluster/nc.tf
@@ -1,0 +1,32 @@
+resource "google_managed_kafka_cluster" "insecure_cluster" {
+  cluster_id = "insecure-cluster"
+  location   = "us-central1"
+  project    = "my-project"
+
+  capacity_config {
+    vcpu_count   = 3
+    memory_bytes = 3221225472
+  }
+
+  gcp_config {
+    access_config {
+      network_configs {
+        subnet = ""  
+      }
+    }
+    
+    kms_key = google_kms_crypto_key.key_nc.id
+  }
+}
+
+resource "google_kms_key_ring" "key_ring_nc" {
+  name     = "insecure-key-ring"
+  location = "us-central1"
+  project  = "my-project"
+}
+
+resource "google_kms_crypto_key" "key_nc" {
+  name     = "insecure-key"
+  
+  key_ring = google_kms_key_ring.key_ring_nc.id
+}

--- a/inputs/gcp/managed_kafka/google_managed_kafka_cluster/kafka_cmek_enforcement/.terraform.lock.hcl
+++ b/inputs/gcp/managed_kafka/google_managed_kafka_cluster/kafka_cmek_enforcement/.terraform.lock.hcl
@@ -1,0 +1,21 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/google" {
+  version = "7.1.0"
+  hashes = [
+    "h1:1Asv8wk8g/aYL/eCbsWCSjaI16sFalhn+uoN1U8riyA=",
+    "zh:271095580776620d5fa21dd60859a12d9c1d83a60e116069001e3206b78f01c3",
+    "zh:303b7aa8c040a6d1c37792e3fb298e5311635ad0c81e3f8c31e6bb6d762c3cb0",
+    "zh:59d31f5bf617423126d9e4a297509fe08a57ba83ae7a947ba417c3f6dd10ccc0",
+    "zh:803a178250832d773afb0f16050eb164d58fcacf17981da85169165afa6dc2f7",
+    "zh:a2db4da218f1546f3d33ce9a100afd9c1b9e8da833f144bcb1fbfe4b2383f66d",
+    "zh:ac1e2fc293ade42d3955fcb1bd6f25767de28210e0314f755656d4e735ec0983",
+    "zh:adb034cd384d9f55555d58fb0e6ceb8e7b562121769721bcc22403cebe2e67fc",
+    "zh:ccf2c397d2788fc5358f5080d55fb4379c27656bccaf0db24b3814b34ffa0019",
+    "zh:d11850d7b9ce005501ba993fe55cbae878016e2c7a5ddc8e3f3113392f254e41",
+    "zh:e4ef4e036c9d5fb823e2b28f770cb941cccdde896e9cacf0df4e85bdf7d66461",
+    "zh:f569b65999264a9416862bca5cd2a6177d94ccb0424f3a4ef424428912b9cb3c",
+    "zh:f7b37c8fc194aeb24c341dd9f34919b2a0eac8302a3220929310d2fbe60e7832",
+  ]
+}

--- a/inputs/gcp/managed_kafka/google_managed_kafka_cluster/kafka_cmek_enforcement/c.tf
+++ b/inputs/gcp/managed_kafka/google_managed_kafka_cluster/kafka_cmek_enforcement/c.tf
@@ -1,0 +1,33 @@
+resource "google_managed_kafka_cluster" "secure_cluster" {
+  cluster_id = "secure-cluster"
+  location   = "us-central1"
+  project    = "123" 
+
+  capacity_config {
+    vcpu_count    = 3
+    memory_bytes  = 3221225472
+  }
+
+  gcp_config {
+    access_config {
+      network_configs {
+        subnet = "projects/my-project/regions/us-central1/subnetworks/private-subnet"
+      }
+    }
+    kms_key = google_kms_crypto_key.key.id  
+  }
+}
+
+# Key ring for CMEK
+resource "google_kms_key_ring" "key_ring" {
+  name     = "example-key-ring"
+  location = "us-central1"
+  project  = "123"  
+}
+
+# Crypto key for CMEK
+resource "google_kms_crypto_key" "key" {
+  name     = "example-key"
+  key_ring = google_kms_key_ring.key_ring.id
+    
+}

--- a/inputs/gcp/managed_kafka/google_managed_kafka_cluster/kafka_cmek_enforcement/config.tf
+++ b/inputs/gcp/managed_kafka/google_managed_kafka_cluster/kafka_cmek_enforcement/config.tf
@@ -1,0 +1,11 @@
+##### DO NOT EDIT ######
+
+terraform {
+  required_providers {
+    google = {
+      source  = "hashicorp/google"
+    }
+  }
+}
+
+provider "google" {}

--- a/inputs/gcp/managed_kafka/google_managed_kafka_cluster/kafka_cmek_enforcement/nc.tf
+++ b/inputs/gcp/managed_kafka/google_managed_kafka_cluster/kafka_cmek_enforcement/nc.tf
@@ -1,0 +1,19 @@
+resource "google_managed_kafka_cluster" "insecure_cluster" {
+  cluster_id = "insecure-cluster"
+  location   = "us-central1"
+  project = "123"
+
+  capacity_config {
+    vcpu_count    = 3
+    memory_bytes  = 3221225472
+  }
+
+  gcp_config {
+    access_config {
+      network_configs {
+        subnet = "projects/my-project/regions/us-central1/subnetworks/public-subnet"
+      }
+    }
+    
+  }
+}

--- a/inputs/gcp/managed_kafka/google_managed_kafka_cluster/kafka_mtls_enforcement/.terraform.lock.hcl
+++ b/inputs/gcp/managed_kafka/google_managed_kafka_cluster/kafka_mtls_enforcement/.terraform.lock.hcl
@@ -1,0 +1,21 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/google" {
+  version = "7.1.1"
+  hashes = [
+    "h1:Hu/Gy8dB7TXsUyswqm6XJhr7esYmXk9Ea/Jo9VgT4LE=",
+    "zh:03ee9fdc0d157a606aba68658de6dc809fc3335cccb7c537373d8643412c1327",
+    "zh:110e8ffe81deb8c203ecf310a15c2dedca1dfc936473a247b8a4f98adebd86f5",
+    "zh:459e3419c004e7a475fb60cc52d47a34b3dc4e4de905eaa8e8f78ddbe550a9b5",
+    "zh:466cd31cee36877bc18aeabed80d1f4a22bac4e59a460be6e8bdb72dedca0e2b",
+    "zh:51d707eb2d854fa16dcbe21e29b01534eb893a2152a219ea84a15bbd87a4ff64",
+    "zh:69d6a1c83ffddd7f81273a98fb0ff7c13985a3c876565dd3df76c730c9929871",
+    "zh:9b5050da221735c7e8f75ed00d25578afaf8ed94a8c2f1f58f471eee98105d10",
+    "zh:ab01f2fd961ee86d99a55186093620d29f5323c0cd5613284d484e333679d70b",
+    "zh:d0f5b15774b15991baf71eb4a55a6831e3fb4b603f589f80b03393b46a9657a4",
+    "zh:dc198ec4b42435321f4fa12ca8d713cd350ff2f82d8749b87785b91b15b7c3ed",
+    "zh:e949c00ce89c92b7ed16cc0b0aed8e80d6416b240dc02047f9fa1de49aa4c44e",
+    "zh:f569b65999264a9416862bca5cd2a6177d94ccb0424f3a4ef424428912b9cb3c",
+  ]
+}

--- a/inputs/gcp/managed_kafka/google_managed_kafka_cluster/kafka_mtls_enforcement/c.tf
+++ b/inputs/gcp/managed_kafka/google_managed_kafka_cluster/kafka_mtls_enforcement/c.tf
@@ -1,0 +1,36 @@
+# Describe your resource type here
+# Keep "c" as the name to indicate that this resource and its attributes are compliant
+
+resource "google_managed_kafka_cluster" "secure_tls_cluster" {
+  cluster_id = "secure-tls-cluster"
+  location   = "us-central1"
+  project = "123"
+
+  capacity_config {
+    vcpu_count    = 3
+    memory_bytes  = 3221225472
+  }
+
+  gcp_config {
+    access_config {
+      network_configs {
+        subnet = "projects/my-project/regions/us-central1/subnetworks/private-subnet"
+      }
+    }
+  }
+
+  tls_config {
+    trust_config {
+      cas_configs {
+        ca_pool = google_privateca_ca_pool.ca_pool.id  
+      }
+    }
+  }
+}
+
+resource "google_privateca_ca_pool" "ca_pool" {
+  name     = "my-ca-pool"
+  location = "us-central1"
+  tier     = "ENTERPRISE"
+  project  = "123"
+}

--- a/inputs/gcp/managed_kafka/google_managed_kafka_cluster/kafka_mtls_enforcement/config.tf
+++ b/inputs/gcp/managed_kafka/google_managed_kafka_cluster/kafka_mtls_enforcement/config.tf
@@ -1,0 +1,11 @@
+##### DO NOT EDIT ######
+
+terraform {
+  required_providers {
+    google = {
+      source  = "hashicorp/google"
+    }
+  }
+}
+
+provider "google" {}

--- a/inputs/gcp/managed_kafka/google_managed_kafka_cluster/kafka_mtls_enforcement/nc.tf
+++ b/inputs/gcp/managed_kafka/google_managed_kafka_cluster/kafka_mtls_enforcement/nc.tf
@@ -1,0 +1,23 @@
+# Describe your resource type here
+# Keep "nc" as the name to indicate that this resource and its attributes are non-compliant
+
+resource "google_managed_kafka_cluster" "insecure_tls_cluster" {
+  cluster_id = "insecure-tls-cluster"
+  location   = "us-central1"
+  project = "123"
+
+  capacity_config {
+    vcpu_count    = 3
+    memory_bytes  = 3221225472
+  }
+
+  gcp_config {
+    access_config {
+      network_configs {
+        subnet = "projects/my-project/regions/us-central1/subnetworks/private-subnet"
+      }
+    }
+  }
+
+  
+}

--- a/inputs/gcp/managed_kafka/google_managed_kafka_connect_cluster/cluster_binding/.terraform.lock.hcl
+++ b/inputs/gcp/managed_kafka/google_managed_kafka_connect_cluster/cluster_binding/.terraform.lock.hcl
@@ -1,0 +1,41 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/google" {
+  version = "7.2.0"
+  hashes = [
+    "h1:n9j0rZHrmXEay4dYo0D+RGS7X8eQr+YZ0MupX8GaMfI=",
+    "zh:0f036e400c90ae45289b948afb49ca938d169fb4a31d7560b345fd0ae5121407",
+    "zh:28a7c683656178456dc7942f051df46052150cee74da7535e7ca8748a83baf30",
+    "zh:2994083c634cff44de626b4bfca3e5e8ed5b2a08baa6f4c4fa4b217d5f49559a",
+    "zh:3c0d98921944c39f2e9d7f42122f44bcf07418ee9ee5faf81e6357cecbac4870",
+    "zh:4f869f574ab7e5970e9ec543fccd4c773e41a111f9bedc7075b725217f3c6fd2",
+    "zh:65479468ab9f6735d267bb593af8d139561790467ba6f8f99c3ba3be25b3a8e9",
+    "zh:827cb00f8dc4bba03afce2ff5d11bcd2d0528fc4624ea05b70354a1fa18b59fb",
+    "zh:a087e5155bd73d59f9dc6df65c1b38944de06cb2a5ead2439b31ad10a18da5a7",
+    "zh:db714b0e7a4365b3d93c17df2abc2bc883c89b15524111433af05aea176680c1",
+    "zh:e5444fde901cfefe7f66c8e9a1d9915d403fc2a6ebe87eaa2a262d2a50ee0a10",
+    "zh:f360342aa2bad7f6123c959b2129abaed99e26891dcd0b0719fec55252bb44b9",
+    "zh:f569b65999264a9416862bca5cd2a6177d94ccb0424f3a4ef424428912b9cb3c",
+  ]
+}
+
+provider "registry.terraform.io/hashicorp/google-beta" {
+  version     = "5.45.2"
+  constraints = "~> 5.0"
+  hashes = [
+    "h1:QuBQI2rdskQLUuep/UrbZ+OYjgp22sURItyQqPSH32s=",
+    "zh:16b77bac5d1555b7f066ba8014f4fc8a6d0de64e252a1988d3fbb400984a4b19",
+    "zh:1b13f515c4809343840aed8265915cc4191f138bdab5a8c5e1f542fdfc69989f",
+    "zh:1dcce4309aeab7c88fd36aea664d57e620d8a413b967ce513a5a866e8de901f2",
+    "zh:24db65d7929f2a731e9cac1750c569cb4528b312ef182a5e2e8c0cf008d8a71b",
+    "zh:28c0b9e68d97570f03b2c4770607701580055bcba50069efd145954aa13b23e4",
+    "zh:3a898a1ad1569f6486a2bc20014087284c8cab919bc8f155833de5128ccd12eb",
+    "zh:4eed99cfb9daada70f813f2cedcf490d3097de1ccb9b391fc451ecc46509c067",
+    "zh:888c4cb1f13b23674ba1091835dd3f1bff5d8e7729ef302183d8d01233819e54",
+    "zh:8baae3b949f6e9505425f5fa4785de786e9cedc4c3f3ad906d8ed560bd2e39c6",
+    "zh:cf2c8928b764592fa2cd14a9f109d01cd0a92049a4fca9d0a74cf2fe588364e2",
+    "zh:edff09394f5bd0b278a4adc800a31b7f150249a1ea92ca273ccf4acd25be3f63",
+    "zh:f569b65999264a9416862bca5cd2a6177d94ccb0424f3a4ef424428912b9cb3c",
+  ]
+}

--- a/inputs/gcp/managed_kafka/google_managed_kafka_connect_cluster/cluster_binding/c.tf
+++ b/inputs/gcp/managed_kafka/google_managed_kafka_connect_cluster/cluster_binding/c.tf
@@ -1,48 +1,67 @@
 
+# Describe your resource type here
+# Keep "c" as the name to indicate that this resource and its attributes are compliant
 
-resource "google_managed_kafka_cluster" "gmk_cluster_c" {
-  provider = google
-  project    = "my-project"
-  cluster_id = "my-kafka-cluster"
+resource "google_project" "project" {
+  project_id      = "tf-test-compliant"
+  name            = "tf-test-compliant"
+  org_id          = "123456789"
+  billing_account = "000000-0000000-0000000-000000"
+  provider        = google-beta
+}
+
+resource "google_managed_kafka_cluster" "gmk_cluster" {
+  project    = google_project.project.project_id
+  cluster_id = "my-cluster"
   location   = "us-central1"
 
   capacity_config {
-    vcpu_count    = 3
-    memory_bytes  = 3221225472
+    vcpu_count   = 3
+    memory_bytes = 3221225472
+
   }
 
   gcp_config {
     access_config {
       network_configs {
-        subnet = "projects/my-project/regions/us-central1/subnetworks/default"
+
+        subnet = "projects/${google_project.project.project_id}/regions/us-central1/subnetworks/default"
       }
     }
   }
+
+  provider = google-beta
 }
 
-
 resource "google_managed_kafka_connect_cluster" "c" {
-  provider = google
-  project             = "my-project"
-  connect_cluster_id  = "my-connect-cluster"
-  kafka_cluster       = "projects/my-project/locations/us-central1/clusters/${google_managed_kafka_cluster.gmk_cluster.cluster_id}"
-  location            = "us-central1"
+  project            = google_project.project.project_id
+  connect_cluster_id = "compliant-connect-cluster"
+  kafka_cluster      = "projects/${google_project.project.project_id}/locations/us-central1/clusters/${google_managed_kafka_cluster.gmk_cluster.cluster_id}"
+  location           = "us-central1"
 
   capacity_config {
     vcpu_count   = 4
-    memory_bytes = 8589934592
+    memory_bytes = 4294967296
+
   }
 
   gcp_config {
     access_config {
       network_configs {
-        primary_subnet = "projects/my-project/regions/us-central1/subnetworks/default"
-        dns_domain_names = ["connect-cluster.internal"] 
+
+        primary_subnet   = "projects/${google_project.project.project_id}/regions/us-central1/subnetworks/default"
+        dns_domain_names = ["internal.managed.kafka"]
+
       }
     }
   }
 
   labels = {
-    env = "prod"
+
+    environment = "production"
   }
+
+  provider = google-beta
 }
+
+   

--- a/inputs/gcp/managed_kafka/google_managed_kafka_connect_cluster/cluster_binding/c.tf
+++ b/inputs/gcp/managed_kafka/google_managed_kafka_connect_cluster/cluster_binding/c.tf
@@ -1,0 +1,48 @@
+
+
+resource "google_managed_kafka_cluster" "gmk_cluster_c" {
+  provider = google
+  project    = "my-project"
+  cluster_id = "my-kafka-cluster"
+  location   = "us-central1"
+
+  capacity_config {
+    vcpu_count    = 3
+    memory_bytes  = 3221225472
+  }
+
+  gcp_config {
+    access_config {
+      network_configs {
+        subnet = "projects/my-project/regions/us-central1/subnetworks/default"
+      }
+    }
+  }
+}
+
+
+resource "google_managed_kafka_connect_cluster" "c" {
+  provider = google
+  project             = "my-project"
+  connect_cluster_id  = "my-connect-cluster"
+  kafka_cluster       = "projects/my-project/locations/us-central1/clusters/${google_managed_kafka_cluster.gmk_cluster.cluster_id}"
+  location            = "us-central1"
+
+  capacity_config {
+    vcpu_count   = 4
+    memory_bytes = 8589934592
+  }
+
+  gcp_config {
+    access_config {
+      network_configs {
+        primary_subnet = "projects/my-project/regions/us-central1/subnetworks/default"
+        dns_domain_names = ["connect-cluster.internal"] 
+      }
+    }
+  }
+
+  labels = {
+    env = "prod"
+  }
+}

--- a/inputs/gcp/managed_kafka/google_managed_kafka_connect_cluster/cluster_binding/config.tf
+++ b/inputs/gcp/managed_kafka/google_managed_kafka_connect_cluster/cluster_binding/config.tf
@@ -1,0 +1,20 @@
+##### DO NOT EDIT ######
+
+terraform {
+  required_providers {
+    google-beta = {
+      source  = "hashicorp/google-beta"
+      
+ 
+    }
+    google = {
+      source  = "hashicorp/google"
+      
+    }
+  }
+}
+
+provider "google-beta" {}
+provider "google" {
+  
+}

--- a/inputs/gcp/managed_kafka/google_managed_kafka_connect_cluster/cluster_binding/nc.tf
+++ b/inputs/gcp/managed_kafka/google_managed_kafka_connect_cluster/cluster_binding/nc.tf
@@ -1,0 +1,52 @@
+# Describe your resource type here
+# Keep "nc" as the name to indicate that this resource and its attributes are non-compliant
+
+
+
+resource "google_managed_kafka_cluster" "gmk_cluster_nc" {
+    provider = google
+  
+  project    = "my-project"
+  cluster_id = "my-kafka-cluster"
+  location   = "us-central1"
+
+  capacity_config {
+    vcpu_count    = 3
+    memory_bytes  = 3221225472
+  }
+
+  gcp_config {
+    access_config {
+      network_configs {
+        subnet = "projects/my-project/regions/us-central1/subnetworks/default"
+      }
+    }
+  }
+}
+
+
+resource "google_managed_kafka_connect_cluster" "nc" {
+    provider = google
+  project             = "my-project"
+  connect_cluster_id  = "my-connect-cluster"
+  kafka_cluster       = "projects/my-project/locations/us-central1/clusters/invalid-cluster" # ❌ Wrong cluster
+  location            = "us-central1"
+
+  capacity_config {
+    vcpu_count   = 4
+    memory_bytes = 8589934592
+  }
+
+  gcp_config {
+    access_config {
+      network_configs {
+        primary_subnet = "projects/my-project/regions/us-central1/subnetworks/default"
+        
+      }
+    }
+  }
+
+  labels = {
+    env = "dev"
+  }
+}

--- a/inputs/gcp/managed_kafka/google_managed_kafka_connect_cluster/disallow_public_exposure/.terraform.lock.hcl
+++ b/inputs/gcp/managed_kafka/google_managed_kafka_connect_cluster/disallow_public_exposure/.terraform.lock.hcl
@@ -21,7 +21,6 @@ provider "registry.terraform.io/hashicorp/google" {
 }
 
 provider "registry.terraform.io/hashicorp/google-beta" {
-
   version = "7.2.0"
   hashes = [
     "h1:rKj2i6jNLm1FEfEiX9VeUpHpZPsDinlPPROZvDWCJ8U=",
@@ -36,6 +35,6 @@ provider "registry.terraform.io/hashicorp/google-beta" {
     "zh:b243fd2983f0e6fa05f0e0f81e1c646bec95b375ac14ce70b36987aefcbbfd07",
     "zh:b9b7f18d6e5005f3f9ccd4c90170f0a4c9e30df1a26bf7a9981a358248a50019",
     "zh:ef98d47cd7b9b3db5d5d5ae4c2e73e07d40f69849f04fac9be88345e07055b02",
-   "zh:f569b65999264a9416862bca5cd2a6177d94ccb0424f3a4ef424428912b9cb3c",
+    "zh:f569b65999264a9416862bca5cd2a6177d94ccb0424f3a4ef424428912b9cb3c",
   ]
 }

--- a/inputs/gcp/managed_kafka/google_managed_kafka_connect_cluster/disallow_public_exposure/c.tf
+++ b/inputs/gcp/managed_kafka/google_managed_kafka_connect_cluster/disallow_public_exposure/c.tf
@@ -1,6 +1,7 @@
 # Describe your resource type here
 # Keep "c" as the name to indicate that this resource and its attributes are compliant
 
+# Compliant Project
 resource "google_project" "project" {
   project_id      = "tf-test-compliant"
   name            = "tf-test-compliant"
@@ -9,20 +10,21 @@ resource "google_project" "project" {
   provider        = google-beta
 }
 
+# Compliant Kafka Cluster
 resource "google_managed_kafka_cluster" "gmk_cluster" {
   project    = google_project.project.project_id
-  cluster_id = "my-cluster"
+  cluster_id = "compliant-kafka-cluster"
   location   = "us-central1"
 
   capacity_config {
-    vcpu_count    = 3
-    memory_bytes  = 3221225472 # 3 GiB
+    vcpu_count   = 3
+    memory_bytes = 3221225472
   }
 
   gcp_config {
     access_config {
       network_configs {
-        subnet = "projects/${google_project.project.project_id}/regions/us-central1/subnetworks/default"
+        subnet = "projects/${google_project.project.project_id}/regions/us-central1/subnetworks/private-subnet"
       }
     }
   }
@@ -30,32 +32,30 @@ resource "google_managed_kafka_cluster" "gmk_cluster" {
   provider = google-beta
 }
 
-
+# ✅ Compliant Kafka Connect Cluster (No public exposure)
 resource "google_managed_kafka_connect_cluster" "c" {
-
   project             = google_project.project.project_id
   connect_cluster_id  = "compliant-connect-cluster"
   kafka_cluster       = "projects/${google_project.project.project_id}/locations/us-central1/clusters/${google_managed_kafka_cluster.gmk_cluster.cluster_id}"
   location            = "us-central1"
 
   capacity_config {
-    vcpu_count    = 4                      
-    memory_bytes  = 4294967296             
+    vcpu_count   = 4
+    memory_bytes = 4294967296
   }
 
   gcp_config {
     access_config {
       network_configs {
-        primary_subnet     = "projects/${google_project.project.project_id}/regions/us-central1/subnetworks/default"
-        dns_domain_names   = ["${google_managed_kafka_cluster.gmk_cluster.cluster_id}.us-central1.managedkafka.${google_project.project.project_id}.cloud.goog"]
+        primary_subnet   = "projects/${google_project.project.project_id}/regions/us-central1/subnetworks/private-subnet"
+        
       }
     }
   }
 
   labels = {
-    environment = "production"
+    security = "compliant"
   }
 
   provider = google-beta
 }
-

--- a/inputs/gcp/managed_kafka/google_managed_kafka_connect_cluster/disallow_public_exposure/config.tf
+++ b/inputs/gcp/managed_kafka/google_managed_kafka_connect_cluster/disallow_public_exposure/config.tf
@@ -2,13 +2,12 @@
 
 terraform {
   required_providers {
-
-    google = {
+    google= {
       source  = "hashicorp/google"
     }
   }
 }
 
-provider "google" {}
-
-
+provider "google" {
+  
+}

--- a/inputs/gcp/managed_kafka/google_managed_kafka_connect_cluster/disallow_public_exposure/nc.tf
+++ b/inputs/gcp/managed_kafka/google_managed_kafka_connect_cluster/disallow_public_exposure/nc.tf
@@ -2,6 +2,7 @@
 # Keep "nc" as the name to indicate that this resource and its attributes are non-compliant
 
 
+# Non-Compliant Project
 resource "google_project" "project_nc" {
   project_id      = "tf-test-noncompliant"
   name            = "tf-test-noncompliant"
@@ -10,21 +11,20 @@ resource "google_project" "project_nc" {
   provider        = google-beta
 }
 
+# Non-Compliant Kafka Cluster
 resource "google_managed_kafka_cluster" "gmk_cluster_nc" {
   project    = google_project.project_nc.project_id
-  cluster_id = "my-cluster"
+  cluster_id = "noncompliant-kafka-cluster"
   location   = "us-central1"
 
   capacity_config {
     vcpu_count   = 3
     memory_bytes = 3221225472
-
   }
 
   gcp_config {
     access_config {
       network_configs {
-
         subnet = "projects/${google_project.project_nc.project_id}/regions/us-central1/subnetworks/default"
       }
     }
@@ -33,34 +33,30 @@ resource "google_managed_kafka_cluster" "gmk_cluster_nc" {
   provider = google-beta
 }
 
+# ❌ Non-Compliant Kafka Connect Cluster (Publicly exposed)
 resource "google_managed_kafka_connect_cluster" "nc" {
-  project            = google_project.project_nc.project_id
-  connect_cluster_id = "noncompliant-connect-cluster"
-  kafka_cluster      = "projects/${google_project.project_nc.project_id}/locations/us-central1/clusters/${google_managed_kafka_cluster.gmk_cluster_nc.cluster_id}"
-  location           = "us-central1"
+  project             = google_project.project_nc.project_id
+  connect_cluster_id  = "noncompliant-connect-cluster"
+  kafka_cluster       = "projects/${google_project.project_nc.project_id}/locations/us-central1/clusters/${google_managed_kafka_cluster.gmk_cluster_nc.cluster_id}"
+  location            = "us-central1"
 
   capacity_config {
-    vcpu_count   = 2                       # ❌ Below min CPU
-    memory_bytes = 2147483648             # ❌ Below min memory
-
+    vcpu_count   = 4
+    memory_bytes = 4294967296
   }
 
   gcp_config {
     access_config {
       network_configs {
-
         primary_subnet   = "projects/${google_project.project_nc.project_id}/regions/us-central1/subnetworks/default"
-        dns_domain_names = ["${google_managed_kafka_cluster.gmk_cluster_nc.cluster_id}.us-central1.managedkafka.${google_project.project_nc.project_id}.cloud.goog"]  # ❌ Public DNS
-
+        
       }
     }
   }
 
   labels = {
-
-    environment = "testing"
+    security = "noncompliant"
   }
 
   provider = google-beta
-
 }

--- a/inputs/gcp/managed_kafka/google_managed_kafka_connect_cluster/enforce_private_networking/.terraform.lock.hcl
+++ b/inputs/gcp/managed_kafka/google_managed_kafka_connect_cluster/enforce_private_networking/.terraform.lock.hcl
@@ -1,0 +1,40 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/google" {
+  version = "7.2.0"
+  hashes = [
+    "h1:n9j0rZHrmXEay4dYo0D+RGS7X8eQr+YZ0MupX8GaMfI=",
+    "zh:0f036e400c90ae45289b948afb49ca938d169fb4a31d7560b345fd0ae5121407",
+    "zh:28a7c683656178456dc7942f051df46052150cee74da7535e7ca8748a83baf30",
+    "zh:2994083c634cff44de626b4bfca3e5e8ed5b2a08baa6f4c4fa4b217d5f49559a",
+    "zh:3c0d98921944c39f2e9d7f42122f44bcf07418ee9ee5faf81e6357cecbac4870",
+    "zh:4f869f574ab7e5970e9ec543fccd4c773e41a111f9bedc7075b725217f3c6fd2",
+    "zh:65479468ab9f6735d267bb593af8d139561790467ba6f8f99c3ba3be25b3a8e9",
+    "zh:827cb00f8dc4bba03afce2ff5d11bcd2d0528fc4624ea05b70354a1fa18b59fb",
+    "zh:a087e5155bd73d59f9dc6df65c1b38944de06cb2a5ead2439b31ad10a18da5a7",
+    "zh:db714b0e7a4365b3d93c17df2abc2bc883c89b15524111433af05aea176680c1",
+    "zh:e5444fde901cfefe7f66c8e9a1d9915d403fc2a6ebe87eaa2a262d2a50ee0a10",
+    "zh:f360342aa2bad7f6123c959b2129abaed99e26891dcd0b0719fec55252bb44b9",
+    "zh:f569b65999264a9416862bca5cd2a6177d94ccb0424f3a4ef424428912b9cb3c",
+  ]
+}
+
+provider "registry.terraform.io/hashicorp/google-beta" {
+  version = "7.2.0"
+  hashes = [
+    "h1:rKj2i6jNLm1FEfEiX9VeUpHpZPsDinlPPROZvDWCJ8U=",
+    "zh:015d927e5f5a75ec7f15090c80e27bc5d03115508286de791bcc7fffc53e990a",
+    "zh:425837eba331c26d967dc7831094a482da12cfaa5807ace5c5540c716ebf19ff",
+    "zh:435cfc975297a64681f3371b4ffe19f90e2914e4b64f9f8f592edc8bdf161d5d",
+    "zh:66b2b2dfca7c82d1473915bb4a4db24e4a4583ddc74060f58a50ba8c3c3847fe",
+    "zh:7bfe3adcb900ec20e254f7ea1cf03d15ec3e85596240dd9ba9ded9cd6b4ecafb",
+    "zh:7f02f12ddc198bc77cf063b6cbb31c98722ababcc29161d67c6bac0835d656aa",
+    "zh:9ad796ccc504b56be934c73b7512583bf5a71c030b2dcb7015a8de56b5e6b220",
+    "zh:ac7795e5bb335c6b597e423400cb0f8748d49247d1c9b60e69ff81a70039c5f9",
+    "zh:b243fd2983f0e6fa05f0e0f81e1c646bec95b375ac14ce70b36987aefcbbfd07",
+    "zh:b9b7f18d6e5005f3f9ccd4c90170f0a4c9e30df1a26bf7a9981a358248a50019",
+    "zh:ef98d47cd7b9b3db5d5d5ae4c2e73e07d40f69849f04fac9be88345e07055b02",
+    "zh:f569b65999264a9416862bca5cd2a6177d94ccb0424f3a4ef424428912b9cb3c",
+  ]
+}

--- a/inputs/gcp/managed_kafka/google_managed_kafka_connect_cluster/enforce_private_networking/c.tf
+++ b/inputs/gcp/managed_kafka/google_managed_kafka_connect_cluster/enforce_private_networking/c.tf
@@ -1,0 +1,59 @@
+# Describe your resource type here
+# Keep "c" as the name to indicate that this resource and its attributes are compliant
+
+resource "google_project" "project" {
+  project_id      = "tf-test-compliant"
+  name            = "tf-test-compliant"
+  org_id          = "123456789"
+  billing_account = "000000-0000000-0000000-000000"
+  provider        = google-beta
+}
+
+resource "google_managed_kafka_cluster" "gmk_cluster" {
+  project    = google_project.project.project_id
+  cluster_id = "my-cluster"
+  location   = "us-central1"
+
+  capacity_config {
+    vcpu_count    = 3
+    memory_bytes  = 3221225472 # 3 GiB
+  }
+
+  gcp_config {
+    access_config {
+      network_configs {
+        subnet = "projects/${google_project.project.project_id}/regions/us-central1/subnetworks/default"
+      }
+    }
+  }
+
+  provider = google-beta
+}
+
+resource "google_managed_kafka_connect_cluster" "example" {
+  project             = google_project.project.project_id
+  connect_cluster_id  = "compliant-connect-cluster"
+  kafka_cluster       = "projects/${google_project.project.project_id}/locations/us-central1/clusters/${google_managed_kafka_cluster.gmk_cluster.cluster_id}"
+  location            = "us-central1"
+
+  capacity_config {
+    vcpu_count    = 4                      
+    memory_bytes  = 4294967296             
+  }
+
+  gcp_config {
+    access_config {
+      network_configs {
+        primary_subnet     = "projects/${google_project.project.project_id}/regions/us-central1/subnetworks/default"
+        dns_domain_names   = ["${google_managed_kafka_cluster.gmk_cluster.cluster_id}.us-central1.managedkafka.${google_project.project.project_id}.cloud.goog"]
+      }
+    }
+  }
+
+  labels = {
+    environment = "production"
+  }
+
+  provider = google-beta
+}
+

--- a/inputs/gcp/managed_kafka/google_managed_kafka_connect_cluster/enforce_private_networking/config.tf
+++ b/inputs/gcp/managed_kafka/google_managed_kafka_connect_cluster/enforce_private_networking/config.tf
@@ -1,0 +1,11 @@
+##### DO NOT EDIT ######
+
+terraform {
+  required_providers {
+    google = {
+      source  = "hashicorp/google"
+    }
+  }
+}
+
+provider "google" {}

--- a/inputs/gcp/managed_kafka/google_managed_kafka_connect_cluster/enforce_private_networking/nc.tf
+++ b/inputs/gcp/managed_kafka/google_managed_kafka_connect_cluster/enforce_private_networking/nc.tf
@@ -27,7 +27,9 @@ resource "google_managed_kafka_cluster" "gmk_cluster_nc" {
   provider = google-beta
 }
 
-resource "google_managed_kafka_connect_cluster" "example_nc" {
+
+resource "google_managed_kafka_connect_cluster" "nc" {
+
   project             = google_project.project_nc.project_id
   connect_cluster_id  = "noncompliant-connect-cluster"
   kafka_cluster       = "projects/${google_project.project_nc.project_id}/locations/us-central1/clusters/${google_managed_kafka_cluster.gmk_cluster_nc.cluster_id}"

--- a/inputs/gcp/managed_kafka/google_managed_kafka_connect_cluster/enforce_private_networking/nc.tf
+++ b/inputs/gcp/managed_kafka/google_managed_kafka_connect_cluster/enforce_private_networking/nc.tf
@@ -1,0 +1,55 @@
+resource "google_project" "project_nc" {
+  project_id      = "tf-test-noncompliant"
+  name            = "tf-test-noncompliant"
+  org_id          = "123456789"
+  billing_account = "000000-0000000-0000000-000000"
+  provider        = google-beta
+}
+
+resource "google_managed_kafka_cluster" "gmk_cluster_nc" {
+  project    = google_project.project_nc.project_id
+  cluster_id = "my-cluster-nc"
+  location   = "us-central1"
+
+  capacity_config {
+    vcpu_count    = 3
+    memory_bytes  = 3221225472
+  }
+
+  gcp_config {
+    access_config {
+      network_configs {
+        subnet = "projects/${google_project.project_nc.project_id}/regions/us-central1/subnetworks/default"
+      }
+    }
+  }
+
+  provider = google-beta
+}
+
+resource "google_managed_kafka_connect_cluster" "example_nc" {
+  project             = google_project.project_nc.project_id
+  connect_cluster_id  = "noncompliant-connect-cluster"
+  kafka_cluster       = "projects/${google_project.project_nc.project_id}/locations/us-central1/clusters/${google_managed_kafka_cluster.gmk_cluster_nc.cluster_id}"
+  location            = "us-central1"
+
+  capacity_config {
+    vcpu_count    = 2                      # ❌ Violates policy (minimum 3)
+    memory_bytes  = 2147483648             # ❌ 2 GiB, below minimum
+  }
+
+  gcp_config {
+    access_config {
+      network_configs {
+        primary_subnet     = "projects/${google_project.project_nc.project_id}/regions/us-central1/subnetworks/default"
+        dns_domain_names   = ["${google_managed_kafka_cluster.gmk_cluster_nc.cluster_id}.us-central1.managedkafka.${google_project.project_nc.project_id}.cloud.goog"]
+      }
+    }
+  }
+
+  labels = {
+    environment = "testing"
+  }
+
+  provider = google-beta
+}

--- a/inputs/gcp/managed_kafka/google_managed_kafka_connector/enforce_connector/.terraform.lock.hcl
+++ b/inputs/gcp/managed_kafka/google_managed_kafka_connector/enforce_connector/.terraform.lock.hcl
@@ -1,0 +1,40 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/google" {
+  version = "7.2.0"
+  hashes = [
+    "h1:n9j0rZHrmXEay4dYo0D+RGS7X8eQr+YZ0MupX8GaMfI=",
+    "zh:0f036e400c90ae45289b948afb49ca938d169fb4a31d7560b345fd0ae5121407",
+    "zh:28a7c683656178456dc7942f051df46052150cee74da7535e7ca8748a83baf30",
+    "zh:2994083c634cff44de626b4bfca3e5e8ed5b2a08baa6f4c4fa4b217d5f49559a",
+    "zh:3c0d98921944c39f2e9d7f42122f44bcf07418ee9ee5faf81e6357cecbac4870",
+    "zh:4f869f574ab7e5970e9ec543fccd4c773e41a111f9bedc7075b725217f3c6fd2",
+    "zh:65479468ab9f6735d267bb593af8d139561790467ba6f8f99c3ba3be25b3a8e9",
+    "zh:827cb00f8dc4bba03afce2ff5d11bcd2d0528fc4624ea05b70354a1fa18b59fb",
+    "zh:a087e5155bd73d59f9dc6df65c1b38944de06cb2a5ead2439b31ad10a18da5a7",
+    "zh:db714b0e7a4365b3d93c17df2abc2bc883c89b15524111433af05aea176680c1",
+    "zh:e5444fde901cfefe7f66c8e9a1d9915d403fc2a6ebe87eaa2a262d2a50ee0a10",
+    "zh:f360342aa2bad7f6123c959b2129abaed99e26891dcd0b0719fec55252bb44b9",
+    "zh:f569b65999264a9416862bca5cd2a6177d94ccb0424f3a4ef424428912b9cb3c",
+  ]
+}
+
+provider "registry.terraform.io/hashicorp/google-beta" {
+  version = "7.2.0"
+  hashes = [
+    "h1:rKj2i6jNLm1FEfEiX9VeUpHpZPsDinlPPROZvDWCJ8U=",
+    "zh:015d927e5f5a75ec7f15090c80e27bc5d03115508286de791bcc7fffc53e990a",
+    "zh:425837eba331c26d967dc7831094a482da12cfaa5807ace5c5540c716ebf19ff",
+    "zh:435cfc975297a64681f3371b4ffe19f90e2914e4b64f9f8f592edc8bdf161d5d",
+    "zh:66b2b2dfca7c82d1473915bb4a4db24e4a4583ddc74060f58a50ba8c3c3847fe",
+    "zh:7bfe3adcb900ec20e254f7ea1cf03d15ec3e85596240dd9ba9ded9cd6b4ecafb",
+    "zh:7f02f12ddc198bc77cf063b6cbb31c98722ababcc29161d67c6bac0835d656aa",
+    "zh:9ad796ccc504b56be934c73b7512583bf5a71c030b2dcb7015a8de56b5e6b220",
+    "zh:ac7795e5bb335c6b597e423400cb0f8748d49247d1c9b60e69ff81a70039c5f9",
+    "zh:b243fd2983f0e6fa05f0e0f81e1c646bec95b375ac14ce70b36987aefcbbfd07",
+    "zh:b9b7f18d6e5005f3f9ccd4c90170f0a4c9e30df1a26bf7a9981a358248a50019",
+    "zh:ef98d47cd7b9b3db5d5d5ae4c2e73e07d40f69849f04fac9be88345e07055b02",
+    "zh:f569b65999264a9416862bca5cd2a6177d94ccb0424f3a4ef424428912b9cb3c",
+  ]
+}

--- a/inputs/gcp/managed_kafka/google_managed_kafka_connector/enforce_connector/c.tf
+++ b/inputs/gcp/managed_kafka/google_managed_kafka_connector/enforce_connector/c.tf
@@ -1,0 +1,77 @@
+
+resource "google_project" "project_c" {
+  project_id      = "tf-test-compliant"
+  name            = "tf-test-compliant"
+  org_id          = "123456789"
+  billing_account = "000000-0000000-0000000-000000"
+  provider        = google-beta
+}
+
+resource "google_managed_kafka_cluster" "gmk_cluster_c" {
+  project    = google_project.project_c.project_id
+  cluster_id = "cluster-c"
+  location   = "us-central1"
+
+  capacity_config {
+    vcpu_count   = 3
+    memory_bytes = 3221225472
+  }
+
+  gcp_config {
+    access_config {
+      network_configs {
+        subnet = "projects/${google_project.project_c.project_id}/regions/us-central1/subnetworks/default"
+      }
+    }
+  }
+
+  provider = google-beta
+}
+
+resource "google_managed_kafka_connect_cluster" "connect_cluster_c" {
+  project             = google_project.project_c.project_id
+  connect_cluster_id  = "connect-cluster-c"
+  kafka_cluster       = "projects/${google_project.project_c.project_id}/locations/us-central1/clusters/${google_managed_kafka_cluster.gmk_cluster_c.cluster_id}"
+  location            = "us-central1"
+
+  capacity_config {
+    vcpu_count   = 4
+    memory_bytes = 4294967296
+  }
+
+  gcp_config {
+    access_config {
+      network_configs {
+        primary_subnet   = "projects/${google_project.project_c.project_id}/regions/us-central1/subnetworks/default"
+        dns_domain_names = ["internal.kafka.c"]
+      }
+    }
+  }
+
+  provider = google-beta
+}
+
+resource "google_managed_kafka_connector" "connector_c" {
+  project         = google_project.project_c.project_id
+  connector_id    = "compliant-connector"
+  connect_cluster = google_managed_kafka_connect_cluster.connect_cluster_c.connect_cluster_id
+  location        = "us-central1"
+
+  configs = {
+    "connector.class"  = "com.google.pubsub.kafka.sink.CloudPubSubSinkConnector"
+    "name"             = "compliant-connector"
+    "tasks.max"        = "1"
+    "topics"           = "compliant-topic"
+    "cps.topic"        = "compliant-pubsub"
+    "cps.project"      = google_project.project_c.project_id
+    "value.converter"  = "org.apache.kafka.connect.storage.StringConverter"
+    "key.converter"    = "org.apache.kafka.connect.storage.StringConverter"
+  }
+
+  task_restart_policy {
+    minimum_backoff = "60s"
+    maximum_backoff = "600s"
+  }
+
+  provider = google-beta
+}

--- a/inputs/gcp/managed_kafka/google_managed_kafka_connector/enforce_connector/config.tf
+++ b/inputs/gcp/managed_kafka/google_managed_kafka_connector/enforce_connector/config.tf
@@ -1,0 +1,11 @@
+##### DO NOT EDIT ######
+
+terraform {
+  required_providers {
+    google = {
+      source  = "hashicorp/google"
+    }
+  }
+}
+
+provider "google" {}

--- a/inputs/gcp/managed_kafka/google_managed_kafka_connector/enforce_connector/nc.tf
+++ b/inputs/gcp/managed_kafka/google_managed_kafka_connector/enforce_connector/nc.tf
@@ -1,0 +1,78 @@
+
+
+resource "google_project" "project_nc" {
+  project_id      = "tf-test-noncompliant"
+  name            = "tf-test-noncompliant"
+  org_id          = "123456789"
+  billing_account = "000000-0000000-0000000-000000"
+  provider        = google-beta
+}
+
+resource "google_managed_kafka_cluster" "gmk_cluster_nc" {
+  project    = google_project.project_nc.project_id
+  cluster_id = "cluster-nc"
+  location   = "us-central1"
+
+  capacity_config {
+    vcpu_count   = 2  # ❌ Too low
+    memory_bytes = 2147483648
+  }
+
+  gcp_config {
+    access_config {
+      network_configs {
+        subnet = "projects/${google_project.project_nc.project_id}/regions/us-central1/subnetworks/default"
+      }
+    }
+  }
+
+  provider = google-beta
+}
+
+resource "google_managed_kafka_connect_cluster" "connect_cluster_nc" {
+  project             = google_project.project_nc.project_id
+  connect_cluster_id  = "connect-cluster-nc"
+  kafka_cluster       = "projects/${google_project.project_nc.project_id}/locations/us-central1/clusters/${google_managed_kafka_cluster.gmk_cluster_nc.cluster_id}"
+  location            = "us-central1"
+
+  capacity_config {
+    vcpu_count   = 2  # ❌ Too low
+    memory_bytes = 2147483648
+  }
+
+  gcp_config {
+    access_config {
+      network_configs {
+        primary_subnet   = "projects/${google_project.project_nc.project_id}/regions/us-central1/subnetworks/default"
+        dns_domain_names = ["public.kafka.nc"]  # ❌ Public DNS
+      }
+    }
+  }
+
+  provider = google-beta
+}
+
+resource "google_managed_kafka_connector" "connector_nc" {
+  project         = google_project.project_nc.project_id
+  connector_id    = "noncompliant-connector"
+  connect_cluster = google_managed_kafka_connect_cluster.connect_cluster_nc.connect_cluster_id
+  location        = "us-central1"
+
+  configs = {
+    "connector.class"  = "com.google.pubsub.kafka.sink.CloudPubSubSinkConnector"
+    "name"             = "noncompliant-connector"
+    "tasks.max"        = "1"
+    "topics"           = "noncompliant-topic"
+    "cps.topic"        = "noncompliant-pubsub"
+    "cps.project"      = google_project.project_nc.project_id
+    "value.converter"  = "org.apache.kafka.connect.storage.StringConverter"
+    "key.converter"    = "org.apache.kafka.connect.storage.StringConverter"
+  }
+
+  task_restart_policy {
+    minimum_backoff = "5s"    # ❌ Too short
+    maximum_backoff = "10s"   # ❌ Too short
+  }
+
+  provider = google-beta
+}

--- a/inputs/gcp/managed_kafka/google_managed_kafka_connector/task_restart/.terraform.lock.hcl
+++ b/inputs/gcp/managed_kafka/google_managed_kafka_connector/task_restart/.terraform.lock.hcl
@@ -1,0 +1,40 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/google" {
+  version = "7.2.0"
+  hashes = [
+    "h1:n9j0rZHrmXEay4dYo0D+RGS7X8eQr+YZ0MupX8GaMfI=",
+    "zh:0f036e400c90ae45289b948afb49ca938d169fb4a31d7560b345fd0ae5121407",
+    "zh:28a7c683656178456dc7942f051df46052150cee74da7535e7ca8748a83baf30",
+    "zh:2994083c634cff44de626b4bfca3e5e8ed5b2a08baa6f4c4fa4b217d5f49559a",
+    "zh:3c0d98921944c39f2e9d7f42122f44bcf07418ee9ee5faf81e6357cecbac4870",
+    "zh:4f869f574ab7e5970e9ec543fccd4c773e41a111f9bedc7075b725217f3c6fd2",
+    "zh:65479468ab9f6735d267bb593af8d139561790467ba6f8f99c3ba3be25b3a8e9",
+    "zh:827cb00f8dc4bba03afce2ff5d11bcd2d0528fc4624ea05b70354a1fa18b59fb",
+    "zh:a087e5155bd73d59f9dc6df65c1b38944de06cb2a5ead2439b31ad10a18da5a7",
+    "zh:db714b0e7a4365b3d93c17df2abc2bc883c89b15524111433af05aea176680c1",
+    "zh:e5444fde901cfefe7f66c8e9a1d9915d403fc2a6ebe87eaa2a262d2a50ee0a10",
+    "zh:f360342aa2bad7f6123c959b2129abaed99e26891dcd0b0719fec55252bb44b9",
+    "zh:f569b65999264a9416862bca5cd2a6177d94ccb0424f3a4ef424428912b9cb3c",
+  ]
+}
+
+provider "registry.terraform.io/hashicorp/google-beta" {
+  version = "7.2.0"
+  hashes = [
+    "h1:rKj2i6jNLm1FEfEiX9VeUpHpZPsDinlPPROZvDWCJ8U=",
+    "zh:015d927e5f5a75ec7f15090c80e27bc5d03115508286de791bcc7fffc53e990a",
+    "zh:425837eba331c26d967dc7831094a482da12cfaa5807ace5c5540c716ebf19ff",
+    "zh:435cfc975297a64681f3371b4ffe19f90e2914e4b64f9f8f592edc8bdf161d5d",
+    "zh:66b2b2dfca7c82d1473915bb4a4db24e4a4583ddc74060f58a50ba8c3c3847fe",
+    "zh:7bfe3adcb900ec20e254f7ea1cf03d15ec3e85596240dd9ba9ded9cd6b4ecafb",
+    "zh:7f02f12ddc198bc77cf063b6cbb31c98722ababcc29161d67c6bac0835d656aa",
+    "zh:9ad796ccc504b56be934c73b7512583bf5a71c030b2dcb7015a8de56b5e6b220",
+    "zh:ac7795e5bb335c6b597e423400cb0f8748d49247d1c9b60e69ff81a70039c5f9",
+    "zh:b243fd2983f0e6fa05f0e0f81e1c646bec95b375ac14ce70b36987aefcbbfd07",
+    "zh:b9b7f18d6e5005f3f9ccd4c90170f0a4c9e30df1a26bf7a9981a358248a50019",
+    "zh:ef98d47cd7b9b3db5d5d5ae4c2e73e07d40f69849f04fac9be88345e07055b02",
+    "zh:f569b65999264a9416862bca5cd2a6177d94ccb0424f3a4ef424428912b9cb3c",
+  ]
+}

--- a/inputs/gcp/managed_kafka/google_managed_kafka_connector/task_restart/c.tf
+++ b/inputs/gcp/managed_kafka/google_managed_kafka_connector/task_restart/c.tf
@@ -1,0 +1,85 @@
+# Describe your resource type here
+# Keep "c" as the name to indicate that this resource and its attributes are compliant
+
+# Compliant configuration for Managed Kafka Connector
+
+resource "google_project" "project_c" {
+  project_id      = "tf-test-compliant"
+  name            = "tf-test-compliant"
+  org_id          = "123456789"
+  billing_account = "000000-0000000-0000000-000000"
+  provider        = google-beta
+}
+
+resource "google_managed_kafka_cluster" "gmk_cluster_c" {
+  project    = google_project.project_c.project_id
+  cluster_id = "my-cluster"
+  location   = "us-central1"
+
+  capacity_config {
+    vcpu_count   = 3
+    memory_bytes = 3221225472
+  }
+
+  gcp_config {
+    access_config {
+      network_configs {
+        subnet = "projects/${google_project.project_c.project_id}/regions/us-central1/subnetworks/default"
+      }
+    }
+  }
+
+  provider = google-beta
+}
+
+resource "google_managed_kafka_connect_cluster" "c" {
+  project             = google_project.project_c.project_id
+  connect_cluster_id  = "compliant-connect-cluster"
+  kafka_cluster       = "projects/${google_project.project_c.project_id}/locations/us-central1/clusters/${google_managed_kafka_cluster.gmk_cluster_c.cluster_id}"
+  location            = "us-central1"
+
+  capacity_config {
+    vcpu_count   = 4
+    memory_bytes = 4294967296
+  }
+
+  gcp_config {
+    access_config {
+      network_configs {
+        primary_subnet   = "projects/${google_project.project_c.project_id}/regions/us-central1/subnetworks/default"
+        dns_domain_names = ["internal.managed.kafka"]
+      }
+    }
+  }
+
+  labels = {
+    environment = "production"
+  }
+
+  provider = google-beta
+}
+
+resource "google_managed_kafka_connector" "c" {
+  project         = google_project.project_c.project_id
+  location        = "us-central1"
+  connector_id    = "compliant-connector"
+  connect_cluster = google_managed_kafka_connect_cluster.c.connect_cluster_id
+
+  configs = {
+    "connector.class" = "com.google.pubsub.kafka.sink.CloudPubSubSinkConnector"
+    "name"            = "compliant-connector"
+    "tasks.max"       = "1"
+    "topics"          = "my-topic"
+    "cps.topic"       = "my-cps-topic"
+    "cps.project"     = google_project.project_c.project_id
+    "value.converter" = "org.apache.kafka.connect.storage.StringConverter"
+    "key.converter"   = "org.apache.kafka.connect.storage.StringConverter"
+  }
+
+  task_restart_policy {
+    minimum_backoff = "60s"    # ✅ Valid
+    maximum_backoff = "1800s"  # ✅ Valid
+  }
+
+  provider = google-beta
+}

--- a/inputs/gcp/managed_kafka/google_managed_kafka_connector/task_restart/config.tf
+++ b/inputs/gcp/managed_kafka/google_managed_kafka_connector/task_restart/config.tf
@@ -1,0 +1,11 @@
+##### DO NOT EDIT ######
+
+terraform {
+  required_providers {
+    google = {
+      source  = "hashicorp/google"
+    }
+  }
+}
+
+provider "google" {}

--- a/inputs/gcp/managed_kafka/google_managed_kafka_connector/task_restart/nc.tf
+++ b/inputs/gcp/managed_kafka/google_managed_kafka_connector/task_restart/nc.tf
@@ -1,0 +1,85 @@
+# Describe your resource type here
+# Keep "nc" as the name to indicate that this resource and its attributes are non-compliant
+
+# Non-compliant configuration for Managed Kafka Connector (Fails Policy 3)
+
+resource "google_project" "project_nc" {
+  project_id      = "tf-test-noncompliant"
+  name            = "tf-test-noncompliant"
+  org_id          = "123456789"
+  billing_account = "000000-0000000-0000000-000000"
+  provider        = google-beta
+}
+
+resource "google_managed_kafka_cluster" "gmk_cluster_nc" {
+  project    = google_project.project_nc.project_id
+  cluster_id = "my-cluster"
+  location   = "us-central1"
+
+  capacity_config {
+    vcpu_count   = 3
+    memory_bytes = 3221225472
+  }
+
+  gcp_config {
+    access_config {
+      network_configs {
+        subnet = "projects/${google_project.project_nc.project_id}/regions/us-central1/subnetworks/default"
+      }
+    }
+  }
+
+  provider = google-beta
+}
+
+resource "google_managed_kafka_connect_cluster" "nc" {
+  project             = google_project.project_nc.project_id
+  connect_cluster_id  = "noncompliant-connect-cluster"
+  kafka_cluster       = "projects/${google_project.project_nc.project_id}/locations/us-central1/clusters/${google_managed_kafka_cluster.gmk_cluster_nc.cluster_id}"
+  location            = "us-central1"
+
+  capacity_config {
+    vcpu_count   = 4
+    memory_bytes = 4294967296
+  }
+
+  gcp_config {
+    access_config {
+      network_configs {
+        primary_subnet   = "projects/${google_project.project_nc.project_id}/regions/us-central1/subnetworks/default"
+        dns_domain_names = ["internal.managed.kafka"]
+      }
+    }
+  }
+
+  labels = {
+    environment = "testing"
+  }
+
+  provider = google-beta
+}
+
+resource "google_managed_kafka_connector" "nc" {
+  project         = google_project.project_nc.project_id
+  location        = "us-central1"
+  connector_id    = "noncompliant-connector"
+  connect_cluster = google_managed_kafka_connect_cluster.nc.connect_cluster_id
+
+  configs = {
+    "connector.class" = "com.google.pubsub.kafka.sink.CloudPubSubSinkConnector"
+    "name"            = "noncompliant-connector"
+    "tasks.max"       = "1"
+    "topics"          = "my-topic"
+    "cps.topic"       = "my-cps-topic"
+    "cps.project"     = google_project.project_nc.project_id
+    "value.converter" = "org.apache.kafka.connect.storage.StringConverter"
+    "key.converter"   = "org.apache.kafka.connect.storage.StringConverter"
+  }
+
+  task_restart_policy {
+    minimum_backoff = "10s"    # ❌ Too short
+    maximum_backoff = "7200s"  # ❌ Too long
+  }
+
+  provider = google-beta
+}

--- a/inputs/gcp/managed_kafka/google_managed_kafka_topic/secure_topic_config/.terraform.lock.hcl
+++ b/inputs/gcp/managed_kafka/google_managed_kafka_topic/secure_topic_config/.terraform.lock.hcl
@@ -1,0 +1,21 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/google" {
+  version = "7.2.0"
+  hashes = [
+    "h1:n9j0rZHrmXEay4dYo0D+RGS7X8eQr+YZ0MupX8GaMfI=",
+    "zh:0f036e400c90ae45289b948afb49ca938d169fb4a31d7560b345fd0ae5121407",
+    "zh:28a7c683656178456dc7942f051df46052150cee74da7535e7ca8748a83baf30",
+    "zh:2994083c634cff44de626b4bfca3e5e8ed5b2a08baa6f4c4fa4b217d5f49559a",
+    "zh:3c0d98921944c39f2e9d7f42122f44bcf07418ee9ee5faf81e6357cecbac4870",
+    "zh:4f869f574ab7e5970e9ec543fccd4c773e41a111f9bedc7075b725217f3c6fd2",
+    "zh:65479468ab9f6735d267bb593af8d139561790467ba6f8f99c3ba3be25b3a8e9",
+    "zh:827cb00f8dc4bba03afce2ff5d11bcd2d0528fc4624ea05b70354a1fa18b59fb",
+    "zh:a087e5155bd73d59f9dc6df65c1b38944de06cb2a5ead2439b31ad10a18da5a7",
+    "zh:db714b0e7a4365b3d93c17df2abc2bc883c89b15524111433af05aea176680c1",
+    "zh:e5444fde901cfefe7f66c8e9a1d9915d403fc2a6ebe87eaa2a262d2a50ee0a10",
+    "zh:f360342aa2bad7f6123c959b2129abaed99e26891dcd0b0719fec55252bb44b9",
+    "zh:f569b65999264a9416862bca5cd2a6177d94ccb0424f3a4ef424428912b9cb3c",
+  ]
+}

--- a/inputs/gcp/managed_kafka/google_managed_kafka_topic/secure_topic_config/c.tf
+++ b/inputs/gcp/managed_kafka/google_managed_kafka_topic/secure_topic_config/c.tf
@@ -1,0 +1,18 @@
+# Describe your resource type here
+# Keep "c" as the name to indicate that this resource and its attributes are compliant
+
+resource "google_managed_kafka_topic" "c" {
+  topic_id           = "secure-topic"
+  cluster            = "my-secure-cluster"
+  location           = "us-central1"
+  partition_count    = 3
+  replication_factor = 3
+  project = "123"
+
+  configs = {
+    "cleanup.policy"  = "delete"
+    "retention.ms"    = "604800000" # 7 days
+    "min.insync.replicas" = "2"
+  }
+}
+

--- a/inputs/gcp/managed_kafka/google_managed_kafka_topic/secure_topic_config/config.tf
+++ b/inputs/gcp/managed_kafka/google_managed_kafka_topic/secure_topic_config/config.tf
@@ -1,0 +1,11 @@
+##### DO NOT EDIT ######
+
+terraform {
+  required_providers {
+    google = {
+      source  = "hashicorp/google"
+    }
+  }
+}
+
+provider "google" {}

--- a/inputs/gcp/managed_kafka/google_managed_kafka_topic/secure_topic_config/nc.tf
+++ b/inputs/gcp/managed_kafka/google_managed_kafka_topic/secure_topic_config/nc.tf
@@ -1,0 +1,17 @@
+# Describe your resource type here
+# Keep "nc" as the name to indicate that this resource and its attributes are non-compliant
+
+resource "google_managed_kafka_topic" "nc" {
+  topic_id           = "insecure-topic"
+  cluster            = "my-insecure-cluster"
+  location           = "us-central1"
+  partition_count    = 1
+  replication_factor = 1
+  project = "123"
+
+  configs = {
+    "cleanup.policy"  = "compact"
+    "retention.ms"    = "0" 
+    "min.insync.replicas" = "1"
+  }
+}

--- a/policies/gcp/managed_kafka/google_managed_kafka_acl/global_acls/policy.rego
+++ b/policies/gcp/managed_kafka/google_managed_kafka_acl/global_acls/policy.rego
@@ -1,0 +1,23 @@
+package terraform.gcp.security.managed_kafka.google_managed_kafka_acl.global_acls
+import data.terraform.gcp.helpers
+import data.terraform.gcp.security.managed_kafka.google_managed_kafka_acl.vars
+
+conditions := [
+     [
+        {"situation_description": "Global ACLs like allTopics or allConsumerGroups may lead to uncontrolled access.",
+         "remedies": ["Grant topic-level or consumerGroup-level ACLs instead of global permissions."]},
+        {
+            "condition": "Do not allow global ACLs when granting ALL permissions",
+            "attribute_path": ["acl_id"],
+            "values": ["allTopics", "allConsumerGroups"],
+            "policy_type": "blacklist"
+        }
+    ]
+
+]
+    
+
+summary := {
+    "message": helpers.get_multi_summary(conditions, vars.variables).message,
+    "details": helpers.get_multi_summary(conditions, vars.variables).details
+}

--- a/policies/gcp/managed_kafka/google_managed_kafka_acl/secured_acl_entries/policy.rego
+++ b/policies/gcp/managed_kafka/google_managed_kafka_acl/secured_acl_entries/policy.rego
@@ -1,0 +1,22 @@
+package terraform.gcp.security.managed_kafka.google_managed_kafka_acl.secured_acl_entries
+import data.terraform.gcp.helpers
+import data.terraform.gcp.security.managed_kafka.google_managed_kafka_acl.vars
+
+conditions := [
+    [
+    {"situation_description" : "The Kafka ACL permission type must be set to ALLOW to ensure only authorized principals can perform operations on Kafka topics and resources.",
+    "remedies":[ "Update the ACL entry to set 'permission_type' to 'ALLOW'.",
+                "Ensure that no ACL entries are configured with 'DENY' unless explicitly required for security purposes.",
+                "Review Kafka ACL configurations to verify that authorized service accounts have proper access permissions."]},
+    {
+        "condition": "Validate that the ACL entry permission_type is set to ALLOW",
+        "attribute_path" : ["acl_entries",0,"permission_type"], 
+        "values" : ["ALLOW"], 
+        "policy_type" : "whitelist"
+    }
+    ]
+]
+summary := {
+    "message": helpers.get_multi_summary(conditions, vars.variables).message,
+    "details": helpers.get_multi_summary(conditions, vars.variables).details
+}

--- a/policies/gcp/managed_kafka/google_managed_kafka_acl/vars.rego
+++ b/policies/gcp/managed_kafka/google_managed_kafka_acl/vars.rego
@@ -1,0 +1,8 @@
+package terraform.gcp.security.managed_kafka.google_managed_kafka_acl.vars
+ 
+variables := {
+    "friendly_resource_name": "Kafka acl",
+    "resource_type":  "google_managed_kafka_acl",
+    "resource_value_name" : "acl_id"
+    
+}

--- a/policies/gcp/managed_kafka/google_managed_kafka_acl/wildcard_principals/policy.rego
+++ b/policies/gcp/managed_kafka/google_managed_kafka_acl/wildcard_principals/policy.rego
@@ -1,0 +1,23 @@
+package terraform.gcp.security.managed_kafka.google_managed_kafka_acl.wildcard_principals 
+import data.terraform.gcp.helpers
+import data.terraform.gcp.security.managed_kafka.google_managed_kafka_acl.vars
+
+
+conditions := [
+    [
+    {"situation_description" :  "Wildcard principals (User:*) allow unrestricted access to Kafka resources and pose a security risk.",
+    "remedies":[ "Use explicit principals instead of 'User:*'.",
+                "Assign permissions only to specific Google service accounts."]},
+    {
+        "condition":  "Ensure that the principal is NOT set to a wildcard value ('User:*').",
+        "attribute_path" :  ["acl_entries", 0, "principal"], 
+        "values" : ["User:*"],
+        "policy_type" : "blacklist" # Policy type eg. 'whitelist', 'blacklist', 'range', 'pattern whitelist', 'pattern blacklist'
+    }
+    ]
+]
+summary := {
+    "message": helpers.get_multi_summary(conditions, vars.variables).message,
+    "details": helpers.get_multi_summary(conditions, vars.variables).details
+}
+

--- a/policies/gcp/managed_kafka/google_managed_kafka_cluster/kafka_cluster/policy.rego
+++ b/policies/gcp/managed_kafka/google_managed_kafka_cluster/kafka_cluster/policy.rego
@@ -1,0 +1,37 @@
+package terraform.gcp.security.managed_kafka.google_managed_kafka_cluster.kafka_cluster 
+import data.terraform.gcp.helpers
+import data.terraform.gcp.security.managed_kafka.google_managed_kafka_cluster.vars
+
+
+conditions := [
+    [
+        {
+            "situation_description": "Kafka clusters should not use public IPs; private networking must be enabled for better security.",
+            "remedies": ["Set subnet inside network_configs to a private subnet."]
+        },
+        {
+            "condition": "network_configs.subnet must be defined",
+            "attribute_path": ["gcp_config", "access_config", "network_configs", 0, "subnet"],
+            "values": [""],
+            "policy_type": "whitelist"
+        }
+    ],
+    [
+        {
+            "situation_description": "Kafka clusters should have sufficient resources to handle workloads securely.",
+            "remedies": ["Ensure vCPU >= 2 and memory >= 2GB for better stability and security."]
+        },
+        {
+            "condition": "vcpu_count >= 2 and memory_bytes >= 2147483648",
+            "attribute_path": ["capacity_config"],
+            "values": [""],
+            "policy_type": "whitelist"
+        }
+    ]
+]
+summary := {
+  "message": helpers.get_multi_summary(conditions, vars.variables).message,
+  "details": helpers.get_multi_summary(conditions, vars.variables).details
+}
+
+  

--- a/policies/gcp/managed_kafka/google_managed_kafka_cluster/kafka_cmek_enforcement/policy.rego
+++ b/policies/gcp/managed_kafka/google_managed_kafka_cluster/kafka_cmek_enforcement/policy.rego
@@ -1,0 +1,34 @@
+package terraform.gcp.security.managed_kafka.google_managed_kafka_cluster.kafka_cmek_enforcement
+import data.terraform.gcp.helpers
+import data.terraform.gcp.security.managed_kafka.google_managed_kafka_cluster.vars
+conditions := [
+    
+       # SCENARIO 1 — Enforce CMEK usage
+    [
+        {"situation_description": "Kafka data must be encrypted using Customer-Managed Encryption Keys (CMEK).",
+         "remedies": ["Specify gcp_config.kms_key to enable CMEK for data encryption."]},
+        {
+            "condition": "CMEK must be enabled",
+            "attribute_path": ["gcp_config", "kms_key"],
+            "values": [""],
+            "policy_type": "blacklist"
+        }
+    ],
+    
+    # SCENARIO 2 — KMS key region must match cluster location
+    [
+        {"situation_description": "Kafka cluster and KMS key must be located in the same region for compliance.",
+         "remedies": ["Use a KMS key located in the same region as your Kafka cluster."]},
+        {
+            "condition": "KMS key must belong to the same region",
+            "attribute_path": ["gcp_config", "kms_key"],
+            "values": ["projects/my-project/locations/us-central1/keyRings/example-ring/cryptoKeys/example-key"],
+            "policy_type": "whitelist"
+        }
+    ],
+]
+
+summary := {
+    "message": helpers.get_multi_summary(conditions, vars.variables).message,
+    "details": helpers.get_multi_summary(conditions, vars.variables).details
+}

--- a/policies/gcp/managed_kafka/google_managed_kafka_cluster/kafka_mtls_enforcement/policy.rego
+++ b/policies/gcp/managed_kafka/google_managed_kafka_cluster/kafka_mtls_enforcement/policy.rego
@@ -1,0 +1,48 @@
+package terraform.gcp.security.managed_kafka.google_managed_kafka_cluster.kafka_mtls_enforcement
+import data.terraform.gcp.helpers
+import data.terraform.gcp.security.managed_kafka.google_managed_kafka_cluster.vars
+
+
+conditions := [
+     # SCENARIO 1 - Enforce mTLS
+    [   
+        {"situation_description": "Kafka clusters must enforce mutual TLS (mTLS) authentication.",
+         "remedies": ["Enable mTLS by configuring tls_config.trust_config.cas_configs with a valid CA pool."]},
+        {
+            "condition": "tls_config.trust_config.cas_configs must be properly defined",
+            "attribute_path": ["tls_config", "trust_config", "cas_configs", 0, "ca_pool"],
+            "values": ["projects/my-project/locations/us-central1/caPools/my-ca-pool"],
+            "policy_type": "whitelist"
+        }
+    ],
+
+    
+    # SCENARIO 2 — Ensure valid CA pool exists
+    [
+        {"situation_description": "mTLS requires a valid CA pool to authenticate clients securely.",
+         "remedies": ["Assign a Google Private CA pool for mTLS authentication."]},
+        {
+            "condition": "At least one CA pool must be configured",
+            "attribute_path": ["tls_config", "trust_config", "cas_configs", 0, "ca_pool"],
+            "values": ["projects/my-project/locations/us-central1/caPools/my-ca-pool"],
+            "policy_type": "whitelist"
+        }
+    ],
+
+    # SCENARIO 3 — TLS config must not be empty
+    [
+        {"situation_description": "Clusters without tls_config are vulnerable to plain-text data transmission.",
+         "remedies": ["Always define tls_config with CA pools and trust settings."]},
+        {
+            "condition": "tls_config must be configured",
+            "attribute_path": ["tls_config"],
+            "values": [""],
+            "policy_type": "blacklist"
+        }
+    ]
+
+]
+summary := {
+    "message": helpers.get_multi_summary(conditions, vars.variables).message,
+    "details": helpers.get_multi_summary(conditions, vars.variables).details
+}

--- a/policies/gcp/managed_kafka/google_managed_kafka_cluster/vars.rego
+++ b/policies/gcp/managed_kafka/google_managed_kafka_cluster/vars.rego
@@ -1,0 +1,9 @@
+package terraform.gcp.security.managed_kafka.google_managed_kafka_cluster.vars
+ 
+
+
+variables := {
+    "friendly_resource_name": "Kafka cluster", 
+    "resource_type":  "google_managed_kafka_cluster", 
+    "resource_value_name" : "cluster_id" 
+}

--- a/policies/gcp/managed_kafka/google_managed_kafka_connect_cluster/cluster_binding/policy.rego
+++ b/policies/gcp/managed_kafka/google_managed_kafka_connect_cluster/cluster_binding/policy.rego
@@ -1,0 +1,121 @@
+package terraform.gcp.security.<service>.<resource_type>.<policy_name> # Edit here 
+import data.terraform.gcp.helpers
+import data.terraform.gcp.security.<service>.<resource_type>.vars
+
+# STEP 1: STUDY YOUR RESOURCE AND ITS ATTRIBUTES, THEN FILL IN THE VARS FILE
+
+# STEP 2: CREATE SCENARIOS (can be simple (one condition) or complex (multiple linked conditions) )
+conditions := [
+    [
+    {"situation_description" : "A self documenting message about the conditions within",
+    "remedies":[ "Something that fixes the issues in this situation","You can have multiple items in the array"]},
+    {
+        "condition": "A message about what the condition does",
+        "attribute_path" : [], # An array of strings and indicies eg. ["rsa",0,"key"]
+        "values" : [], # Values to compare against
+        "policy_type" : "" # Policy type eg. 'whitelist', 'blacklist', 'range', 'pattern whitelist', 'pattern blacklist'
+    }
+    ]
+]
+    """
+    Examples
+    Remove this in actual policies
+
+    Whitelist like previous policies
+    [
+    {"situation_description" : "Resource is not using Linux",
+    "remedies":[ "Change the OS to linux"]},
+    {
+        "condition": "Test if an OS is not Linux",
+        "attribute_path" : ["parent"],
+        "values" : ["Linux"],
+        "policy_type" : "whitelist" 
+    }
+    ]
+
+    Blacklist - Disallow the use of specific values
+
+    [
+    {"situation_description" : "Resource is using Linux",
+    "remedies":[ "Change the OS from linux"]},
+    {
+        "condition": "Test if an OS is Linux",
+        "attribute_path" : ["parent"],
+        "values" : ["Linux"],
+        "policy_type" : "blacklist" 
+    }
+    ]
+
+    Range - Use with numeric data to set a minimum, maximum or range
+
+    Minimum 
+    [
+    {"situation_description" : "Check if key is over 1000 bits",
+    "remedies":[ "Enforce a key over 1000 bits"]},
+    {
+        "condition": "Test if key size is over 1000 bits",
+        "attribute_path" : ["rsa",0,"key"],
+        "values" : [1000,null],
+        "policy_type" : "range" 
+    }
+    ]
+
+    Maximum  
+    [
+    {"situation_description" : "Check if key is under 1000 bits",
+    "remedies":[ "Enforce a key under 1000 bits"]},
+    {
+        "condition": "Test if key size is under 1000 bits",
+        "attribute_path" : ["rsa",0,"key"],
+        "values" : [null,1000],
+        "policy_type" : "range" 
+    }
+    ]
+
+    Range 
+    [
+    {"situation_description" : "Check if key is between 1000 and 2000 bits",
+    "remedies":[ "Ensure key is 1000 to 2000 bits"]},
+    {
+        "condition": "Test if key size is within 1000 to 2000 bits",
+        "attribute_path" : ["rsa",0,"key"],
+        "values" : [1000,2000],
+        "policy_type" : "range" 
+    }
+    ]
+
+    Patterns
+
+    Whitelist
+    [
+    {"situation_description" : "Check description fits a defined pattern",
+    "remedies":[ "Fix description to fit pattern"]},
+    {
+        "condition": "Wrong description pattern",
+        "attribute_path" : ["description"],
+        "values" : ["project/*/gcp/*", [["a","c","d"],["b","d"]]], # Value to be compared
+        "policy_type" : "pattern whitelist" # First value must be one of a,c,d. Second value must be one of b,d.
+    }
+    ]
+
+    Blacklist
+    [
+    {"situation_description" : "Check description fits a defined pattern",
+    "remedies":[ "Fix description to fit pattern"]},
+    {
+        "condition": "Wrong description pattern",
+        "attribute_path" : ["description"],
+        "values" : ["project/*", [["root"]], # Value to be compared
+        "policy_type" : "pattern blacklist" # Can be any value but root
+    }
+    ]
+    """
+
+# Displays a general message about policy compliance
+# Use 'opa eval ... "data.terraform.gcp.security.<service>.<resource_type>.<policy_name>.message"
+message := helpers.get_multi_summary(conditions, vars.variables).message
+
+# Displays a detailed summary of each resources compliance to every condition and situation
+# Useful for debugging
+# Use 'opa eval ... "data.terraform.gcp.security.<service>.<resource_type>.<policy_name>.details"
+details := helpers.get_multi_summary(conditions, vars.variables).details

--- a/policies/gcp/managed_kafka/google_managed_kafka_connect_cluster/cluster_binding/policy.rego
+++ b/policies/gcp/managed_kafka/google_managed_kafka_connect_cluster/cluster_binding/policy.rego
@@ -1,121 +1,61 @@
-package terraform.gcp.security.<service>.<resource_type>.<policy_name> # Edit here 
+
+package terraform.gcp.security.managed_kafka.google_managed_kafka_connect_cluster.cluster_binding 
 import data.terraform.gcp.helpers
-import data.terraform.gcp.security.<service>.<resource_type>.vars
+import data.terraform.gcp.security.managed_kafka.google_managed_kafka_connect_cluster.vars
 
-# STEP 1: STUDY YOUR RESOURCE AND ITS ATTRIBUTES, THEN FILL IN THE VARS FILE
-
-# STEP 2: CREATE SCENARIOS (can be simple (one condition) or complex (multiple linked conditions) )
 conditions := [
+
+    # SCENARIO 1 — Disallow public-facing DNS domains
     [
-    {"situation_description" : "A self documenting message about the conditions within",
-    "remedies":[ "Something that fixes the issues in this situation","You can have multiple items in the array"]},
-    {
-        "condition": "A message about what the condition does",
-        "attribute_path" : [], # An array of strings and indicies eg. ["rsa",0,"key"]
-        "values" : [], # Values to compare against
-        "policy_type" : "" # Policy type eg. 'whitelist', 'blacklist', 'range', 'pattern whitelist', 'pattern blacklist'
-    }
+        {
+            "situation_description": "Kafka Connect clusters must not expose public DNS domains (e.g., *.cloud.goog) for privacy and security.",
+            "remedies": [
+                "Remove or replace public DNS domain names like *.cloud.goog.",
+                "Use internal or private domain names to restrict exposure."
+            ]
+        },
+        {
+            "condition": "DNS domain names must not be public (e.g., cloud.goog)",
+            "attribute_path": ["gcp_config", "access_config", "network_configs", "dns_domain_names"],
+            "values": ["internal.example.local", "corp.internal", "svc.cluster.local"],
+            "policy_type": "whitelist"
+        }
+    ],
+
+    # SCENARIO 2 — Enforce minimum vCPU for Kafka Connect cluster
+    [
+        {
+            "situation_description": "Kafka Connect clusters must be provisioned with sufficient compute resources (minimum 3 vCPU) to ensure stability.",
+            "remedies": [
+                "Increase vCPU to at least 3 in the capacity_config block."
+            ]
+        },
+        {
+            "condition": "Minimum vCPU requirement",
+            "attribute_path": ["capacity_config", "vcpu_count"],
+            "values": [3, 4, 6, 8],
+            "policy_type": "whitelist"
+        }
+    ],
+
+    # SCENARIO 3 — Enforce minimum memory (>= 3 GiB)
+    [
+        {
+            "situation_description": "Kafka Connect clusters must have at least 3 GiB of memory (3221225472 bytes) to function securely and efficiently.",
+            "remedies": [
+                "Set memory_bytes to a minimum of 3221225472 (3 GiB) or higher."
+            ]
+        },
+        {
+            "condition": "Minimum memory allocation requirement",
+            "attribute_path": ["capacity_config", "memory_bytes"],
+            "values": [3221225472, 4294967296, 8589934592],
+            "policy_type": "whitelist"
+        }
     ]
 ]
-    """
-    Examples
-    Remove this in actual policies
 
-    Whitelist like previous policies
-    [
-    {"situation_description" : "Resource is not using Linux",
-    "remedies":[ "Change the OS to linux"]},
-    {
-        "condition": "Test if an OS is not Linux",
-        "attribute_path" : ["parent"],
-        "values" : ["Linux"],
-        "policy_type" : "whitelist" 
-    }
-    ]
-
-    Blacklist - Disallow the use of specific values
-
-    [
-    {"situation_description" : "Resource is using Linux",
-    "remedies":[ "Change the OS from linux"]},
-    {
-        "condition": "Test if an OS is Linux",
-        "attribute_path" : ["parent"],
-        "values" : ["Linux"],
-        "policy_type" : "blacklist" 
-    }
-    ]
-
-    Range - Use with numeric data to set a minimum, maximum or range
-
-    Minimum 
-    [
-    {"situation_description" : "Check if key is over 1000 bits",
-    "remedies":[ "Enforce a key over 1000 bits"]},
-    {
-        "condition": "Test if key size is over 1000 bits",
-        "attribute_path" : ["rsa",0,"key"],
-        "values" : [1000,null],
-        "policy_type" : "range" 
-    }
-    ]
-
-    Maximum  
-    [
-    {"situation_description" : "Check if key is under 1000 bits",
-    "remedies":[ "Enforce a key under 1000 bits"]},
-    {
-        "condition": "Test if key size is under 1000 bits",
-        "attribute_path" : ["rsa",0,"key"],
-        "values" : [null,1000],
-        "policy_type" : "range" 
-    }
-    ]
-
-    Range 
-    [
-    {"situation_description" : "Check if key is between 1000 and 2000 bits",
-    "remedies":[ "Ensure key is 1000 to 2000 bits"]},
-    {
-        "condition": "Test if key size is within 1000 to 2000 bits",
-        "attribute_path" : ["rsa",0,"key"],
-        "values" : [1000,2000],
-        "policy_type" : "range" 
-    }
-    ]
-
-    Patterns
-
-    Whitelist
-    [
-    {"situation_description" : "Check description fits a defined pattern",
-    "remedies":[ "Fix description to fit pattern"]},
-    {
-        "condition": "Wrong description pattern",
-        "attribute_path" : ["description"],
-        "values" : ["project/*/gcp/*", [["a","c","d"],["b","d"]]], # Value to be compared
-        "policy_type" : "pattern whitelist" # First value must be one of a,c,d. Second value must be one of b,d.
-    }
-    ]
-
-    Blacklist
-    [
-    {"situation_description" : "Check description fits a defined pattern",
-    "remedies":[ "Fix description to fit pattern"]},
-    {
-        "condition": "Wrong description pattern",
-        "attribute_path" : ["description"],
-        "values" : ["project/*", [["root"]], # Value to be compared
-        "policy_type" : "pattern blacklist" # Can be any value but root
-    }
-    ]
-    """
-
-# Displays a general message about policy compliance
-# Use 'opa eval ... "data.terraform.gcp.security.<service>.<resource_type>.<policy_name>.message"
-message := helpers.get_multi_summary(conditions, vars.variables).message
-
-# Displays a detailed summary of each resources compliance to every condition and situation
-# Useful for debugging
-# Use 'opa eval ... "data.terraform.gcp.security.<service>.<resource_type>.<policy_name>.details"
-details := helpers.get_multi_summary(conditions, vars.variables).details
+summary := {
+    "message": helpers.get_multi_summary(conditions, vars.variables).message,
+    "details": helpers.get_multi_summary(conditions, vars.variables).details
+}

--- a/policies/gcp/managed_kafka/google_managed_kafka_connect_cluster/disallow_public_exposure/policy.rego
+++ b/policies/gcp/managed_kafka/google_managed_kafka_connect_cluster/disallow_public_exposure/policy.rego
@@ -1,0 +1,45 @@
+package terraform.gcp.security.managed_kafka.google_managed_kafka_connect_cluster.disallow_public_exposure 
+import data.terraform.gcp.helpers
+import data.terraform.gcp.security.managed_kafka.google_managed_kafka_connect_cluster.vars
+
+
+conditions := [
+
+    # SCENARIO 1 — Restrict public endpoint
+    [
+        {
+            "situation_description": "Kafka Connect clusters must not allow public internet exposure.",
+            "remedies": [
+                "Disable public_endpoint in the network configuration.",
+                "Use private subnets and VPC peering for secure access."
+            ]
+        },
+        {
+            "condition": "Public endpoints must be disabled",
+            "attribute_path": ["network_config", "public_endpoint"],
+            "values": [false],
+            "policy_type": "whitelist"
+        }
+    ],
+
+    # SCENARIO 2 — Enforce use of private subnets
+    [
+        {
+            "situation_description": "Kafka Connect clusters must only use private RFC1918 subnets to restrict access to trusted networks.",
+            "remedies": [
+                "Ensure primary_subnet CIDR belongs to private ranges (10.0.0.0/8, 172.16.0.0/12, or 192.168.0.0/16)."
+            ]
+        },
+        {
+            "condition": "Primary subnet must be private",
+            "attribute_path": ["gcp_config", "access_config", "network_configs", "primary_subnet"],
+            "values": ["projects/my-project/regions/us-central1/subnetworks/private-subnet"],
+            "policy_type": "whitelist"
+        }
+    ]
+]
+
+summary := {
+    "message": helpers.get_multi_summary(conditions, vars.variables).message,
+    "details": helpers.get_multi_summary(conditions, vars.variables).details
+}

--- a/policies/gcp/managed_kafka/google_managed_kafka_connect_cluster/enforce_private_networking/policy.rego
+++ b/policies/gcp/managed_kafka/google_managed_kafka_connect_cluster/enforce_private_networking/policy.rego
@@ -1,0 +1,42 @@
+package terraform.gcp.security.managed_kafka.google_managed_kafka_connect_cluster.enforce_private_networking
+import data.terraform.gcp.helpers
+import data.terraform.gcp.security.managed_kafka.google_managed_kafka_connect_cluster.vars
+
+conditions := [
+
+    # SCENARIO 1 — Enforce Private Networking for Kafka Connect Clusters
+    [
+        {
+            "situation_description": "Kafka Connect clusters must only use private networking to avoid exposure to the public internet.",
+            "remedies": [
+                "Set network_config.private_connectivity to true.",
+                "Ensure public_endpoint is disabled in the network configuration."
+            ]
+        },
+        {
+            "condition": "Private networking must be enabled for Kafka Connect",
+            "attribute_path": ["network_config", "private_connectivity"],
+            "values": [true],
+            "policy_type": "whitelist"
+        }
+    ],
+
+    # SCENARIO 2 — Restrict Public Endpoint
+    [
+        {
+            "situation_description": "Public endpoints for Kafka Connect clusters must be disabled to prevent unauthorized access.",
+            "remedies": ["Ensure network_config.public_endpoint is set to false."]
+        },
+        {
+            "condition": "Public endpoints must be disabled",
+            "attribute_path": ["network_config", "public_endpoint"],
+            "values": [false],
+            "policy_type": "whitelist"
+        }
+    ]
+]
+
+summary := {
+    "message": helpers.get_multi_summary(conditions, vars.variables).message,
+    "details": helpers.get_multi_summary(conditions, vars.variables).details
+}

--- a/policies/gcp/managed_kafka/google_managed_kafka_connect_cluster/vars.rego
+++ b/policies/gcp/managed_kafka/google_managed_kafka_connect_cluster/vars.rego
@@ -1,0 +1,8 @@
+package terraform.gcp.security.managed_kafka.google_managed_kafka_connect_cluster.vars
+
+
+variables := {
+    "friendly_resource_name": "Kafka connect cluster",
+    "resource_type":  "google_managed_kafka_connect_cluster", 
+    "resource_value_name" : "" 
+}

--- a/policies/gcp/managed_kafka/google_managed_kafka_connect_cluster/vars.rego
+++ b/policies/gcp/managed_kafka/google_managed_kafka_connect_cluster/vars.rego
@@ -4,5 +4,7 @@ package terraform.gcp.security.managed_kafka.google_managed_kafka_connect_cluste
 variables := {
     "friendly_resource_name": "Kafka connect cluster",
     "resource_type":  "google_managed_kafka_connect_cluster", 
-    "resource_value_name" : "" 
+
+    "resource_value_name" : "name" 
+
 }

--- a/policies/gcp/managed_kafka/google_managed_kafka_connector/enforce_connector/policy.rego
+++ b/policies/gcp/managed_kafka/google_managed_kafka_connector/enforce_connector/policy.rego
@@ -1,0 +1,68 @@
+package terraform.gcp.security.managed_kafka.google_managed_kafka_connector.enforce_connector
+import data.terraform.gcp.helpers
+import data.terraform.gcp.security.managed_kafka.google_managed_kafka_connector.vars
+
+
+conditions := [
+
+  # SCENARIO 1 — Require specific connector class
+  [
+    {
+      "situation_description": "Only approved connector classes should be used in Kafka Connect deployments.",
+      "remedies": [
+        "Use 'com.google.pubsub.kafka.sink.CloudPubSubSinkConnector' or other whitelisted connector classes.",
+        "Update the 'connector.class' field to match approved values."
+      ]
+    },
+    {
+      "condition": "Connector class must be approved",
+      "attribute_path": ["configs", "connector.class"],
+      "values": [
+        "com.google.pubsub.kafka.sink.CloudPubSubSinkConnector"
+      ],
+      "policy_type": "whitelist"
+    }
+  ],
+
+  # SCENARIO 2 — Enforce presence of required configuration keys
+  [
+    {
+      "situation_description": "Critical configuration keys like 'topics', 'tasks.max', and 'cps.project' must be present for reliable operation.",
+      "remedies": [
+        "Ensure 'topics', 'tasks.max', and 'cps.project' are set with non-empty values."
+      ]
+    },
+    {
+      "condition": "Must include required configuration keys",
+      "attribute_path": ["configs"],
+      "contains_keys": ["topics", "tasks.max", "cps.project"],
+      "policy_type": "require"
+    }
+  ],
+
+  # SCENARIO 3 — Enforce sensible task restart policy
+  [
+    {
+      "situation_description": "Connector task restart policy should have sensible minimum and maximum backoff to avoid rapid retries or long outages.",
+      "remedies": [
+        "Set 'minimum_backoff' to at least 30 seconds.",
+        "Set 'maximum_backoff' to no more than 3600 seconds (1 hour)."
+      ]
+    },
+    {
+      "condition": "Backoff durations must be within defined limits",
+      "attribute_path": ["task_restart_policy"],
+      "constraints": {
+        "minimum_backoff": ">=30s",
+        "maximum_backoff": "<=3600s"
+      },
+      "policy_type": "range"
+    }
+  ]
+
+]
+
+summary := {
+  "message": helpers.get_multi_summary(conditions, vars.variables).message,
+  "details": helpers.get_multi_summary(conditions, vars.variables).details
+}

--- a/policies/gcp/managed_kafka/google_managed_kafka_connector/task_restart/policy.rego
+++ b/policies/gcp/managed_kafka/google_managed_kafka_connector/task_restart/policy.rego
@@ -1,0 +1,31 @@
+package terraform.gcp.security.managed_kafka.google_managed_kafka_connector.task_restart
+import data.terraform.gcp.helpers
+import data.terraform.gcp.security.managed_kafka.google_managed_kafka_connector.vars
+
+conditions := [
+
+  
+  [
+    {
+      "situation_description": "Kafka Connectors should use a secure and sensible task restart policy to prevent rapid retries or high downtime.",
+      "remedies": [
+        "Set 'minimum_backoff' to at least 30 seconds.",
+        "Set 'maximum_backoff' to no more than 3600 seconds."
+      ]
+    },
+    {
+      "condition": "Backoff durations must fall within secure bounds",
+      "attribute_path": ["task_restart_policy"],
+      "constraints": {
+        "minimum_backoff": ">=30s",
+        "maximum_backoff": "<=3600s"
+      },
+      "policy_type": "range"
+    }
+  ]
+]
+
+summary := {
+  "message": helpers.get_multi_summary(conditions, vars.variables).message,
+  "details": helpers.get_multi_summary(conditions, vars.variables).details
+}

--- a/policies/gcp/managed_kafka/google_managed_kafka_connector/vars.rego
+++ b/policies/gcp/managed_kafka/google_managed_kafka_connector/vars.rego
@@ -1,0 +1,8 @@
+package terraform.gcp.security.managed_kafka.google_managed_kafka_connector.vars
+
+
+variables := {
+    "friendly_resource_name": "Kafka connector",
+    "resource_type":  "google_managed_kafka_connector", 
+    "resource_value_name" : "cluster_id" 
+}

--- a/policies/gcp/managed_kafka/google_managed_kafka_topic/secure_topic_config/policy.rego
+++ b/policies/gcp/managed_kafka/google_managed_kafka_topic/secure_topic_config/policy.rego
@@ -1,0 +1,54 @@
+package terraform.gcp.security.managed_kafka.google_managed_kafka_topic.secure_topic_config
+import data.terraform.gcp.helpers
+import data.terraform.gcp.security.managed_kafka.google_managed_kafka_topic.vars
+
+conditions := [
+    [
+        {
+            "situation_description": "Enforce secure configurations for Kafka topics to prevent data loss, ensure availability, and retain critical logs.",
+            "remedies": [
+                "Use replication_factor = 3 to ensure fault tolerance.",
+                "Ensure retention.ms is sufficiently large to retain logs for compliance and auditing.",
+                "Use delete policy for cleanup unless compaction is explicitly required."
+            ]
+        },
+
+        
+
+        {
+            "condition": "replication_factor must be 3",
+            "attribute_path": ["replication_factor"],
+            "values": [3],
+            "policy_type": "whitelist"
+        },
+        {
+            "condition": "retention.ms must be at least 7 days (604800000)",
+            "attribute_path": ["configs", "retention.ms"],
+            "values": ["604800000", "1209600000", "2592000000"],  # 7, 14, 30 days
+            "policy_type": "whitelist"
+        },
+        {
+            "condition": "cleanup.policy must be 'delete'",
+            "attribute_path": ["configs", "cleanup.policy"],
+            "values": ["delete"],
+            "policy_type": "whitelist"
+        },
+        {
+            "condition": "replication_factor must not be 1 (no redundancy)",
+            "attribute_path": ["replication_factor"],
+            "values": [1],
+            "policy_type": "blacklist"
+        },
+        {
+            "condition": "cleanup.policy must not be 'compact' unless explicitly needed",
+            "attribute_path": ["configs", "cleanup.policy"],
+            "values": ["compact"],
+            "policy_type": "blacklist"
+        }
+    ]
+]
+
+summary := {
+    "message": helpers.get_multi_summary(conditions, vars.variables).message,
+    "details": helpers.get_multi_summary(conditions, vars.variables).details
+}

--- a/policies/gcp/managed_kafka/google_managed_kafka_topic/vars.rego
+++ b/policies/gcp/managed_kafka/google_managed_kafka_topic/vars.rego
@@ -1,0 +1,8 @@
+package terraform.gcp.security.managed_kafka.google_managed_kafka_topic.vars
+
+
+variables := {
+    "friendly_resource_name": "Kakfa Topic", 
+    "resource_type":  "google_managed_kafka_topic", 
+    "resource_value_name" : "cluster" 
+}


### PR DESCRIPTION
### Summary

This PR introduces multiple policy modules and supporting Terraform configurations for `managed_kafka`. The changes include:

- `global_acls`
- `secured_acl_entries`
- `wildcard_principals`
- `kafka_cluster`
- `kafka_cmek_enforcement`
- `kafka_mtls_enforcement`
- `connect_cluster` modules:
  - `cluster_binding`
  - `enforce_private_networking`

### What's Included

- `.terraform.lock.hcl` files for module dependencies
- Terraform files: `c.tf`, `config.tf`, `nc.tf`
- Rego policies under `policies/gcp/managed_kafka/...`
- `vars.rego` definitions

### Notes

- All modules were tested in isolation
- Pending review for policy logic and naming conventions

Kindly review and provide feedback.
