### PR TITLE
Fix: get_attribute_value function to support array-of-objects field

### DIFF
--- a/policies/_helpers/shared.rego
+++ b/policies/_helpers/shared.rego
@@ -90,7 +90,28 @@ ensure_array(values) = [values] if {
 
 # Get attribute value from a resource with null fallback
 # Simplifies the common pattern of accessing nested resource attributes
-get_attribute_value(resource, attribute_path) := object.get(resource.values, attribute_path, null)
+#
+# Enhanced: Array-of-Objects Field Extraction (Added 2025-12-04)
+# When the attribute path ends with a string field name and leads to an array of objects,
+# this function automatically extracts that field from each object in the array.
+get_attribute_value(resource, attribute_path) := extracted_values if {
+    # Check if this might be an array-of-objects extraction pattern
+    count(attribute_path) > 1
+    last_element := attribute_path[count(attribute_path) - 1]
+    is_string(last_element)
+    
+    # Get the path to the array (everything except the last element)
+    array_path := array.slice(attribute_path, 0, count(attribute_path) - 1)
+    array_value := object.get(resource.values, array_path, null)
+    
+    # If it's an array of objects, extract the field from each
+    is_array(array_value)
+    count(array_value) > 0
+    is_object(array_value[0])
+    
+    # Extract the field from each object in the array
+    extracted_values := [obj[last_element] | obj := array_value[_]; obj[last_element] != null]
+} else := object.get(resource.values, attribute_path, null)
 
 # Searches an array of objects for a specific key and returns its value
 # Used to extract metadata from condition groups

--- a/tests/_helpers/shared_test.rego
+++ b/tests/_helpers/shared_test.rego
@@ -154,10 +154,95 @@ test_shared_utilities_with_deep_nesting if {
 }
 
 # ==============================================================================
+# ARRAY-OF-OBJECTS FIELD EXTRACTION (1): Test new enhancement
+# ==============================================================================
+
+# Test 12: Array-of-objects field extraction (new enhancement)
+test_get_attribute_value_array_of_objects_extraction if {
+	# Mock resource with array of objects (realistic os_constraints pattern)
+	mock_resource := {
+		"type": "google_access_context_manager_access_level",
+		"values": {
+			"basic": [{
+				"conditions": [{
+					"device_policy": [{
+						"os_constraints": [
+							{"os_type": "ANDROID", "minimum_version": "10"},
+							{"os_type": "IOS", "minimum_version": "14"},
+							{"os_type": "OS_UNSPECIFIED", "minimum_version": null},
+						],
+					}],
+				}],
+			}],
+		},
+	}
+
+	# Test: Extract os_type field from array of objects
+	os_types := shared.get_attribute_value(
+		mock_resource,
+		["basic", 0, "conditions", 0, "device_policy", 0, "os_constraints", "os_type"],
+	)
+	
+	# Should return array of extracted field values
+	trace(sprintf("Extracted os_types: %v", [os_types]))
+	is_array(os_types)
+	count(os_types) == 3
+	os_types == ["ANDROID", "IOS", "OS_UNSPECIFIED"]
+
+	# Test: Also works with other fields in the same array
+	versions := shared.get_attribute_value(
+		mock_resource,
+		["basic", 0, "conditions", 0, "device_policy", 0, "os_constraints", "minimum_version"],
+	)
+	trace(sprintf("Extracted versions: %v", [versions]))
+	is_array(versions)
+	count(versions) == 2  # null values are filtered out
+	versions == ["10", "14"]
+}
+
+# Test 13: Array-of-objects extraction edge cases
+test_get_attribute_value_array_of_objects_edge_cases if {
+	mock_resource := {
+		"type": "test_resource",
+		"values": {
+			"empty_array": [],
+			"scalar_value": "not-an-array",
+			"array_of_scalars": ["a", "b", "c"],
+			"nested": [{
+				"items": [
+					{"field": "value1"},
+					{"field": "value2"},
+					{"different": "ignored"},  # Missing 'field' key
+				],
+			}],
+		},
+	}
+
+	# Empty array should return null (fallback to object.get)
+	empty_result := shared.get_attribute_value(mock_resource, ["empty_array", "field"])
+	empty_result == null
+
+	# Scalar value with field access should return null
+	scalar_result := shared.get_attribute_value(mock_resource, ["scalar_value", "field"])
+	scalar_result == null
+
+	# Array of scalars (not objects) should return null
+	scalar_array_result := shared.get_attribute_value(mock_resource, ["array_of_scalars", "field"])
+	scalar_array_result == null
+
+	# Extraction from nested array with missing field in some objects
+	nested_result := shared.get_attribute_value(mock_resource, ["nested", 0, "items", "field"])
+	trace(sprintf("Nested extraction: %v", [nested_result]))
+	is_array(nested_result)
+	count(nested_result) == 2  # Only objects with 'field' key
+	nested_result == ["value1", "value2"]
+}
+
+# ==============================================================================
 # REALITY CHECK (1): Test with real Terraform plan structure
 # ==============================================================================
 
-# Test 12: Reality check with actual fixture data
+# Test 14: Reality check with actual fixture data
 test_shared_utilities_with_real_structure if {
 	# Access real Terraform plan loaded by OPA from fixtures/gcp_access_level/
 	# The wrapped file loads as data.gcp_access_level_plan (wrapper key becomes the path)


### PR DESCRIPTION
Get attribute value from a resource with null fallback
Simplifies the common pattern of accessing nested resource attributes

Fix: Array-of-Objects Field Extraction (Added 2025-12-04)
When the attribute path ends with a string field name and leads to an array of objects,
this function automatically extracts that field from each object in the array. 

Added corresponding tests