### PR TITLE
Add plugin caching to address storage issues with pipeline runs

### DIFF
--- a/.github/workflows/policy_check.yaml
+++ b/.github/workflows/policy_check.yaml
@@ -28,6 +28,10 @@ jobs:
           curl -L -o opa https://openpolicyagent.org/downloads/latest/opa_linux_amd64_static
           chmod +x opa
           sudo mv opa /usr/local/bin/opa
+      
+      - name: Run Linter
+        run: |
+          python3 scripts/linters/linters.py 
  
       - name: Run policy checks (Terraform + OPA)
         run: |

--- a/.github/workflows/policy_check.yaml
+++ b/.github/workflows/policy_check.yaml
@@ -32,6 +32,14 @@ jobs:
       - name: Set up plugin cache config
         run: |
           bash scripts/auto_test/cache_setup.sh 
+      
+      - name: Cache terraform plugins
+        uses: actions/cache@v4
+        with:
+          path: ~/.terraform.d/plugin-cache
+          key: terraform-plugins-${{ runner.os }}-${{ hashFiles('**/.terraform.lock.hcl') }}
+          restore-keys: terraform-plugins-${{ runner.os }}-
+      - run: echo "TF_PLUGIN_CACHE_DIR=$HOME/.terraform.d/plugin-cache" >> $GITHUB_ENV
  
       - name: Run policy checks (Terraform + OPA)
         run: |

--- a/.github/workflows/policy_check.yaml
+++ b/.github/workflows/policy_check.yaml
@@ -28,10 +28,6 @@ jobs:
           curl -L -o opa https://openpolicyagent.org/downloads/latest/opa_linux_amd64_static
           chmod +x opa
           sudo mv opa /usr/local/bin/opa
-      
-      - name: Run Linter
-        run: |
-          python3 scripts/linters/linter.py 
  
       - name: Run policy checks (Terraform + OPA)
         run: |

--- a/.github/workflows/policy_check.yaml
+++ b/.github/workflows/policy_check.yaml
@@ -31,7 +31,7 @@ jobs:
       
       - name: Run Linter
         run: |
-          python3 scripts/linters/linters.py 
+          python3 scripts/linters/linter.py 
  
       - name: Run policy checks (Terraform + OPA)
         run: |

--- a/.github/workflows/policy_check.yaml
+++ b/.github/workflows/policy_check.yaml
@@ -28,9 +28,14 @@ jobs:
           curl -L -o opa https://openpolicyagent.org/downloads/latest/opa_linux_amd64_static
           chmod +x opa
           sudo mv opa /usr/local/bin/opa
+
+      - name: Set up plugin cache config
+        run: |
+          bash scripts/auto_test/setup_terraform_cache.sh 
  
       - name: Run policy checks (Terraform + OPA)
         run: |
           python3 scripts/auto_test/auto_test.py \
             --inputs inputs/gcp \
             --policies policies/gcp
+            --verbose

--- a/.github/workflows/policy_check.yaml
+++ b/.github/workflows/policy_check.yaml
@@ -31,15 +31,7 @@ jobs:
 
       - name: Set up plugin cache config
         run: |
-          bash scripts/auto_test/cache_setup.sh 
-      
-      - name: Cache terraform plugins
-        uses: actions/cache@v4
-        with:
-          path: ~/.terraform.d/plugin-cache
-          key: terraform-plugins-${{ runner.os }}-${{ hashFiles('**/.terraform.lock.hcl') }}
-          restore-keys: terraform-plugins-${{ runner.os }}-
-      - run: echo "TF_PLUGIN_CACHE_DIR=$HOME/.terraform.d/plugin-cache" >> $GITHUB_ENV
+          bash scripts/auto_test/cache_setup.sh
  
       - name: Run policy checks (Terraform + OPA)
         run: |

--- a/.github/workflows/policy_check.yaml
+++ b/.github/workflows/policy_check.yaml
@@ -31,7 +31,7 @@ jobs:
 
       - name: Set up plugin cache config
         run: |
-          bash scripts/auto_test/setup_terraform_cache.sh 
+          bash scripts/auto_test/cache_setup.sh 
  
       - name: Run policy checks (Terraform + OPA)
         run: |

--- a/.github/workflows/policy_check.yaml
+++ b/.github/workflows/policy_check.yaml
@@ -38,3 +38,4 @@ jobs:
           python3 scripts/auto_test/auto_test.py \
             --inputs inputs/gcp \
             --policies policies/gcp
