### PR TITLE
Change branch name from 'documentation/initialstructure' to 'dev'

### DIFF
--- a/index.html
+++ b/index.html
@@ -95,7 +95,7 @@
   <script>
     (async () => {
       try {
-        const branch = "documentation/initialstructure"; // 👈 change this
+        const branch = "dev"; // 👈 change this
         const url = `https://api.github.com/repos/Hardhat-Enterprises/Policy-Deployment-Engine/git/trees/${branch}?recursive=1`;
 
         const response = await fetch(url);


### PR DESCRIPTION
Changing the branch to ensure that the GitHub Pages directs to the correct repo