+            --verbose

--- a/.github/workflows/policy_check.yaml
+++ b/.github/workflows/policy_check.yaml
@@ -38,4 +38,3 @@ jobs:
           python3 scripts/auto_test/auto_test.py \
             --inputs inputs/gcp \
             --policies policies/gcp
-            --verbose

--- a/.gitignore
+++ b/.gitignore
@@ -30,8 +30,8 @@ override.tf.json
 *_override.tf.json
 
 # Ignore transient lock info files created by terraform apply
-.terraform.tfstate.lock.info
-.terraform.tfstate.lock.hcl
+#.terraform.tfstate.lock.info
+#.terraform.tfstate.lock.hcl
 plan
 plan.json
 

--- a/scripts/auto_test/auto_test.py
+++ b/scripts/auto_test/auto_test.py
@@ -236,6 +236,7 @@ def validate_policy_output(attribute: str, resource_type: str | None, plan_path:
 def run_policy_check_pair(input_dir: Path, policy_dir: Path, policies_root: Path, verbose: bool = False):
     # Extract data about services and filesystem paths
     abs_input_dir = input_dir.resolve()
+    print(abs_input_dir)
     service, resource, attribute = extract_path_parts(input_dir)
     # Runs TF commands and returns abs path to plan.json
     plan_path = run_terraform_commands(abs_input_dir, verbose)
@@ -281,7 +282,6 @@ def find_matching_pairs(inputs_root: Path, policies_root: Path):
             pairs.append((input_dir, policy_dir))
         else:
             print(f" No matching policy dir for: {input_dir}")
-    print(pairs)
     return pairs
 
 

--- a/scripts/auto_test/auto_test.py
+++ b/scripts/auto_test/auto_test.py
@@ -4,6 +4,7 @@ import subprocess
 import argparse
 import json
 import re
+import shutil
 from pathlib import Path
 
 
@@ -266,20 +267,56 @@ def run_policy_check_pair(input_dir: Path, policy_dir: Path, policies_root: Path
         res = make_failure(attribute, "Could not run OPA query!", service, resource)
         return res
     
-    try:
-        (abs_input_dir / "plan").unlink(missing_ok=True)
-        (abs_input_dir / "fake-creds.json").unlink(missing_ok=True)
-        tf_dir = abs_input_dir / ".terraform"
-        if tf_dir.exists():
-            import shutil
-            shutil.rmtree(tf_dir, ignore_errors=True)
-    except Exception as e:
-        print(f"Warning: cleanup failed in {abs_input_dir}: {e}")
+    cleanup_workspace(input_dir)
 
     log_messages(verbose, message_query, messages)
     res = validate_policy_output(attribute, resource_type, plan_path, messages, verbose, service, resource)
     return res
 
+def cleanup_workspace(workdir: Path):
+
+    before_free, before_inodes, before_disk_str, before_inode_str = check_disk_and_inodes("/")
+    print("Before cleanup →", before_disk_str, "|", before_inode_str)
+
+    # remove plan.json and plan binary
+    for fname in ["plan", "fake-creds.json"]:
+        f = workdir / fname
+        try:
+            f.unlink()
+            print(f"Deleted {f}")
+        except FileNotFoundError:
+            pass
+
+    # remove .terraform directory recursively
+    tfdir = workdir / ".terraform"
+    if tfdir.exists():
+        shutil.rmtree(tfdir, ignore_errors=True)
+        print(f"Deleted {tfdir}")
+
+    after_free, after_inodes, after_disk_str, after_inode_str = check_disk_and_inodes("/")
+    print("After cleanup  →", after_disk_str, "|", after_inode_str)
+
+def _human(n: int) -> str:
+    """Convert bytes to human-readable string."""
+    for unit in ["B", "KB", "MB", "GB", "TB"]:
+        if n < 1024:
+            return f"{n:.1f}{unit}"
+        n /= 1024
+    return f"{n:.1f}PB"
+
+def check_disk_and_inodes(path: str = "/"):
+    """Return (disk_free_bytes, inode_free, disk_usage_str, inode_usage_str)."""
+    usage = shutil.disk_usage(path)
+    stats = os.statvfs(path)
+    total_inodes = stats.f_files
+    free_inodes = stats.f_ffree
+    used_inodes = total_inodes - free_inodes
+    inode_percent = (used_inodes / total_inodes) * 100 if total_inodes > 0 else 0
+
+    disk_str = f"Disk free: {_human(usage.free)} / {_human(usage.total)}"
+    inode_str = f"Inodes used: {used_inodes}/{total_inodes} ({inode_percent:.2f}%)"
+
+    return usage.free, free_inodes, disk_str, inode_str
 
 def find_matching_pairs(inputs_root: Path, policies_root: Path):
     def is_leaf_terraform_dir(directory: Path) -> bool:

--- a/scripts/auto_test/auto_test.py
+++ b/scripts/auto_test/auto_test.py
@@ -256,6 +256,16 @@ def run_policy_check_pair(input_dir: Path, policy_dir: Path, policies_root: Path
     if not messages:
         res = make_failure(attribute, "Could not run OPA query!", service, resource)
         return res
+    
+    try:
+        (abs_input_dir / "plan").unlink(missing_ok=True)
+        (abs_input_dir / "fake-creds.json").unlink(missing_ok=True)
+        tf_dir = abs_input_dir / ".terraform"
+        if tf_dir.exists():
+            import shutil
+            shutil.rmtree(tf_dir, ignore_errors=True)
+    except Exception as e:
+        print(f"Warning: cleanup failed in {abs_input_dir}: {e}")
 
     log_messages(verbose, message_query, messages)
     res = validate_policy_output(attribute, resource_type, plan_path, messages, verbose, service, resource)

--- a/scripts/auto_test/auto_test.py
+++ b/scripts/auto_test/auto_test.py
@@ -296,6 +296,8 @@ def cleanup_workspace(workdir: Path):
     after_free, after_inodes, after_disk_str, after_inode_str = check_disk_and_inodes("/")
     print("After cleanup  →", after_disk_str, "|", after_inode_str)
 
+    print(subprocess.run("du -ahx / | sort -rh | head -n 50", shell=True, text=True, capture_output=True).stdout)
+    
 def _human(n: int) -> str:
     """Convert bytes to human-readable string."""
     for unit in ["B", "KB", "MB", "GB", "TB"]:

--- a/scripts/auto_test/auto_test.py
+++ b/scripts/auto_test/auto_test.py
@@ -137,16 +137,21 @@ def run_terraform_commands(input_dir: Path, verbose: bool = False) -> Path | Non
     creds_content = '{"type": "service_account", "project_id": "fake-project"}'
     creds_path.write_text(creds_content)
 
+    plugin_cache = Path.home() / ".terraform.d" / "plugin-cache"
+    global_data_dir = Path(".tfshared").resolve()
+    global_data_dir.mkdir(parents=True, exist_ok=True)
+    
     env.update({
         'GOOGLE_APPLICATION_CREDENTIALS': str(creds_path),
         'GOOGLE_PROJECT': 'fake-project',
         'GOOGLE_REGION': 'us-central1',
-        'TF_PLUGIN_CACHE_DIR': '$HOME/.terraform.d/plugin-cache'
+        'TF_PLUGIN_CACHE_DIR': str(plugin_cache),
+        'TF_DATA_DIR': str(global_data_dir),
     })
 
     commands = [
         ("terraform init -backend=false"),
-        ("terraform plan -input=false -out=plan"),
+        ("terraform plan -refresh=false -lock=false -input=false -out=plan"),
         ("terraform show -json plan > plan.json")
     ]
 

--- a/scripts/auto_test/auto_test.py
+++ b/scripts/auto_test/auto_test.py
@@ -144,7 +144,7 @@ def run_terraform_commands(input_dir: Path, verbose: bool = False) -> Path | Non
     })
 
     commands = [
-        ("terraform init"),
+        ("terraform init -backend=false"),
         ("terraform plan -input=false -out=plan"),
         ("terraform show -json plan > plan.json")
     ]

--- a/scripts/auto_test/auto_test.py
+++ b/scripts/auto_test/auto_test.py
@@ -274,7 +274,7 @@ def run_policy_check_pair(input_dir: Path, policy_dir: Path, policies_root: Path
     return res
 
 def cleanup_workspace(workdir: Path):
-
+    workdir = workdir.resolve()
     before_free, before_inodes, before_disk_str, before_inode_str = check_disk_and_inodes("/")
     print("Before cleanup →", before_disk_str, "|", before_inode_str)
 

--- a/scripts/auto_test/auto_test.py
+++ b/scripts/auto_test/auto_test.py
@@ -149,8 +149,6 @@ def run_terraform_commands(input_dir: Path, verbose: bool = False) -> Path | Non
     ]
 
     for cmd in commands:
-        print(f"Running Terraform in: {input_dir}")
-        print(f"Commands: {commands}")
         result = subprocess.run(
             cmd,
             shell=True,
@@ -283,7 +281,7 @@ def find_matching_pairs(inputs_root: Path, policies_root: Path):
             pairs.append((input_dir, policy_dir))
         else:
             print(f" No matching policy dir for: {input_dir}")
-
+    print(pairs)
     return pairs
 
 

--- a/scripts/auto_test/auto_test.py
+++ b/scripts/auto_test/auto_test.py
@@ -145,7 +145,7 @@ def run_terraform_commands(input_dir: Path, verbose: bool = False) -> Path | Non
     })
 
     commands = [
-        ["terraform", "init", "-backend=false", "-reconfigure"],
+        ["terraform", "init", "-backend=false"],
         ["terraform", "plan", "-input=false", "-out=plan"],
     ]
 

--- a/scripts/auto_test/auto_test.py
+++ b/scripts/auto_test/auto_test.py
@@ -131,13 +131,11 @@ def get_policy_messages(policies_root: Path, plan_path: Path, message_query: str
 
 def run_terraform_commands(input_dir: Path, verbose: bool = False) -> Path | None:
     env = os.environ.copy()
-
-    # Write fake credentials file
+    
     creds_path = input_dir / "fake-creds.json"
     creds_content = '{"type": "service_account", "project_id": "fake-project"}'
     creds_path.write_text(creds_content)
 
-    # Correct env var for Google provider
     env.update({
         'GOOGLE_APPLICATION_CREDENTIALS': str(creds_path),
         'GOOGLE_PROJECT': 'fake-project',
@@ -145,9 +143,9 @@ def run_terraform_commands(input_dir: Path, verbose: bool = False) -> Path | Non
     })
 
     commands = [
-        ["terraform", "init", "-backend=false"],
-        ["terraform", "plan", "-input=false", "-out=plan"],
-        ["terraform", "show", "-json", "plan > plan.json"]
+        ("terraform init -backend=false"),
+        ("terraform plan -input=false -out=plan"),
+        ("terraform show -json plan > plan.json")
     ]
 
     for cmd in commands:

--- a/scripts/auto_test/auto_test.py
+++ b/scripts/auto_test/auto_test.py
@@ -167,6 +167,15 @@ def run_terraform_commands(input_dir: Path, verbose: bool = False) -> Path | Non
                 print(result.stderr)
             return None
 
+    try:
+        (input_dir / "plan").unlink(missing_ok=True)
+        (input_dir / "fake-creds.json").unlink(missing_ok=True)
+        tf_dir = input_dir / ".terraform"
+        if tf_dir.exists():
+            import shutil
+            shutil.rmtree(tf_dir, ignore_errors=True)
+    except Exception as e:
+        print(f"Warning: cleanup failed in {input_dir}: {e}")
     # Export plan.json explicitly
     plan_json = input_dir / "plan.json"
     print(plan_json)

--- a/scripts/auto_test/auto_test.py
+++ b/scripts/auto_test/auto_test.py
@@ -168,16 +168,6 @@ def run_terraform_commands(input_dir: Path, verbose: bool = False) -> Path | Non
                 print(result.stderr)
             return None
 
-    try:
-        (input_dir / "plan").unlink(missing_ok=True)
-        (input_dir / "fake-creds.json").unlink(missing_ok=True)
-        tf_dir = input_dir / ".terraform"
-        if tf_dir.exists():
-            import shutil
-            shutil.rmtree(tf_dir, ignore_errors=True)
-    except Exception as e:
-        print(f"Warning: cleanup failed in {input_dir}: {e}")
-    # Export plan.json explicitly
     plan_json = input_dir / "plan.json"
     print(plan_json)
     return plan_json
@@ -251,6 +241,8 @@ def run_policy_check_pair(input_dir: Path, policy_dir: Path, policies_root: Path
     service, resource, attribute = extract_path_parts(input_dir)
     # Runs TF commands and returns abs path to plan.json
     plan_path = run_terraform_commands(abs_input_dir, verbose)
+    find_all_terraform_dirs(Path("."))
+    cleanup_workspace(abs_input_dir)
     if plan_path is None:
         res = make_failure(attribute, "Terraform failed to compile!", service, resource)
         return res
@@ -266,15 +258,12 @@ def run_policy_check_pair(input_dir: Path, policy_dir: Path, policies_root: Path
     if not messages:
         res = make_failure(attribute, "Could not run OPA query!", service, resource)
         return res
-    
-    cleanup_workspace(input_dir)
 
     log_messages(verbose, message_query, messages)
     res = validate_policy_output(attribute, resource_type, plan_path, messages, verbose, service, resource)
     return res
 
 def cleanup_workspace(workdir: Path):
-    workdir = workdir.resolve()
     before_free, before_inodes, before_disk_str, before_inode_str = check_disk_and_inodes("/")
     print("Before cleanup →", before_disk_str, "|", before_inode_str)
 
@@ -309,6 +298,18 @@ def _human(n: int) -> str:
             return f"{n:.1f}{unit}"
         n /= 1024
     return f"{n:.1f}PB"
+
+def find_all_terraform_dirs(root: Path):
+    print(f"Scanning for .terraform dirs under {root}")
+    result = subprocess.run(
+        f"find {root} -type d -name .terraform",
+        shell=True, text=True, capture_output=True
+    )
+    if result.stdout.strip():
+        print("Found these .terraform dirs:")
+        print(result.stdout)
+    else:
+        print("No .terraform dirs found")
 
 def check_disk_and_inodes(path: str = "/"):
     """Return (disk_free_bytes, inode_free, disk_usage_str, inode_usage_str)."""

--- a/scripts/auto_test/auto_test.py
+++ b/scripts/auto_test/auto_test.py
@@ -180,7 +180,7 @@ def run_terraform_commands(input_dir: Path, verbose: bool = False) -> Path | Non
         if verbose:
             print("❌ terraform show failed")
         return None
-
+    print(plan_json)
     return plan_json
 
 

--- a/scripts/auto_test/auto_test.py
+++ b/scripts/auto_test/auto_test.py
@@ -147,6 +147,7 @@ def run_terraform_commands(input_dir: Path, verbose: bool = False) -> Path | Non
     commands = [
         ["terraform", "init", "-backend=false"],
         ["terraform", "plan", "-input=false", "-out=plan"],
+        ["terraform", "show", "-json", "plan"]
     ]
 
     for cmd in commands:
@@ -168,18 +169,6 @@ def run_terraform_commands(input_dir: Path, verbose: bool = False) -> Path | Non
 
     # Export plan.json explicitly
     plan_json = input_dir / "plan.json"
-    with plan_json.open("w") as f:
-        result = subprocess.run(
-            ["terraform", "show", "-json", "plan"],
-            cwd=input_dir,
-            env=env,
-            stdout=f,
-            text=True
-        )
-    if result.returncode != 0:
-        if verbose:
-            print("❌ terraform show failed")
-        return None
     print(plan_json)
     return plan_json
 

--- a/scripts/auto_test/auto_test.py
+++ b/scripts/auto_test/auto_test.py
@@ -145,7 +145,7 @@ def run_terraform_commands(input_dir: Path, verbose: bool = False) -> Path | Non
     })
 
     commands = [
-        ["terraform", "init", "-reconfigure"],
+        ["terraform", "init", "-backend=false", "-reconfigure"],
         ["terraform", "plan", "-input=false", "-out=plan"],
     ]
 

--- a/scripts/auto_test/auto_test.py
+++ b/scripts/auto_test/auto_test.py
@@ -143,7 +143,7 @@ def run_terraform_commands(input_dir: Path, verbose: bool = False) -> Path | Non
     })
 
     commands = [
-        ("terraform init -backend=false"),
+        ("terraform init"),
         ("terraform plan -input=false -out=plan"),
         ("terraform show -json plan > plan.json")
     ]

--- a/scripts/auto_test/auto_test.py
+++ b/scripts/auto_test/auto_test.py
@@ -137,8 +137,8 @@ def run_terraform_commands(input_dir: Path, verbose: bool = False) -> Path | Non
         'GOOGLE_REGION': 'us-central1'
     })
     tf_commands = [
-        ("terraform init -backend=false -reconfigure"),
-        ("terraform plan -refresh=false -input=false -out=plan"),
+        ("terraform init"),
+        ("terraform plan -out=plan"),
         ("terraform show -json plan > plan.json"),
     ]
     for cmd in tf_commands:

--- a/scripts/auto_test/auto_test.py
+++ b/scripts/auto_test/auto_test.py
@@ -137,8 +137,8 @@ def run_terraform_commands(input_dir: Path, verbose: bool = False) -> Path | Non
         'GOOGLE_REGION': 'us-central1'
     })
     tf_commands = [
-        ("terraform init -backend=false -reconfigure"),
-        ("terraform plan -refresh=false -input=false -out=plan"),
+        ("terraform init -reconfigure"),
+        ("terraform plan -input=false -out=plan"),
         ("terraform show -json plan > plan.json"),
     ]
     for cmd in tf_commands:

--- a/scripts/auto_test/auto_test.py
+++ b/scripts/auto_test/auto_test.py
@@ -140,6 +140,7 @@ def run_terraform_commands(input_dir: Path, verbose: bool = False) -> Path | Non
         'GOOGLE_APPLICATION_CREDENTIALS': str(creds_path),
         'GOOGLE_PROJECT': 'fake-project',
         'GOOGLE_REGION': 'us-central1',
+        'TF_PLUGIN_CACHE_DIR': '$HOME/.terraform.d/plugin-cache'
     })
 
     commands = [

--- a/scripts/auto_test/auto_test.py
+++ b/scripts/auto_test/auto_test.py
@@ -131,7 +131,7 @@ def get_policy_messages(policies_root: Path, plan_path: Path, message_query: str
 
 def run_terraform_commands(input_dir: Path, verbose: bool = False) -> Path | None:
     env = os.environ.copy()
-    
+
     creds_path = input_dir / "fake-creds.json"
     creds_content = '{"type": "service_account", "project_id": "fake-project"}'
     creds_path.write_text(creds_content)
@@ -151,6 +151,7 @@ def run_terraform_commands(input_dir: Path, verbose: bool = False) -> Path | Non
     for cmd in commands:
         result = subprocess.run(
             cmd,
+            shell=True,
             cwd=input_dir,
             capture_output=True,
             text=True,

--- a/scripts/auto_test/auto_test.py
+++ b/scripts/auto_test/auto_test.py
@@ -285,19 +285,23 @@ def cleanup_workspace(workdir: Path):
             f.unlink()
             print(f"Deleted {f}")
         except FileNotFoundError:
+            print(f"File not found {f}")
             pass
 
     # remove .terraform directory recursively
-    tfdir = workdir / ".terraform"
-    if tfdir.exists():
-        shutil.rmtree(tfdir, ignore_errors=True)
-        print(f"Deleted {tfdir}")
+    for tfdir in workdir.rglob(".terraform"):
+        if tfdir.is_dir():
+            try:
+                shutil.rmtree(tfdir)
+                print(f"  Deleted {tfdir}")
+            except Exception as e:
+                print(f"  Failed to delete {tfdir}: {e}")
+        else:
+            print(".Tf directory not found")
 
     after_free, after_inodes, after_disk_str, after_inode_str = check_disk_and_inodes("/")
     print("After cleanup  →", after_disk_str, "|", after_inode_str)
 
-    print(subprocess.run("du -ahx / | sort -rh | head -n 50", shell=True, text=True, capture_output=True).stdout)
-    
 def _human(n: int) -> str:
     """Convert bytes to human-readable string."""
     for unit in ["B", "KB", "MB", "GB", "TB"]:

--- a/scripts/auto_test/auto_test.py
+++ b/scripts/auto_test/auto_test.py
@@ -174,7 +174,6 @@ def run_terraform_commands(input_dir: Path, verbose: bool = False) -> Path | Non
             return None
 
     plan_json = input_dir / "plan.json"
-    print(plan_json)
     return plan_json
 
 
@@ -242,12 +241,11 @@ def validate_policy_output(attribute: str, resource_type: str | None, plan_path:
 def run_policy_check_pair(input_dir: Path, policy_dir: Path, policies_root: Path, verbose: bool = False):
     # Extract data about services and filesystem paths
     abs_input_dir = input_dir.resolve()
-    print(abs_input_dir)
     service, resource, attribute = extract_path_parts(input_dir)
     # Runs TF commands and returns abs path to plan.json
     plan_path = run_terraform_commands(abs_input_dir, verbose)
-    find_all_terraform_dirs(Path("."))
     cleanup_workspace(abs_input_dir)
+
     if plan_path is None:
         res = make_failure(attribute, "Terraform failed to compile!", service, resource)
         return res
@@ -269,17 +267,12 @@ def run_policy_check_pair(input_dir: Path, policy_dir: Path, policies_root: Path
     return res
 
 def cleanup_workspace(workdir: Path):
-    before_free, before_inodes, before_disk_str, before_inode_str = check_disk_and_inodes("/")
-    print("Before cleanup →", before_disk_str, "|", before_inode_str)
-
-    # remove plan.json and plan binary
+    # remove plan binary and other transient parts
     for fname in ["plan", "fake-creds.json"]:
         f = workdir / fname
         try:
             f.unlink()
-            print(f"Deleted {f}")
         except FileNotFoundError:
-            print(f"File not found {f}")
             pass
 
     # remove .terraform directory recursively
@@ -287,48 +280,8 @@ def cleanup_workspace(workdir: Path):
         if tfdir.is_dir():
             try:
                 shutil.rmtree(tfdir)
-                print(f"  Deleted {tfdir}")
             except Exception as e:
-                print(f"  Failed to delete {tfdir}: {e}")
-        else:
-            print(".Tf directory not found")
-
-    after_free, after_inodes, after_disk_str, after_inode_str = check_disk_and_inodes("/")
-    print("After cleanup  →", after_disk_str, "|", after_inode_str)
-
-def _human(n: int) -> str:
-    """Convert bytes to human-readable string."""
-    for unit in ["B", "KB", "MB", "GB", "TB"]:
-        if n < 1024:
-            return f"{n:.1f}{unit}"
-        n /= 1024
-    return f"{n:.1f}PB"
-
-def find_all_terraform_dirs(root: Path):
-    print(f"Scanning for .terraform dirs under {root}")
-    result = subprocess.run(
-        f"find {root} -type d -name .terraform",
-        shell=True, text=True, capture_output=True
-    )
-    if result.stdout.strip():
-        print("Found these .terraform dirs:")
-        print(result.stdout)
-    else:
-        print("No .terraform dirs found")
-
-def check_disk_and_inodes(path: str = "/"):
-    """Return (disk_free_bytes, inode_free, disk_usage_str, inode_usage_str)."""
-    usage = shutil.disk_usage(path)
-    stats = os.statvfs(path)
-    total_inodes = stats.f_files
-    free_inodes = stats.f_ffree
-    used_inodes = total_inodes - free_inodes
-    inode_percent = (used_inodes / total_inodes) * 100 if total_inodes > 0 else 0
-
-    disk_str = f"Disk free: {_human(usage.free)} / {_human(usage.total)}"
-    inode_str = f"Inodes used: {used_inodes}/{total_inodes} ({inode_percent:.2f}%)"
-
-    return usage.free, free_inodes, disk_str, inode_str
+                pass
 
 def find_matching_pairs(inputs_root: Path, policies_root: Path):
     def is_leaf_terraform_dir(directory: Path) -> bool:

--- a/scripts/auto_test/auto_test.py
+++ b/scripts/auto_test/auto_test.py
@@ -137,8 +137,8 @@ def run_terraform_commands(input_dir: Path, verbose: bool = False) -> Path | Non
         'GOOGLE_REGION': 'us-central1'
     })
     tf_commands = [
-        ("terraform init"),
-        ("terraform plan -out=plan"),
+        ("terraform init -backend=false -reconfigure"),
+        ("terraform plan -refresh=false -input=false -out=plan"),
         ("terraform show -json plan > plan.json"),
     ]
     for cmd in tf_commands:

--- a/scripts/auto_test/auto_test.py
+++ b/scripts/auto_test/auto_test.py
@@ -131,25 +131,57 @@ def get_policy_messages(policies_root: Path, plan_path: Path, message_query: str
 
 def run_terraform_commands(input_dir: Path, verbose: bool = False) -> Path | None:
     env = os.environ.copy()
+
+    # Write fake credentials file
+    creds_path = input_dir / "fake-creds.json"
+    creds_content = '{"type": "service_account", "project_id": "fake-project"}'
+    creds_path.write_text(creds_content)
+
+    # Correct env var for Google provider
     env.update({
-        'GOOGLE_CREDENTIALS': '{"type": "service_account", "project_id": "fake-project"}',
+        'GOOGLE_APPLICATION_CREDENTIALS': str(creds_path),
         'GOOGLE_PROJECT': 'fake-project',
-        'GOOGLE_REGION': 'us-central1'
+        'GOOGLE_REGION': 'us-central1',
     })
-    tf_commands = [
-        ("terraform init -reconfigure"),
-        ("terraform plan -input=false -out=plan"),
-        ("terraform show -json plan > plan.json"),
+
+    commands = [
+        ["terraform", "init", "-reconfigure"],
+        ["terraform", "plan", "-input=false", "-out=plan"],
     ]
-    for cmd in tf_commands:
-        result = subprocess.run(cmd, shell=True, cwd=str(input_dir), capture_output=True, text=True, env=env)
+
+    for cmd in commands:
+        result = subprocess.run(
+            cmd,
+            cwd=input_dir,
+            capture_output=True,
+            text=True,
+            env=env
+        )
         if result.returncode != 0:
             if verbose:
-                print(f" Command failed: {cmd}")
+                print(f"❌ Command failed: {' '.join(cmd)}")
+                print("--- stdout ---")
                 print(result.stdout)
+                print("--- stderr ---")
                 print(result.stderr)
             return None
-    return input_dir / "plan.json"
+
+    # Export plan.json explicitly
+    plan_json = input_dir / "plan.json"
+    with plan_json.open("w") as f:
+        result = subprocess.run(
+            ["terraform", "show", "-json", "plan"],
+            cwd=input_dir,
+            env=env,
+            stdout=f,
+            text=True
+        )
+    if result.returncode != 0:
+        if verbose:
+            print("❌ terraform show failed")
+        return None
+
+    return plan_json
 
 
 def get_policy_metadata(policy_dir: Path, service: str, resource: str, attribute: str) -> tuple[str, str]:

--- a/scripts/auto_test/auto_test.py
+++ b/scripts/auto_test/auto_test.py
@@ -149,6 +149,8 @@ def run_terraform_commands(input_dir: Path, verbose: bool = False) -> Path | Non
     ]
 
     for cmd in commands:
+        print(f"Running Terraform in: {input_dir}")
+        print(f"Commands: {commands}")
         result = subprocess.run(
             cmd,
             shell=True,
@@ -159,7 +161,7 @@ def run_terraform_commands(input_dir: Path, verbose: bool = False) -> Path | Non
         )
         if result.returncode != 0:
             if verbose:
-                print(f"❌ Command failed: {' '.join(cmd)}")
+                print(f"❌ Command failed: {cmd}")
                 print("--- stdout ---")
                 print(result.stdout)
                 print("--- stderr ---")

--- a/scripts/auto_test/auto_test.py
+++ b/scripts/auto_test/auto_test.py
@@ -147,7 +147,7 @@ def run_terraform_commands(input_dir: Path, verbose: bool = False) -> Path | Non
     commands = [
         ["terraform", "init", "-backend=false"],
         ["terraform", "plan", "-input=false", "-out=plan"],
-        ["terraform", "show", "-json", "plan"]
+        ["terraform", "show", "-json", "plan > plan.json"]
     ]
 
     for cmd in commands:

--- a/scripts/auto_test/cache_setup.sh
+++ b/scripts/auto_test/cache_setup.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Default cache directory
+CACHE_DIR="${1:-$HOME/.terraform.d/plugin-cache}"
+
+# Ensure cache directory exists
+mkdir -p "$CACHE_DIR"
+
+# Create terraform.rc configuration
+CONFIG_CONTENT=$(cat <<EOF
+plugin_cache_dir = "$CACHE_DIR"
+EOF
+)
+
+# Write to user-level config (for most environments)
+mkdir -p "$HOME/.terraform.d"
+echo "$CONFIG_CONTENT" > "$HOME/.terraform.d/terraform.rc"
+
+# Also write to working directory as .terraformrc (used by Terraform in CI/CD sometimes)
+echo "$CONFIG_CONTENT" > .terraformrc
+
+echo "✅ Terraform plugin cache configuration written."


### PR DESCRIPTION
This PR makes adjustments to the pipeline to utilise a local cache for TF plugins as the pipeline runs were failing due to storage exhaustion. It also adds in a cleanup after running terraform commands to remove unneeded files. 