### PR TITLE
Refactor import paths in Rego policy files to unify helper imports

### DIFF
--- a/policies/gcp/Firebase/android_app/deletion_policy/policy.rego
+++ b/policies/gcp/Firebase/android_app/deletion_policy/policy.rego
@@ -1,5 +1,5 @@
 package terraform.gcp.security.Firebase.android_app.deletion_policy
-import data.terraform.gcp.helpers
+import data.terraform.helpers
 import data.terraform.gcp.security.Firebase.android_app.vars
 
 conditions := [

--- a/policies/gcp/Firebase/apple_app/deletion_policy/policy.rego
+++ b/policies/gcp/Firebase/apple_app/deletion_policy/policy.rego
@@ -1,5 +1,5 @@
 package terraform.gcp.security.Firebase.apple_app.deletion_policy
-import data.terraform.gcp.helpers
+import data.terraform.helpers
 import data.terraform.gcp.security.Firebase.apple_app.vars
 
 conditions := [

--- a/policies/gcp/Firebase/web_app/deletion_policy/policy.rego
+++ b/policies/gcp/Firebase/web_app/deletion_policy/policy.rego
@@ -1,5 +1,5 @@
 package terraform.gcp.security.Firebase.web_app.deletion_policy
-import data.terraform.gcp.helpers
+import data.terraform.helpers
 import data.terraform.gcp.security.Firebase.web_app.vars
 
 conditions := [

--- a/policies/gcp/Firebase_Data_Connect/data_connect_service/deletion_policy/policy.rego
+++ b/policies/gcp/Firebase_Data_Connect/data_connect_service/deletion_policy/policy.rego
@@ -1,5 +1,5 @@
 package terraform.gcp.security.Firebase_Data_Connect.data_connect_service.deletion_policy
-import data.terraform.gcp.helpers
+import data.terraform.helpers
 import data.terraform.gcp.security.Firebase_Data_Connect.data_connect_service.vars
 
 conditions := [

--- a/policies/gcp/GKEHub/google_gke_hub_feature/fleet_logging_default_mode_required/policy.rego
+++ b/policies/gcp/GKEHub/google_gke_hub_feature/fleet_logging_default_mode_required/policy.rego
@@ -1,5 +1,5 @@
 package terraform.gcp.security.gke_hub.google_gke_hub_feature.fleet_logging_default_mode_required
-import data.terraform.gcp.helpers
+import data.terraform.helpers
 import data.terraform.gcp.security.gke_hub.google_gke_hub_feature.vars
 
 conditions := [[

--- a/policies/gcp/GKEHub/google_gke_hub_feature_iam_binding/no_public_principals_binding/policy.rego
+++ b/policies/gcp/GKEHub/google_gke_hub_feature_iam_binding/no_public_principals_binding/policy.rego
@@ -1,5 +1,5 @@
 package terraform.gcp.security.gke_hub.google_gke_hub_feature_iam_binding.no_public_principals_binding
-import data.terraform.gcp.helpers
+import data.terraform.helpers
 import data.terraform.gcp.security.gke_hub.google_gke_hub_feature_iam_binding.vars
 
 conditions := [[

--- a/policies/gcp/GKEHub/google_gke_hub_feature_iam_member/no_public_principals_member/policy.rego
+++ b/policies/gcp/GKEHub/google_gke_hub_feature_iam_member/no_public_principals_member/policy.rego
@@ -1,5 +1,5 @@
 package terraform.gcp.security.gke_hub.google_gke_hub_feature_iam_member.no_public_principals_member
-import data.terraform.gcp.helpers
+import data.terraform.helpers
 import data.terraform.gcp.security.gke_hub.google_gke_hub_feature_iam_member.vars
 
 

--- a/policies/gcp/GKEHub/google_gke_hub_feature_membership/git_approved_HTTPS/policy.rego
+++ b/policies/gcp/GKEHub/google_gke_hub_feature_membership/git_approved_HTTPS/policy.rego
@@ -1,5 +1,5 @@
 package terraform.gcp.security.gke_hub.google_gke_hub_feature_membership.git_approved_HTTPS
-import data.terraform.gcp.helpers
+import data.terraform.helpers
 import data.terraform.gcp.security.gke_hub.google_gke_hub_feature_membership.vars
 
 conditions := [

--- a/policies/gcp/GKEHub/google_gke_hub_feature_membership/git_secure_auth/policy.rego
+++ b/policies/gcp/GKEHub/google_gke_hub_feature_membership/git_secure_auth/policy.rego
@@ -1,5 +1,5 @@
 package terraform.gcp.security.gke_hub.google_gke_hub_feature_membership.git_secure_auth
-import data.terraform.gcp.helpers
+import data.terraform.helpers
 import data.terraform.gcp.security.gke_hub.google_gke_hub_feature_membership.vars
 
 

--- a/policies/gcp/GKEHub/google_gke_hub_feature_membership/pc_enable_requied/policy.rego
+++ b/policies/gcp/GKEHub/google_gke_hub_feature_membership/pc_enable_requied/policy.rego
@@ -1,5 +1,5 @@
 package terraform.gcp.security.gke_hub.google_gke_hub_feature_membership.pc_enabled_required
-import data.terraform.gcp.helpers
+import data.terraform.helpers
 import data.terraform.gcp.security.gke_hub.google_gke_hub_feature_membership.vars
 
 

--- a/policies/gcp/GKEHub/google_gke_hub_fleet/binauthz_policy_binding_approved/policy.rego
+++ b/policies/gcp/GKEHub/google_gke_hub_fleet/binauthz_policy_binding_approved/policy.rego
@@ -1,5 +1,5 @@
 package terraform.gcp.security.gke_hub.google_gke_hub_fleet.binauthz_policy_binding_approved
-import data.terraform.gcp.helpers
+import data.terraform.helpers
 import data.terraform.gcp.security.gke_hub.google_gke_hub_fleet.vars
 
 

--- a/policies/gcp/GKEHub/google_gke_hub_membership/authority_issuer/policy.rego
+++ b/policies/gcp/GKEHub/google_gke_hub_membership/authority_issuer/policy.rego
@@ -1,5 +1,5 @@
 package terraform.gcp.security.gke_hub.google_gke_hub_membership.authority_issuer
-import data.terraform.gcp.helpers
+import data.terraform.helpers
 import data.terraform.gcp.security.gke_hub.google_gke_hub_membership.vars
 
 conditions := [

--- a/policies/gcp/GKEHub/google_gke_hub_membership_rbac_role_binding/approved_roles/policy.rego
+++ b/policies/gcp/GKEHub/google_gke_hub_membership_rbac_role_binding/approved_roles/policy.rego
@@ -1,5 +1,5 @@
 package terraform.gcp.security.gke_hub.google_gke_hub_membership_rbac_role_binding.approved_roles
-import data.terraform.gcp.helpers
+import data.terraform.helpers
 import data.terraform.gcp.security.gke_hub.google_gke_hub_membership_rbac_role_binding.vars
 
 conditions := [

--- a/policies/gcp/GKEHub/google_gke_hub_scope_iam_binding/no_public_principals_binding/policy.rego
+++ b/policies/gcp/GKEHub/google_gke_hub_scope_iam_binding/no_public_principals_binding/policy.rego
@@ -1,5 +1,5 @@
 package terraform.gcp.security.gke_hub.google_gke_hub_scope_iam_binding.no_public_principals_binding
-import data.terraform.gcp.helpers
+import data.terraform.helpers
 import data.terraform.gcp.security.gke_hub.google_gke_hub_scope_iam_binding.vars
 
 conditions := [

--- a/policies/gcp/GKEHub/google_gke_hub_scope_iam_member/no_public_principals_member/policy.rego
+++ b/policies/gcp/GKEHub/google_gke_hub_scope_iam_member/no_public_principals_member/policy.rego
@@ -1,5 +1,5 @@
 package terraform.gcp.security.gke_hub.google_gke_hub_scope_iam_member.no_public_principals_member
-import data.terraform.gcp.helpers
+import data.terraform.helpers
 import data.terraform.gcp.security.gke_hub.google_gke_hub_scope_iam_member.vars
 
 conditions := [

--- a/policies/gcp/GKEHub/google_gke_hub_scope_iam_policy/no_public_principals_policy/policy.rego
+++ b/policies/gcp/GKEHub/google_gke_hub_scope_iam_policy/no_public_principals_policy/policy.rego
@@ -1,5 +1,5 @@
 package terraform.gcp.security.gke_hub.google_gke_hub_scope_iam_policy.no_public_principals_policy
-import data.terraform.gcp.helpers
+import data.terraform.helpers
 import data.terraform.gcp.security.gke_hub.google_gke_hub_scope_iam_policy.vars
 
 conditions := [

--- a/policies/gcp/access_approval/google_folder_access_approval_settings/enrolled_services/policy.rego
+++ b/policies/gcp/access_approval/google_folder_access_approval_settings/enrolled_services/policy.rego
@@ -1,6 +1,6 @@
 package terraform.gcp.security.access_approval.google_folder_access_approval_settings.enrolled_services
 
-import data.terraform.gcp.helpers
+import data.terraform.helpers
 import data.terraform.gcp.security.access_approval.google_folder_access_approval_settings.vars
 
 conditions := [[

--- a/policies/gcp/access_approval/google_folder_access_approval_settings/enrollment_level/policy.rego
+++ b/policies/gcp/access_approval/google_folder_access_approval_settings/enrollment_level/policy.rego
@@ -1,6 +1,6 @@
 package terraform.gcp.security.access_approval.google_folder_access_approval_settings.enrollment_level
 
-import data.terraform.gcp.helpers
+import data.terraform.helpers
 import data.terraform.gcp.security.access_approval.google_folder_access_approval_settings.vars
 
 conditions := [[

--- a/policies/gcp/access_approval/google_organization_access_approval_settings/enrolled_services/policy.rego
+++ b/policies/gcp/access_approval/google_organization_access_approval_settings/enrolled_services/policy.rego
@@ -1,6 +1,6 @@
 package terraform.gcp.security.access_approval.google_organization_access_approval_settings.enrolled_services
 
-import data.terraform.gcp.helpers
+import data.terraform.helpers
 import data.terraform.gcp.security.access_approval.google_organization_access_approval_settings.vars
 
 conditions := [[

--- a/policies/gcp/access_approval/google_project_access_approval_settings/enrolled_services/policy.rego
+++ b/policies/gcp/access_approval/google_project_access_approval_settings/enrolled_services/policy.rego
@@ -1,6 +1,6 @@
 package terraform.gcp.security.access_approval.google_project_access_approval_settings.enrolled_services
 
-import data.terraform.gcp.helpers
+import data.terraform.helpers
 import data.terraform.gcp.security.access_approval.google_project_access_approval_settings.vars
 
 conditions := [[

--- a/policies/gcp/api_hub/google_apihub_api_hub_instance/config_encryption_type/policy.rego
+++ b/policies/gcp/api_hub/google_apihub_api_hub_instance/config_encryption_type/policy.rego
@@ -1,6 +1,6 @@
 package terraform.gcp.security.api_hub.google_apihub_api_hub_instance.config_encryption_type
 
-import data.terraform.gcp.helpers
+import data.terraform.helpers
 import data.terraform.gcp.security.api_hub.google_apihub_api_hub_instance.vars
 
 conditions := [

--- a/policies/gcp/api_hub/google_apihub_api_hub_instance/config_enforce_cmek_key_name/policy.rego
+++ b/policies/gcp/api_hub/google_apihub_api_hub_instance/config_enforce_cmek_key_name/policy.rego
@@ -1,6 +1,6 @@
 package terraform.gcp.security.api_hub.google_apihub_api_hub_instance.config_enforce_cmek_key_name
 
-import data.terraform.gcp.helpers
+import data.terraform.helpers
 import data.terraform.gcp.security.api_hub.google_apihub_api_hub_instance.vars
 
 conditions := [

--- a/policies/gcp/api_hub/google_apihub_api_hub_instance/disable_search/policy.rego
+++ b/policies/gcp/api_hub/google_apihub_api_hub_instance/disable_search/policy.rego
@@ -1,6 +1,6 @@
 package terraform.gcp.security.api_hub.google_apihub_api_hub_instance.disable_search
 
-import data.terraform.gcp.helpers
+import data.terraform.helpers
 import data.terraform.gcp.security.api_hub.google_apihub_api_hub_instance.vars
 
 conditions := [

--- a/policies/gcp/api_hub/google_apihub_api_hub_instance/location/policy.rego
+++ b/policies/gcp/api_hub/google_apihub_api_hub_instance/location/policy.rego
@@ -1,6 +1,6 @@
 package terraform.gcp.security.api_hub.google_apihub_api_hub_instance.location
 
-import data.terraform.gcp.helpers
+import data.terraform.helpers
 import data.terraform.gcp.security.api_hub.google_apihub_api_hub_instance.vars
 
 conditions := [

--- a/policies/gcp/api_hub/google_apihub_curation/endpoint_application_integration_endpoint_details_approved_trigger_id/policy.rego
+++ b/policies/gcp/api_hub/google_apihub_curation/endpoint_application_integration_endpoint_details_approved_trigger_id/policy.rego
@@ -1,6 +1,6 @@
 package terraform.gcp.security.api_hub.google_apihub_curation.endpoint_application_integration_endpoint_details_approved_trigger_id
 
-import data.terraform.gcp.helpers
+import data.terraform.helpers
 import data.terraform.gcp.security.api_hub.google_apihub_curation.vars
 
 conditions := [

--- a/policies/gcp/api_hub/google_apihub_curation/endpoint_application_integration_endpoint_details_approved_uri_pattern/policy.rego
+++ b/policies/gcp/api_hub/google_apihub_curation/endpoint_application_integration_endpoint_details_approved_uri_pattern/policy.rego
@@ -1,6 +1,6 @@
 package terraform.gcp.security.api_hub.google_apihub_curation.endpoint_application_integration_endpoint_details_approved_uri_pattern
 
-import data.terraform.gcp.helpers
+import data.terraform.helpers
 import data.terraform.gcp.security.api_hub.google_apihub_curation.vars
 
 conditions := [

--- a/policies/gcp/api_hub/google_apihub_plugin/allowed_service_account/policy.rego
+++ b/policies/gcp/api_hub/google_apihub_plugin/allowed_service_account/policy.rego
@@ -1,6 +1,6 @@
 package terraform.gcp.security.api_hub.google_apihub_plugin.allowed_service_account
 
-import data.terraform.gcp.helpers
+import data.terraform.helpers
 import data.terraform.gcp.security.api_hub.google_apihub_plugin.vars
 
 conditions := [

--- a/policies/gcp/api_hub/google_apihub_plugin/allowed_supported_auth_types/policy.rego
+++ b/policies/gcp/api_hub/google_apihub_plugin/allowed_supported_auth_types/policy.rego
@@ -1,6 +1,6 @@
 package terraform.gcp.security.api_hub.google_apihub_plugin.allowed_supported_auth_types
 
-import data.terraform.gcp.helpers
+import data.terraform.helpers
 import data.terraform.gcp.security.api_hub.google_apihub_plugin.vars
 
 conditions := [

--- a/policies/gcp/api_hub/google_apihub_plugin_instance/allowed_encryption_type/policy.rego
+++ b/policies/gcp/api_hub/google_apihub_plugin_instance/allowed_encryption_type/policy.rego
@@ -1,6 +1,6 @@
 package terraform.gcp.security.api_hub.google_apihub_plugin_instance.allowed_encryption_type
 
-import data.terraform.gcp.helpers
+import data.terraform.helpers
 import data.terraform.gcp.security.api_hub.google_apihub_plugin_instance.vars
 
 conditions := [

--- a/policies/gcp/api_hub/google_apihub_plugin_instance/force_enable_plugin/policy.rego
+++ b/policies/gcp/api_hub/google_apihub_plugin_instance/force_enable_plugin/policy.rego
@@ -1,6 +1,6 @@
 package terraform.gcp.security.api_hub.google_apihub_plugin_instance.force_enable_plugin
 
-import data.terraform.gcp.helpers
+import data.terraform.helpers
 import data.terraform.gcp.security.api_hub.google_apihub_plugin_instance.vars
 
 conditions := [

--- a/policies/gcp/application_integration/google_integrations_auth_config/allowed_location/policy.rego
+++ b/policies/gcp/application_integration/google_integrations_auth_config/allowed_location/policy.rego
@@ -1,6 +1,6 @@
 package terraform.gcp.security.application_integration.google_integrations_auth_config.allowed_location
 
-import data.terraform.gcp.helpers
+import data.terraform.helpers
 import data.terraform.gcp.security.application_integration.google_integrations_auth_config.vars
 
 conditions := [

--- a/policies/gcp/application_integration/google_integrations_auth_config/decrypted_credential/auth_token/token/policy.rego
+++ b/policies/gcp/application_integration/google_integrations_auth_config/decrypted_credential/auth_token/token/policy.rego
@@ -1,6 +1,6 @@
 package terraform.gcp.security.application_integration.google_integrations_auth_config.decrypted_credential.auth_token.token
 
-import data.terraform.gcp.helpers
+import data.terraform.helpers
 import data.terraform.gcp.security.application_integration.google_integrations_auth_config.vars
 
 conditions := [

--- a/policies/gcp/application_integration/google_integrations_auth_config/decrypted_credential/auth_token/type/policy.rego
+++ b/policies/gcp/application_integration/google_integrations_auth_config/decrypted_credential/auth_token/type/policy.rego
@@ -1,6 +1,6 @@
 package terraform.gcp.security.application_integration.google_integrations_auth_config.decrypted_credential.auth_token.type
 
-import data.terraform.gcp.helpers
+import data.terraform.helpers
 import data.terraform.gcp.security.application_integration.google_integrations_auth_config.vars
 
 conditions := [

--- a/policies/gcp/application_integration/google_integrations_auth_config/decrypted_credential/credential_type/policy.rego
+++ b/policies/gcp/application_integration/google_integrations_auth_config/decrypted_credential/credential_type/policy.rego
@@ -1,6 +1,6 @@
 package terraform.gcp.security.application_integration.google_integrations_auth_config.decrypted_credential.credential_type
 
-import data.terraform.gcp.helpers
+import data.terraform.helpers
 import data.terraform.gcp.security.application_integration.google_integrations_auth_config.vars
 
 conditions := [

--- a/policies/gcp/application_integration/google_integrations_auth_config/decrypted_credential/jwt/jwt_header/policy.rego
+++ b/policies/gcp/application_integration/google_integrations_auth_config/decrypted_credential/jwt/jwt_header/policy.rego
@@ -1,6 +1,6 @@
 package terraform.gcp.security.application_integration.google_integrations_auth_config.decrypted_credential.jwt.jwt_header
 
-import data.terraform.gcp.helpers
+import data.terraform.helpers
 import data.terraform.gcp.security.application_integration.google_integrations_auth_config.vars
 
 conditions := [

--- a/policies/gcp/application_integration/google_integrations_auth_config/decrypted_credential/oauth2_client_credentials/client_secret/policy.rego
+++ b/policies/gcp/application_integration/google_integrations_auth_config/decrypted_credential/oauth2_client_credentials/client_secret/policy.rego
@@ -1,6 +1,6 @@
 package terraform.gcp.security.application_integration.google_integrations_auth_config.decrypted_credential.oauth2_client_credentials.client_secret
 
-import data.terraform.gcp.helpers
+import data.terraform.helpers
 import data.terraform.gcp.security.application_integration.google_integrations_auth_config.vars
 
 conditions := [

--- a/policies/gcp/application_integration/google_integrations_auth_config/decrypted_credential/oauth2_client_credentials/request_type/policy.rego
+++ b/policies/gcp/application_integration/google_integrations_auth_config/decrypted_credential/oauth2_client_credentials/request_type/policy.rego
@@ -1,6 +1,6 @@
 package terraform.gcp.security.application_integration.google_integrations_auth_config.decrypted_credential.oauth2_client_credentials.request_type
 
-import data.terraform.gcp.helpers
+import data.terraform.helpers
 import data.terraform.gcp.security.application_integration.google_integrations_auth_config.vars
 
 conditions := [

--- a/policies/gcp/application_integration/google_integrations_auth_config/visibility/policy.rego
+++ b/policies/gcp/application_integration/google_integrations_auth_config/visibility/policy.rego
@@ -1,6 +1,6 @@
 package terraform.gcp.security.application_integration.google_integrations_auth_config.visibility
 
-import data.terraform.gcp.helpers
+import data.terraform.helpers
 import data.terraform.gcp.security.application_integration.google_integrations_auth_config.vars
 
 conditions := [

--- a/policies/gcp/application_integration/google_integrations_client/allowed_location/policy.rego
+++ b/policies/gcp/application_integration/google_integrations_client/allowed_location/policy.rego
@@ -1,6 +1,6 @@
 package terraform.gcp.security.application_integration.google_integrations_client.allowed_location
 
-import data.terraform.gcp.helpers
+import data.terraform.helpers
 import data.terraform.gcp.security.application_integration.google_integrations_client.vars
 
 conditions := [

--- a/policies/gcp/application_integration/google_integrations_client/cloud_kms_config/allowed_kms_location/policy.rego
+++ b/policies/gcp/application_integration/google_integrations_client/cloud_kms_config/allowed_kms_location/policy.rego
@@ -1,6 +1,6 @@
 package terraform.gcp.security.application_integration.google_integrations_client.cloud_kms_config.allowed_kms_location
 
-import data.terraform.gcp.helpers
+import data.terraform.helpers
 import data.terraform.gcp.security.application_integration.google_integrations_client.vars
 
 conditions := [

--- a/policies/gcp/application_integration/google_integrations_client/cloud_kms_config/key/policy.rego
+++ b/policies/gcp/application_integration/google_integrations_client/cloud_kms_config/key/policy.rego
@@ -1,6 +1,6 @@
 package terraform.gcp.security.application_integration.google_integrations_client.cloud_kms_config.key
 
-import data.terraform.gcp.helpers
+import data.terraform.helpers
 import data.terraform.gcp.security.application_integration.google_integrations_client.vars
 
 conditions := [

--- a/policies/gcp/application_integration/google_integrations_client/cloud_kms_config/kms_ring/policy.rego
+++ b/policies/gcp/application_integration/google_integrations_client/cloud_kms_config/kms_ring/policy.rego
@@ -1,6 +1,6 @@
 package terraform.gcp.security.application_integration.google_integrations_client.cloud_kms_config.kms_ring
 
-import data.terraform.gcp.helpers
+import data.terraform.helpers
 import data.terraform.gcp.security.application_integration.google_integrations_client.vars
 
 # Define the conditions for valid kms_ring

--- a/policies/gcp/beyondcorp/google_beyondcorp_app_connection/port_whitelist/policy.rego
+++ b/policies/gcp/beyondcorp/google_beyondcorp_app_connection/port_whitelist/policy.rego
@@ -1,6 +1,6 @@
 package terraform.gcp.security.beyondcorp.google_beyondcorp_app_connection.port_whitelist
 
-import data.terraform.gcp.helpers
+import data.terraform.helpers
 import data.terraform.gcp.security.beyondcorp.google_beyondcorp_app_connection.vars
 
 conditions := [

--- a/policies/gcp/beyondcorp/google_beyondcorp_app_connection/region_whitelist/policy.rego
+++ b/policies/gcp/beyondcorp/google_beyondcorp_app_connection/region_whitelist/policy.rego
@@ -1,7 +1,7 @@
 
 package terraform.gcp.security.beyondcorp.google_beyondcorp_app_connection.region_whitelist
 
-import data.terraform.gcp.helpers
+import data.terraform.helpers
 import data.terraform.gcp.security.beyondcorp.google_beyondcorp_app_connection.vars
 
 conditions := [

--- a/policies/gcp/beyondcorp/google_beyondcorp_app_connector/region_whitelist/policy.rego
+++ b/policies/gcp/beyondcorp/google_beyondcorp_app_connector/region_whitelist/policy.rego
@@ -1,7 +1,7 @@
 
 package terraform.gcp.security.beyondcorp.google_beyondcorp_app_connector.region_whitelist
 
-import data.terraform.gcp.helpers
+import data.terraform.helpers
 import data.terraform.gcp.security.beyondcorp.google_beyondcorp_app_connector.vars
 
 conditions := [

--- a/policies/gcp/beyondcorp/google_beyondcorp_app_connector/service_account_whitelist/policy.rego
+++ b/policies/gcp/beyondcorp/google_beyondcorp_app_connector/service_account_whitelist/policy.rego
@@ -1,6 +1,6 @@
 package terraform.gcp.security.beyondcorp.google_beyondcorp_app_connector.service_account_whitelist
 
-import data.terraform.gcp.helpers
+import data.terraform.helpers
 import data.terraform.gcp.security.beyondcorp.google_beyondcorp_app_connector.vars
 
 conditions := [

--- a/policies/gcp/beyondcorp/google_beyondcorp_app_gateway/host_type_whitelist/policy.rego
+++ b/policies/gcp/beyondcorp/google_beyondcorp_app_gateway/host_type_whitelist/policy.rego
@@ -1,6 +1,6 @@
 package terraform.gcp.security.beyondcorp.google_beyondcorp_app_gateway.host_type_whitelist
 
-import data.terraform.gcp.helpers
+import data.terraform.helpers
 import data.terraform.gcp.security.beyondcorp.google_beyondcorp_app_gateway.vars
 
 conditions := [

--- a/policies/gcp/beyondcorp/google_beyondcorp_app_gateway/region_whitelist/policy.rego
+++ b/policies/gcp/beyondcorp/google_beyondcorp_app_gateway/region_whitelist/policy.rego
@@ -1,6 +1,6 @@
 package terraform.gcp.security.beyondcorp.google_beyondcorp_app_gateway.region_whitelist
 
-import data.terraform.gcp.helpers
+import data.terraform.helpers
 import data.terraform.gcp.security.beyondcorp.google_beyondcorp_app_gateway.vars
 
 conditions := [

--- a/policies/gcp/beyondcorp/google_beyondcorp_security_gateway/hubs_region_whitelist/policy.rego
+++ b/policies/gcp/beyondcorp/google_beyondcorp_security_gateway/hubs_region_whitelist/policy.rego
@@ -1,6 +1,6 @@
 package terraform.gcp.security.beyondcorp.google_beyondcorp_security_gateway.hubs_region_whitelist
 
-import data.terraform.gcp.helpers
+import data.terraform.helpers
 import data.terraform.gcp.security.beyondcorp.google_beyondcorp_security_gateway.vars
 
 conditions := [

--- a/policies/gcp/beyondcorp/google_beyondcorp_security_gateway_application/endpoint_hostname_whitelist/policy.rego
+++ b/policies/gcp/beyondcorp/google_beyondcorp_security_gateway_application/endpoint_hostname_whitelist/policy.rego
@@ -1,6 +1,6 @@
 package terraform.gcp.security.beyondcorp.google_beyondcorp_security_gateway_application.endpoint_hostname_whitelist
 
-import data.terraform.gcp.helpers
+import data.terraform.helpers
 import data.terraform.gcp.security.beyondcorp.google_beyondcorp_security_gateway_application.vars
 
 conditions := [

--- a/policies/gcp/beyondcorp/google_beyondcorp_security_gateway_application/upstreams_whitelist/policy.rego
+++ b/policies/gcp/beyondcorp/google_beyondcorp_security_gateway_application/upstreams_whitelist/policy.rego
@@ -1,6 +1,6 @@
 package terraform.gcp.security.beyondcorp.google_beyondcorp_security_gateway_application.upstreams_whitelist
 
-import data.terraform.gcp.helpers
+import data.terraform.helpers
 import data.terraform.gcp.security.beyondcorp.google_beyondcorp_security_gateway_application.vars
 
 conditions := [

--- a/policies/gcp/beyondcorp/google_beyondcorp_security_gateway_application_iam_binding/public_access_prevention/policy.rego
+++ b/policies/gcp/beyondcorp/google_beyondcorp_security_gateway_application_iam_binding/public_access_prevention/policy.rego
@@ -1,6 +1,6 @@
 package terraform.gcp.security.beyondcorp.google_beyondcorp_security_gateway_application_iam_binding.public_access_prevention
 
-import data.terraform.gcp.helpers
+import data.terraform.helpers
 import data.terraform.gcp.security.beyondcorp.google_beyondcorp_security_gateway_application_iam_binding.vars
 conditions := [
   [

--- a/policies/gcp/beyondcorp/google_beyondcorp_security_gateway_application_iam_member/public_access_prevention/policy.rego
+++ b/policies/gcp/beyondcorp/google_beyondcorp_security_gateway_application_iam_member/public_access_prevention/policy.rego
@@ -1,5 +1,5 @@
 package terraform.gcp.security.beyondcorp.google_beyondcorp_security_gateway_application_iam_member.public_access_prevention
-import data.terraform.gcp.helpers
+import data.terraform.helpers
 import data.terraform.gcp.security.beyondcorp.google_beyondcorp_security_gateway_application_iam_member.vars
 conditions := [
   [

--- a/policies/gcp/beyondcorp/google_beyondcorp_security_gateway_iam_binding/public_access_prevention/policy.rego
+++ b/policies/gcp/beyondcorp/google_beyondcorp_security_gateway_iam_binding/public_access_prevention/policy.rego
@@ -1,5 +1,5 @@
 package terraform.gcp.security.beyondcorp.google_beyondcorp_security_gateway_iam_binding.public_access_prevention
-import data.terraform.gcp.helpers
+import data.terraform.helpers
 import data.terraform.gcp.security.beyondcorp.google_beyondcorp_security_gateway_iam_binding.vars
 conditions := [
   [

--- a/policies/gcp/beyondcorp/google_beyondcorp_security_gateway_iam_member/public_access_prevention/policy.rego
+++ b/policies/gcp/beyondcorp/google_beyondcorp_security_gateway_iam_member/public_access_prevention/policy.rego
@@ -1,5 +1,5 @@
 package terraform.gcp.security.beyondcorp.google_beyondcorp_security_gateway_iam_member.public_access_prevention
-import data.terraform.gcp.helpers
+import data.terraform.helpers
 import data.terraform.gcp.security.beyondcorp.google_beyondcorp_security_gateway_iam_member.vars
 conditions := [
   [

--- a/policies/gcp/bigquery_data_policy/bigquery_datapolicy_data_policy_iam/location/policy.rego
+++ b/policies/gcp/bigquery_data_policy/bigquery_datapolicy_data_policy_iam/location/policy.rego
@@ -1,5 +1,5 @@
 package terraform.gcp.security.bigquery_data_policy.bigquery_datapolicy_data_policy_iam.location
-import data.terraform.gcp.helpers
+import data.terraform.helpers
 import data.terraform.gcp.security.bigquery_data_policy.bigquery_datapolicy_data_policy_iam.vars
 
 conditions := [

--- a/policies/gcp/bigquery_data_policy/bigquery_datapolicy_data_policy_iam/member/policy.rego
+++ b/policies/gcp/bigquery_data_policy/bigquery_datapolicy_data_policy_iam/member/policy.rego
@@ -1,5 +1,5 @@
 package terraform.gcp.security.bigquery_data_policy.bigquery_datapolicy_data_policy_iam.member
-import data.terraform.gcp.helpers
+import data.terraform.helpers
 import data.terraform.gcp.security.bigquery_data_policy.bigquery_datapolicy_data_policy_iam.vars
 
 conditions := [

--- a/policies/gcp/bigquery_data_policy/google_bigquery_datapolicy_data_policy/data_masking_policy/predefined_expression/policy.rego
+++ b/policies/gcp/bigquery_data_policy/google_bigquery_datapolicy_data_policy/data_masking_policy/predefined_expression/policy.rego
@@ -1,5 +1,5 @@
 package terraform.gcp.security.bigquery_data_policy.google_bigquery_datapolicy_data_policy.data_masking_policy.predefined_expression
-import data.terraform.gcp.helpers
+import data.terraform.helpers
 import data.terraform.gcp.security.bigquery_data_policy.google_bigquery_datapolicy_data_policy.vars
 
 conditions := [

--- a/policies/gcp/bigquery_data_policy/google_bigquery_datapolicy_data_policy/data_policy_type/policy.rego
+++ b/policies/gcp/bigquery_data_policy/google_bigquery_datapolicy_data_policy/data_policy_type/policy.rego
@@ -1,5 +1,5 @@
 package terraform.gcp.security.bigquery_data_policy.google_bigquery_datapolicy_data_policy.data_policy_type
-import data.terraform.gcp.helpers
+import data.terraform.helpers
 import data.terraform.gcp.security.bigquery_data_policy.google_bigquery_datapolicy_data_policy.vars
 
 conditions := [

--- a/policies/gcp/bigquery_data_policy/google_bigquery_datapolicy_data_policy/location/policy.rego
+++ b/policies/gcp/bigquery_data_policy/google_bigquery_datapolicy_data_policy/location/policy.rego
@@ -1,5 +1,5 @@
 package terraform.gcp.security.bigquery_data_policy.google_bigquery_datapolicy_data_policy.location
-import data.terraform.gcp.helpers
+import data.terraform.helpers
 import data.terraform.gcp.security.bigquery_data_policy.google_bigquery_datapolicy_data_policy.vars
 
 conditions := [

--- a/policies/gcp/bigquery_data_transfer/bigquery_data_transfer_config/destination_dataset_id/policy.rego
+++ b/policies/gcp/bigquery_data_transfer/bigquery_data_transfer_config/destination_dataset_id/policy.rego
@@ -1,5 +1,5 @@
 package terraform.gcp.security.bigquery_data_transfer.bigquery_data_transfer_config.destination_dataset_id
-import data.terraform.gcp.helpers
+import data.terraform.helpers
 import data.terraform.gcp.security.bigquery_data_transfer.bigquery_data_transfer_config.vars
 
 conditions := [

--- a/policies/gcp/bigquery_data_transfer/bigquery_data_transfer_config/encryption_configuration/policy.rego
+++ b/policies/gcp/bigquery_data_transfer/bigquery_data_transfer_config/encryption_configuration/policy.rego
@@ -1,5 +1,5 @@
 package terraform.gcp.security.bigquery_data_transfer.bigquery_data_transfer_config.encryption_configuration
-import data.terraform.gcp.helpers
+import data.terraform.helpers
 import data.terraform.gcp.security.bigquery_data_transfer.bigquery_data_transfer_config.vars
 
 conditions := [

--- a/policies/gcp/bigquery_data_transfer/bigquery_data_transfer_config/location/policy.rego
+++ b/policies/gcp/bigquery_data_transfer/bigquery_data_transfer_config/location/policy.rego
@@ -1,5 +1,5 @@
 package terraform.gcp.security.bigquery_data_transfer.bigquery_data_transfer_config.location
-import data.terraform.gcp.helpers
+import data.terraform.helpers
 import data.terraform.gcp.security.bigquery_data_transfer.bigquery_data_transfer_config.vars
 
 conditions := [[

--- a/policies/gcp/binary_authorization/google_binary_authorization_attestor/public_keys/policy.rego
+++ b/policies/gcp/binary_authorization/google_binary_authorization_attestor/public_keys/policy.rego
@@ -1,6 +1,6 @@
 package terraform.gcp.security.binary_authorization.google_binary_authorization_attestor.public_keys
 
-import data.terraform.gcp.helpers
+import data.terraform.helpers
 import data.terraform.gcp.security.binary_authorization.google_binary_authorization_attestor.vars
 
 conditions := [

--- a/policies/gcp/binary_authorization/google_binary_authorization_attestor/signature_algorithm/policy.rego
+++ b/policies/gcp/binary_authorization/google_binary_authorization_attestor/signature_algorithm/policy.rego
@@ -1,6 +1,6 @@
 package terraform.gcp.security.binary_authorization.google_binary_authorization_attestor.signature_algorithm
 
-import data.terraform.gcp.helpers
+import data.terraform.helpers
 import data.terraform.gcp.security.binary_authorization.google_binary_authorization_attestor.vars
 
 conditions := [

--- a/policies/gcp/binary_authorization/google_binary_authorization_attestor_iam/attestor_reference/policy.rego
+++ b/policies/gcp/binary_authorization/google_binary_authorization_attestor_iam/attestor_reference/policy.rego
@@ -1,6 +1,6 @@
 package terraform.gcp.security.binary_authorization.google_binary_authorization_attestor_iam.attestor_reference
 
-import data.terraform.gcp.helpers
+import data.terraform.helpers
 import data.terraform.gcp.security.binary_authorization.google_binary_authorization_attestor_iam.vars
 
 conditions := [

--- a/policies/gcp/binary_authorization/google_binary_authorization_attestor_iam/authorized_role/policy.rego
+++ b/policies/gcp/binary_authorization/google_binary_authorization_attestor_iam/authorized_role/policy.rego
@@ -1,6 +1,6 @@
 package terraform.gcp.security.binary_authorization.google_binary_authorization_attestor_iam.authorized_role
 
-import data.terraform.gcp.helpers
+import data.terraform.helpers
 import data.terraform.gcp.security.binary_authorization.google_binary_authorization_attestor_iam.vars
 
 

--- a/policies/gcp/binary_authorization/google_binary_authorization_attestor_iam/required_member/policy.rego
+++ b/policies/gcp/binary_authorization/google_binary_authorization_attestor_iam/required_member/policy.rego
@@ -1,6 +1,6 @@
 package terraform.gcp.security.binary_authorization.google_binary_authorization_attestor_iam.required_member
 
-import data.terraform.gcp.helpers
+import data.terraform.helpers
 import data.terraform.gcp.security.binary_authorization.google_binary_authorization_attestor_iam.vars
 
 conditions := [

--- a/policies/gcp/binary_authorization/google_binary_authorization_policy/audit_log_required/policy.rego
+++ b/policies/gcp/binary_authorization/google_binary_authorization_policy/audit_log_required/policy.rego
@@ -1,6 +1,6 @@
 package terraform.gcp.security.binary_authorization.google_binary_authorization_policy.audit_log_required
 
-import data.terraform.gcp.helpers
+import data.terraform.helpers
 import data.terraform.gcp.security.binary_authorization.google_binary_authorization_policy.vars
 
 conditions := [

--- a/policies/gcp/binary_authorization/google_binary_authorization_policy/cluster_admission_rule/policy.rego
+++ b/policies/gcp/binary_authorization/google_binary_authorization_policy/cluster_admission_rule/policy.rego
@@ -1,6 +1,6 @@
 package terraform.gcp.security.binary_authorization.google_binary_authorization_policy.cluster_admission_rule
 
-import data.terraform.gcp.helpers
+import data.terraform.helpers
 import data.terraform.gcp.security.binary_authorization.google_binary_authorization_policy.vars
 
 conditions := [

--- a/policies/gcp/binary_authorization/google_binary_authorization_policy/default_admission_rule/policy.rego
+++ b/policies/gcp/binary_authorization/google_binary_authorization_policy/default_admission_rule/policy.rego
@@ -1,6 +1,6 @@
 package terraform.gcp.security.binary_authorization.google_binary_authorization_policy.default_admission_rule
 
-import data.terraform.gcp.helpers
+import data.terraform.helpers
 import data.terraform.gcp.security.binary_authorization.google_binary_authorization_policy.vars
 
 conditions := [

--- a/policies/gcp/binary_authorization/google_binary_authorization_policy/require_attestations_by/policy.rego
+++ b/policies/gcp/binary_authorization/google_binary_authorization_policy/require_attestations_by/policy.rego
@@ -1,6 +1,6 @@
 package terraform.gcp.security.binary_authorization.google_binary_authorization_policy.require_attestations_by
 
-import data.terraform.gcp.helpers
+import data.terraform.helpers
 import data.terraform.gcp.security.binary_authorization.google_binary_authorization_policy.vars
 
 conditions := [

--- a/policies/gcp/chronicle/chronicle_rule/allowed_location/policy.rego
+++ b/policies/gcp/chronicle/chronicle_rule/allowed_location/policy.rego
@@ -1,5 +1,5 @@
 package terraform.gcp.security.chronicle.chronicle_rule.allowed_location
-import data.terraform.gcp.helpers
+import data.terraform.helpers
 import data.terraform.gcp.security.chronicle.chronicle_rule.vars
 
 

--- a/policies/gcp/chronicle/chronicle_rule/allowed_scope/policy.rego
+++ b/policies/gcp/chronicle/chronicle_rule/allowed_scope/policy.rego
@@ -1,6 +1,6 @@
 package terraform.gcp.security.chronicle.chronicle_rule.allowed_scope
 
-import data.terraform.gcp.helpers
+import data.terraform.helpers
 import data.terraform.gcp.security.chronicle.chronicle_rule.vars
 
 conditions := [

--- a/policies/gcp/chronicle/data_access_label/allowed_location/policy.rego
+++ b/policies/gcp/chronicle/data_access_label/allowed_location/policy.rego
@@ -1,5 +1,5 @@
 package terraform.gcp.security.chronicle.data_access_label.allowed_location
-import data.terraform.gcp.helpers
+import data.terraform.helpers
 import data.terraform.gcp.security.chronicle.data_access_label.vars
 
 

--- a/policies/gcp/chronicle/data_access_label/udm_query/policy.rego
+++ b/policies/gcp/chronicle/data_access_label/udm_query/policy.rego
@@ -1,6 +1,6 @@
 package terraform.gcp.security.chronicle.data_access_label.udm_query
 
-import data.terraform.gcp.helpers
+import data.terraform.helpers
 import data.terraform.gcp.security.chronicle.data_access_label.vars
 
 conditions := [

--- a/policies/gcp/chronicle/data_access_scope/allowed_location/policy.rego
+++ b/policies/gcp/chronicle/data_access_scope/allowed_location/policy.rego
@@ -1,5 +1,5 @@
 package terraform.gcp.security.chronicle.data_access_scope.allowed_location
-import data.terraform.gcp.helpers
+import data.terraform.helpers
 import data.terraform.gcp.security.chronicle.data_access_scope.vars
 
 

--- a/policies/gcp/chronicle/data_access_scope/secure_data_access_scope_configuration/policy.rego
+++ b/policies/gcp/chronicle/data_access_scope/secure_data_access_scope_configuration/policy.rego
@@ -1,6 +1,6 @@
 package terraform.gcp.security.chronicle.data_access_scope.secure_data_access_scope_configuration
 
-import data.terraform.gcp.helpers
+import data.terraform.helpers
 import data.terraform.gcp.security.chronicle.data_access_scope.vars
 
 conditions := [

--- a/policies/gcp/chronicle/reference_list/allowed_location/policy.rego
+++ b/policies/gcp/chronicle/reference_list/allowed_location/policy.rego
@@ -1,5 +1,5 @@
 package terraform.gcp.security.chronicle.reference_list.allowed_location
-import data.terraform.gcp.helpers
+import data.terraform.helpers
 import data.terraform.gcp.security.chronicle.reference_list.vars
 
 

--- a/policies/gcp/chronicle/retrohunt/allowed_location/policy.rego
+++ b/policies/gcp/chronicle/retrohunt/allowed_location/policy.rego
@@ -1,5 +1,5 @@
 package terraform.gcp.security.chronicle.retrohunt.allowed_location
-import data.terraform.gcp.helpers
+import data.terraform.helpers
 import data.terraform.gcp.security.chronicle.retrohunt.vars
 
 

--- a/policies/gcp/chronicle/rule_deployment/allowed_location/policy.rego
+++ b/policies/gcp/chronicle/rule_deployment/allowed_location/policy.rego
@@ -1,5 +1,5 @@
 package terraform.gcp.security.chronicle.rule_deployment.allowed_location
-import data.terraform.gcp.helpers
+import data.terraform.helpers
 import data.terraform.gcp.security.chronicle.rule_deployment.vars
 
 

--- a/policies/gcp/chronicle/rule_deployment/detect_alerts/policy.rego
+++ b/policies/gcp/chronicle/rule_deployment/detect_alerts/policy.rego
@@ -1,6 +1,6 @@
 package terraform.gcp.security.chronicle.rule_deployment.detect_alerts
 
-import data.terraform.gcp.helpers
+import data.terraform.helpers
 import data.terraform.gcp.security.chronicle.rule_deployment.vars
 
 conditions := [

--- a/policies/gcp/chronicle/rule_deployment/rule_deployment_enabled/policy.rego
+++ b/policies/gcp/chronicle/rule_deployment/rule_deployment_enabled/policy.rego
@@ -1,6 +1,6 @@
 package terraform.gcp.security.chronicle.rule_deployment.rule_deployment_enabled
 
-import data.terraform.gcp.helpers
+import data.terraform.helpers
 import data.terraform.gcp.security.chronicle.rule_deployment.vars
 
 conditions := [

--- a/policies/gcp/chronicle/watchlist/allowed_location/policy.rego
+++ b/policies/gcp/chronicle/watchlist/allowed_location/policy.rego
@@ -1,5 +1,5 @@
 package terraform.gcp.security.chronicle.watchlist.allowed_location
-import data.terraform.gcp.helpers
+import data.terraform.helpers
 import data.terraform.gcp.security.chronicle.watchlist.vars
 
 

--- a/policies/gcp/chronicle/watchlist/disallow_manual_entity_population/policy.rego
+++ b/policies/gcp/chronicle/watchlist/disallow_manual_entity_population/policy.rego
@@ -1,6 +1,6 @@
 package terraform.gcp.security.chronicle.watchlist.disallow_manual_entity_population
 
-import data.terraform.gcp.helpers
+import data.terraform.helpers
 import data.terraform.gcp.security.chronicle.watchlist.vars
 
 conditions := [

--- a/policies/gcp/chronicle/watchlist/multiplying_factor/policy.rego
+++ b/policies/gcp/chronicle/watchlist/multiplying_factor/policy.rego
@@ -1,6 +1,6 @@
 package terraform.gcp.security.chronicle.watchlist.multiplying_factor
 
-import data.terraform.gcp.helpers
+import data.terraform.helpers
 import data.terraform.gcp.security.chronicle.watchlist.vars
 
 conditions := [

--- a/policies/gcp/cloud_deployment_manager/google_deployment_manager_deployment/create_policy/policy.rego
+++ b/policies/gcp/cloud_deployment_manager/google_deployment_manager_deployment/create_policy/policy.rego
@@ -1,5 +1,5 @@
 package terraform.gcp.security.cloud_deployment_manager.google_deployment_manager_deployment.create_policy
-import data.terraform.gcp.helpers
+import data.terraform.helpers
 import data.terraform.gcp.security.cloud_deployment_manager.google_deployment_manager_deployment.vars
 
 conditions := [

--- a/policies/gcp/cloud_deployment_manager/google_deployment_manager_deployment/delete_policy/policy.rego
+++ b/policies/gcp/cloud_deployment_manager/google_deployment_manager_deployment/delete_policy/policy.rego
@@ -1,5 +1,5 @@
 package terraform.gcp.security.cloud_deployment_manager.google_deployment_manager_deployment.delete_policy
-import data.terraform.gcp.helpers
+import data.terraform.helpers
 import data.terraform.gcp.security.cloud_deployment_manager.google_deployment_manager_deployment.vars
 
 conditions := [

--- a/policies/gcp/cloud_deployment_manager/google_deployment_manager_deployment/preview/policy.rego
+++ b/policies/gcp/cloud_deployment_manager/google_deployment_manager_deployment/preview/policy.rego
@@ -1,5 +1,5 @@
 package terraform.gcp.security.cloud_deployment_manager.google_deployment_manager_deployment.preview
-import data.terraform.gcp.helpers
+import data.terraform.helpers
 import data.terraform.gcp.security.cloud_deployment_manager.google_deployment_manager_deployment.vars
 
 conditions := [

--- a/policies/gcp/cloud_platform_service/google_folder/deletion_protection/policy.rego
+++ b/policies/gcp/cloud_platform_service/google_folder/deletion_protection/policy.rego
@@ -1,6 +1,6 @@
 package terraform.gcp.security.cloud_platform_service.google_folder.deletion_protection
 
-import data.terraform.gcp.helpers
+import data.terraform.helpers
 import data.terraform.gcp.security.cloud_platform_service.google_folder.vars
 
 conditions := [

--- a/policies/gcp/cloud_platform_service/google_folder_iam_audit_config/audit_config/policy.rego
+++ b/policies/gcp/cloud_platform_service/google_folder_iam_audit_config/audit_config/policy.rego
@@ -1,5 +1,5 @@
 package terraform.gcp.security.cloud_platform_service.google_folder_iam_audit_config.audit_config
-import data.terraform.gcp.helpers
+import data.terraform.helpers
 import data.terraform.gcp.security.cloud_platform_service.google_folder_iam_audit_config.vars
 
 

--- a/policies/gcp/cloud_platform_service/google_folder_iam_binding/iam_binding/policy.rego
+++ b/policies/gcp/cloud_platform_service/google_folder_iam_binding/iam_binding/policy.rego
@@ -1,5 +1,5 @@
 package terraform.gcp.security.cloud_platform_service.google_folder_iam_binding.iam_binding
-import data.terraform.gcp.helpers
+import data.terraform.helpers
 import data.terraform.gcp.security.cloud_platform_service.google_folder_iam_binding.vars
 
 conditions := [

--- a/policies/gcp/cloud_platform_service/google_folder_iam_member/iam_member/policy.rego
+++ b/policies/gcp/cloud_platform_service/google_folder_iam_member/iam_member/policy.rego
@@ -1,5 +1,5 @@
 package terraform.gcp.security.cloud_platform_service.google_folder_iam_member.iam_member
-import data.terraform.gcp.helpers
+import data.terraform.helpers
 import data.terraform.gcp.security.cloud_platform_service.google_folder_iam_member.vars
 
 conditions := [

--- a/policies/gcp/cloud_platform_service/google_folder_iam_policy/policy_data/policy.rego
+++ b/policies/gcp/cloud_platform_service/google_folder_iam_policy/policy_data/policy.rego
@@ -1,5 +1,5 @@
 package terraform.gcp.security.cloud_platform_service.google_folder_iam_policy.policy_data
-import data.terraform.gcp.helpers
+import data.terraform.helpers
 import data.terraform.gcp.security.cloud_platform_service.google_folder_iam_policy.vars
 
 conditions := [

--- a/policies/gcp/cloud_platform_service/google_folder_organization_policy/constraint/policy.rego
+++ b/policies/gcp/cloud_platform_service/google_folder_organization_policy/constraint/policy.rego
@@ -1,5 +1,5 @@
 package terraform.gcp.security.cloud_platform_service.google_folder_organization_policy.constraint
-import data.terraform.gcp.helpers
+import data.terraform.helpers
 import data.terraform.gcp.security.cloud_platform_service.google_folder_organization_policy.vars
 
 conditions := [

--- a/policies/gcp/cloud_platform_service/google_organization_iam_custom_role/stage/policy.rego
+++ b/policies/gcp/cloud_platform_service/google_organization_iam_custom_role/stage/policy.rego
@@ -1,6 +1,6 @@
 package terraform.gcp.security.cloud_platform_service.google_organization_iam_custom_role.stage
 
-import data.terraform.gcp.helpers
+import data.terraform.helpers
 import data.terraform.gcp.security.cloud_platform_service.google_organization_iam_custom_role.vars
 
 conditions := [

--- a/policies/gcp/cloud_platform_service/google_project/auto_create_network/policy.rego
+++ b/policies/gcp/cloud_platform_service/google_project/auto_create_network/policy.rego
@@ -1,6 +1,6 @@
 package terraform.gcp.security.cloud_platform_service.google_project.auto_create_network
 
-import data.terraform.gcp.helpers
+import data.terraform.helpers
 import data.terraform.gcp.security.cloud_platform_service.google_project.vars
 
 # Enforce: auto_create_network must be false

--- a/policies/gcp/cloud_platform_service/google_project/billing_account/policy.rego
+++ b/policies/gcp/cloud_platform_service/google_project/billing_account/policy.rego
@@ -1,6 +1,6 @@
 package terraform.gcp.security.cloud_platform_service.google_project.billing_account
 
-import data.terraform.gcp.helpers
+import data.terraform.helpers
 import data.terraform.gcp.security.cloud_platform_service.google_project.vars
 
 # Flag projects that have no billing account attached

--- a/policies/gcp/cloud_platform_service/google_project/deletion_policy/policy.rego
+++ b/policies/gcp/cloud_platform_service/google_project/deletion_policy/policy.rego
@@ -1,6 +1,6 @@
 package terraform.gcp.security.cloud_platform_service.google_project.deletion_policy
 
-import data.terraform.gcp.helpers
+import data.terraform.helpers
 import data.terraform.gcp.security.cloud_platform_service.google_project.vars
 
 # Enforce deletion guard at the project level

--- a/policies/gcp/cloud_platform_service/google_project/labels/policy.rego
+++ b/policies/gcp/cloud_platform_service/google_project/labels/policy.rego
@@ -1,6 +1,6 @@
 package terraform.gcp.security.cloud_platform_service.google_project.labels
 
-import data.terraform.gcp.helpers
+import data.terraform.helpers
 import data.terraform.gcp.security.cloud_platform_service.google_project.vars
 
 conditions := [

--- a/policies/gcp/cloud_platform_service/google_project/org_id/policy.rego
+++ b/policies/gcp/cloud_platform_service/google_project/org_id/policy.rego
@@ -1,6 +1,6 @@
 package terraform.gcp.security.cloud_platform_service.google_project.org_id
 
-import data.terraform.gcp.helpers
+import data.terraform.helpers
 import data.terraform.gcp.security.cloud_platform_service.google_project.vars
 
 # Non-compliant when BOTH org_id and folder_id are null.

--- a/policies/gcp/cloud_platform_service/google_project/project_id/policy.rego
+++ b/policies/gcp/cloud_platform_service/google_project/project_id/policy.rego
@@ -1,6 +1,6 @@
 package terraform.gcp.security.cloud_platform_service.google_project.project_id
 
-import data.terraform.gcp.helpers
+import data.terraform.helpers
 import data.terraform.gcp.security.cloud_platform_service.google_project.vars
 
 

--- a/policies/gcp/cloud_platform_service/google_project/tags/policy.rego
+++ b/policies/gcp/cloud_platform_service/google_project/tags/policy.rego
@@ -1,6 +1,6 @@
 package terraform.gcp.security.cloud_platform_service.google_project.tags
 
-import data.terraform.gcp.helpers
+import data.terraform.helpers
 import data.terraform.gcp.security.cloud_platform_service.google_project.vars
 
 # Require env tag with an approved value

--- a/policies/gcp/cloud_platform_service/google_project_default_service_accounts/action/policy.rego
+++ b/policies/gcp/cloud_platform_service/google_project_default_service_accounts/action/policy.rego
@@ -1,6 +1,6 @@
 package terraform.gcp.security.cloud_platform_service.google_project_default_service_accounts.action
 
-import data.terraform.gcp.helpers
+import data.terraform.helpers
 import data.terraform.gcp.security.cloud_platform_service.google_project_default_service_accounts.vars
 
 

--- a/policies/gcp/cloud_platform_service/google_project_service/service/policy.rego
+++ b/policies/gcp/cloud_platform_service/google_project_service/service/policy.rego
@@ -1,6 +1,6 @@
 package terraform.gcp.security.cloud_platform_service.google_project_service.service
 
-import data.terraform.gcp.helpers
+import data.terraform.helpers
 import data.terraform.gcp.security.cloud_platform_service.google_project_service.vars
 
 

--- a/policies/gcp/cloud_platform_service/google_service_account/account_id/policy.rego
+++ b/policies/gcp/cloud_platform_service/google_service_account/account_id/policy.rego
@@ -1,6 +1,6 @@
 package terraform.gcp.security.cloud_platform_service.google_service_account.account_id
 
-import data.terraform.gcp.helpers
+import data.terraform.helpers
 import data.terraform.gcp.security.cloud_platform_service.google_service_account.vars
 
 # (account_id) – single, simple blacklist

--- a/policies/gcp/cloud_platform_service/google_service_account/description/policy.rego
+++ b/policies/gcp/cloud_platform_service/google_service_account/description/policy.rego
@@ -1,6 +1,6 @@
 package terraform.gcp.security.cloud_platform_service.google_service_account.description
 
-import data.terraform.gcp.helpers
+import data.terraform.helpers
 import data.terraform.gcp.security.cloud_platform_service.google_service_account.vars
 
 # Description must not be empty

--- a/policies/gcp/cloud_platform_service/google_service_account/disabled/policy.rego
+++ b/policies/gcp/cloud_platform_service/google_service_account/disabled/policy.rego
@@ -1,6 +1,6 @@
 package terraform.gcp.security.cloud_platform_service.google_service_account.disabled
 
-import data.terraform.gcp.helpers
+import data.terraform.helpers
 import data.terraform.gcp.security.cloud_platform_service.google_service_account.vars
 
 # Disabled on creation – boolean true (not string)

--- a/policies/gcp/cloud_platform_service/google_service_account/display_name/policy.rego
+++ b/policies/gcp/cloud_platform_service/google_service_account/display_name/policy.rego
@@ -1,6 +1,6 @@
 package terraform.gcp.security.cloud_platform_service.google_service_account.display_name
 
-import data.terraform.gcp.helpers
+import data.terraform.helpers
 import data.terraform.gcp.security.cloud_platform_service.google_service_account.vars
 
 # (display_name) – exact matches only

--- a/policies/gcp/cloud_platform_service/google_service_account_key/exposure/policy.rego
+++ b/policies/gcp/cloud_platform_service/google_service_account_key/exposure/policy.rego
@@ -1,6 +1,6 @@
 package terraform.gcp.security.cloud_platform_service.google_service_account_key.exposure
 
-import data.terraform.gcp.helpers
+import data.terraform.helpers
 import data.terraform.gcp.security.cloud_platform_service.google_service_account_key.vars
 
 conditions := [

--- a/policies/gcp/cloud_storage/google_storage_anywhere_cache/zone_whitelist/policy.rego
+++ b/policies/gcp/cloud_storage/google_storage_anywhere_cache/zone_whitelist/policy.rego
@@ -1,6 +1,6 @@
 package terraform.gcp.security.cloud_storage.google_storage_anywhere_cache.zone_whitelist
 
-import data.terraform.gcp.helpers
+import data.terraform.helpers
 import data.terraform.gcp.security.cloud_storage.google_storage_anywhere_cache.vars
 
 conditions := [

--- a/policies/gcp/cloud_storage/google_storage_bucket/allowed_location/policy.rego
+++ b/policies/gcp/cloud_storage/google_storage_bucket/allowed_location/policy.rego
@@ -1,6 +1,6 @@
 package terraform.gcp.security.cloud_storage.google_storage_bucket.allowed_location
 
-import data.terraform.gcp.helpers
+import data.terraform.helpers
 import data.terraform.gcp.security.cloud_storage.google_storage_bucket.vars
 
 conditions := [

--- a/policies/gcp/cloud_storage/google_storage_bucket/block_broad_cors/policy.rego
+++ b/policies/gcp/cloud_storage/google_storage_bucket/block_broad_cors/policy.rego
@@ -1,6 +1,6 @@
 package terraform.gcp.security.cloud_storage.google_storage_bucket.block_broad_cors
 
-import data.terraform.gcp.helpers
+import data.terraform.helpers
 import data.terraform.gcp.security.cloud_storage.google_storage_bucket.vars
 
 

--- a/policies/gcp/cloud_storage/google_storage_bucket/encryption/policy.rego
+++ b/policies/gcp/cloud_storage/google_storage_bucket/encryption/policy.rego
@@ -1,6 +1,6 @@
 package terraform.gcp.security.cloud_storage.google_storage_bucket.encryption
 
-import data.terraform.gcp.helpers
+import data.terraform.helpers
 import data.terraform.gcp.security.cloud_storage.google_storage_bucket.vars
 
 conditions := [

--- a/policies/gcp/cloud_storage/google_storage_bucket/force_destroy/policy.rego
+++ b/policies/gcp/cloud_storage/google_storage_bucket/force_destroy/policy.rego
@@ -1,6 +1,6 @@
 package terraform.gcp.security.cloud_storage.google_storage_bucket.force_destroy
 
-import data.terraform.gcp.helpers
+import data.terraform.helpers
 import data.terraform.gcp.security.cloud_storage.google_storage_bucket.vars
 
 

--- a/policies/gcp/cloud_storage/google_storage_bucket/public_access_prevention/policy.rego
+++ b/policies/gcp/cloud_storage/google_storage_bucket/public_access_prevention/policy.rego
@@ -1,6 +1,6 @@
 package terraform.gcp.security.cloud_storage.google_storage_bucket.public_access_prevention
 
-import data.terraform.gcp.helpers
+import data.terraform.helpers
 import data.terraform.gcp.security.cloud_storage.google_storage_bucket.vars
 
 conditions := [

--- a/policies/gcp/cloud_storage/google_storage_bucket/public_ip_filter/policy.rego
+++ b/policies/gcp/cloud_storage/google_storage_bucket/public_ip_filter/policy.rego
@@ -1,6 +1,6 @@
 package terraform.gcp.security.cloud_storage.google_storage_bucket.public_ip_filter
 
-import data.terraform.gcp.helpers
+import data.terraform.helpers
 import data.terraform.gcp.security.cloud_storage.google_storage_bucket.vars
 
 conditions := [

--- a/policies/gcp/cloud_storage/google_storage_bucket/retention_lock/policy.rego
+++ b/policies/gcp/cloud_storage/google_storage_bucket/retention_lock/policy.rego
@@ -1,6 +1,6 @@
 package terraform.gcp.security.cloud_storage.google_storage_bucket.retention_lock
 
-import data.terraform.gcp.helpers
+import data.terraform.helpers
 import data.terraform.gcp.security.cloud_storage.google_storage_bucket.vars
 
 conditions := [

--- a/policies/gcp/cloud_storage/google_storage_bucket/retention_period/policy.rego
+++ b/policies/gcp/cloud_storage/google_storage_bucket/retention_period/policy.rego
@@ -1,6 +1,6 @@
 package terraform.gcp.security.cloud_storage.google_storage_bucket.retention_period
 
-import data.terraform.gcp.helpers
+import data.terraform.helpers
 import data.terraform.gcp.security.cloud_storage.google_storage_bucket.vars
 
 conditions := [

--- a/policies/gcp/cloud_storage/google_storage_bucket/uniform_bucket_level_access/policy.rego
+++ b/policies/gcp/cloud_storage/google_storage_bucket/uniform_bucket_level_access/policy.rego
@@ -1,6 +1,6 @@
 package terraform.gcp.security.cloud_storage.google_storage_bucket.uniform_bucket_level_access
 
-import data.terraform.gcp.helpers
+import data.terraform.helpers
 import data.terraform.gcp.security.cloud_storage.google_storage_bucket.vars
 
 conditions := [

--- a/policies/gcp/cloud_storage/google_storage_bucket_access_control/public_entity_blacklist/policy.rego
+++ b/policies/gcp/cloud_storage/google_storage_bucket_access_control/public_entity_blacklist/policy.rego
@@ -1,6 +1,6 @@
 package terraform.gcp.security.cloud_storage.google_storage_bucket_access_control.public_entity_blacklist
 
-import data.terraform.gcp.helpers
+import data.terraform.helpers
 import data.terraform.gcp.security.cloud_storage.google_storage_bucket_access_control.vars
 
 conditions := [

--- a/policies/gcp/cloud_storage/google_storage_bucket_acl/block_default_acl/policy.rego
+++ b/policies/gcp/cloud_storage/google_storage_bucket_acl/block_default_acl/policy.rego
@@ -1,6 +1,6 @@
 package terraform.gcp.security.cloud_storage.google_storage_bucket_acl.block_default_acl
 
-import data.terraform.gcp.helpers
+import data.terraform.helpers
 import data.terraform.gcp.security.cloud_storage.google_storage_bucket_acl.vars
 
 conditions := [

--- a/policies/gcp/cloud_storage/google_storage_bucket_acl/role_entity_required/policy.rego
+++ b/policies/gcp/cloud_storage/google_storage_bucket_acl/role_entity_required/policy.rego
@@ -1,6 +1,6 @@
 package terraform.gcp.security.cloud_storage.google_storage_bucket_acl.role_entity_required
 
-import data.terraform.gcp.helpers
+import data.terraform.helpers
 import data.terraform.gcp.security.cloud_storage.google_storage_bucket_acl.vars
 
 conditions := [

--- a/policies/gcp/cloud_storage/google_storage_bucket_iam_binding/public_access_prevention/policy.rego
+++ b/policies/gcp/cloud_storage/google_storage_bucket_iam_binding/public_access_prevention/policy.rego
@@ -1,6 +1,6 @@
 package terraform.gcp.security.cloud_storage.google_storage_bucket_iam_binding.public_access_prevention
 
-import data.terraform.gcp.helpers
+import data.terraform.helpers
 import data.terraform.gcp.security.cloud_storage.google_storage_bucket_iam_binding.vars
 
 conditions := [

--- a/policies/gcp/cloud_storage/google_storage_bucket_iam_member/public_access_prevention/policy.rego
+++ b/policies/gcp/cloud_storage/google_storage_bucket_iam_member/public_access_prevention/policy.rego
@@ -1,6 +1,6 @@
 package terraform.gcp.security.cloud_storage.google_storage_bucket_iam_member.public_access_prevention
 
-import data.terraform.gcp.helpers
+import data.terraform.helpers
 import data.terraform.gcp.security.cloud_storage.google_storage_bucket_iam_member.vars
 
 conditions := [

--- a/policies/gcp/cloud_storage/google_storage_bucket_object/encryption/policy.rego
+++ b/policies/gcp/cloud_storage/google_storage_bucket_object/encryption/policy.rego
@@ -1,6 +1,6 @@
 package terraform.gcp.security.cloud_storage.google_storage_bucket_object.encryption
 
-import data.terraform.gcp.helpers
+import data.terraform.helpers
 import data.terraform.gcp.security.cloud_storage.google_storage_bucket_object.vars
 
 

--- a/policies/gcp/cloud_storage/google_storage_default_object_access_control/public_access_prevention/policy.rego
+++ b/policies/gcp/cloud_storage/google_storage_default_object_access_control/public_access_prevention/policy.rego
@@ -1,6 +1,6 @@
 package terraform.gcp.security.cloud_storage.google_storage_default_object_access_control.public_access_prevention
 
-import data.terraform.gcp.helpers
+import data.terraform.helpers
 import data.terraform.gcp.security.cloud_storage.google_storage_default_object_access_control.vars
 
 conditions := [

--- a/policies/gcp/cloud_storage/google_storage_default_object_acl/public_access_prevention/policy.rego
+++ b/policies/gcp/cloud_storage/google_storage_default_object_acl/public_access_prevention/policy.rego
@@ -1,6 +1,6 @@
 package terraform.gcp.security.cloud_storage.google_storage_default_object_acl.public_access_prevention
 
-import data.terraform.gcp.helpers
+import data.terraform.helpers
 import data.terraform.gcp.security.cloud_storage.google_storage_default_object_acl.vars
 
 conditions := [

--- a/policies/gcp/cloud_storage/google_storage_folder/force_destroy/policy.rego
+++ b/policies/gcp/cloud_storage/google_storage_folder/force_destroy/policy.rego
@@ -1,6 +1,6 @@
 package terraform.gcp.security.cloud_storage.google_storage_folder.force_destroy
 
-import data.terraform.gcp.helpers
+import data.terraform.helpers
 import data.terraform.gcp.security.cloud_storage.google_storage_folder.vars
 
 

--- a/policies/gcp/cloud_storage/google_storage_managed_folder/force_destroy/policy.rego
+++ b/policies/gcp/cloud_storage/google_storage_managed_folder/force_destroy/policy.rego
@@ -1,6 +1,6 @@
 package terraform.gcp.security.cloud_storage.google_storage_managed_folder.force_destroy
 
-import data.terraform.gcp.helpers
+import data.terraform.helpers
 import data.terraform.gcp.security.cloud_storage.google_storage_managed_folder.vars
 
 

--- a/policies/gcp/cloud_storage/google_storage_managed_folder_iam_binding/public_access_prevention/policy.rego
+++ b/policies/gcp/cloud_storage/google_storage_managed_folder_iam_binding/public_access_prevention/policy.rego
@@ -1,6 +1,6 @@
 package terraform.gcp.security.cloud_storage.google_storage_managed_folder_iam_binding.public_access_prevention
 
-import data.terraform.gcp.helpers
+import data.terraform.helpers
 import data.terraform.gcp.security.cloud_storage.google_storage_managed_folder_iam_binding.vars
 
 conditions := [

--- a/policies/gcp/cloud_storage/google_storage_managed_folder_iam_member/public_access_prevention/policy.rego
+++ b/policies/gcp/cloud_storage/google_storage_managed_folder_iam_member/public_access_prevention/policy.rego
@@ -1,6 +1,6 @@
 package terraform.gcp.security.cloud_storage.google_storage_managed_folder_iam_member.public_access_prevention
 
-import data.terraform.gcp.helpers
+import data.terraform.helpers
 import data.terraform.gcp.security.cloud_storage.google_storage_managed_folder_iam_member.vars
 
 conditions := [

--- a/policies/gcp/cloud_storage/google_storage_object_access_control/public_access_prevention/policy.rego
+++ b/policies/gcp/cloud_storage/google_storage_object_access_control/public_access_prevention/policy.rego
@@ -1,6 +1,6 @@
 package terraform.gcp.security.cloud_storage.google_storage_object_access_control.public_access_prevention
 
-import data.terraform.gcp.helpers
+import data.terraform.helpers
 import data.terraform.gcp.security.cloud_storage.google_storage_object_access_control.vars
 
 conditions := [

--- a/policies/gcp/cloud_storage/google_storage_object_acl/predefined_acl/policy.rego
+++ b/policies/gcp/cloud_storage/google_storage_object_acl/predefined_acl/policy.rego
@@ -1,6 +1,6 @@
 package terraform.gcp.security.cloud_storage.google_storage_object_acl.predefined_acl
 
-import data.terraform.gcp.helpers
+import data.terraform.helpers
 import data.terraform.gcp.security.cloud_storage.google_storage_object_acl.vars
 
 conditions := [

--- a/policies/gcp/cloud_storage/google_storage_object_acl/public_access_prevention/policy.rego
+++ b/policies/gcp/cloud_storage/google_storage_object_acl/public_access_prevention/policy.rego
@@ -1,6 +1,6 @@
 package terraform.gcp.security.cloud_storage.google_storage_object_acl.public_access_prevention
 
-import data.terraform.gcp.helpers
+import data.terraform.helpers
 import data.terraform.gcp.security.cloud_storage.google_storage_object_acl.vars
 
 conditions := [

--- a/policies/gcp/cloud_storage_batch_operations/google_storage_batch_operations_job/disallow_permanent_object_deletion/policy.rego
+++ b/policies/gcp/cloud_storage_batch_operations/google_storage_batch_operations_job/disallow_permanent_object_deletion/policy.rego
@@ -1,6 +1,6 @@
 package terraform.gcp.security.cloud_storage_batch_operations.google_storage_batch_operations_job.disallow_permanent_object_deletion
 
-import data.terraform.gcp.helpers
+import data.terraform.helpers
 import data.terraform.gcp.security.cloud_storage_batch_operations.google_storage_batch_operations_job.vars
 
 conditions := [[

--- a/policies/gcp/cloud_storage_batch_operations/google_storage_batch_operations_job/forbid_unsetting_object_holds/policy.rego
+++ b/policies/gcp/cloud_storage_batch_operations/google_storage_batch_operations_job/forbid_unsetting_object_holds/policy.rego
@@ -1,6 +1,6 @@
 package terraform.gcp.security.cloud_storage_batch_operations.google_storage_batch_operations_job.forbid_unsetting_object_holds
 
-import data.terraform.gcp.helpers
+import data.terraform.helpers
 import data.terraform.gcp.security.cloud_storage_batch_operations.google_storage_batch_operations_job.vars
 
 conditions := [[

--- a/policies/gcp/cloud_storage_batch_operations/google_storage_batch_operations_job/require_scope_prefix_or_manifest/policy.rego
+++ b/policies/gcp/cloud_storage_batch_operations/google_storage_batch_operations_job/require_scope_prefix_or_manifest/policy.rego
@@ -1,6 +1,6 @@
 package terraform.gcp.security.cloud_storage_batch_operations.google_storage_batch_operations_job.require_scope_prefix_or_manifest
 
-import data.terraform.gcp.helpers
+import data.terraform.helpers
 import data.terraform.gcp.security.cloud_storage_batch_operations.google_storage_batch_operations_job.vars
 
 conditions := [[

--- a/policies/gcp/cloud_storage_batch_operations/google_storage_batch_operations_job/rewrite_requires_cmek/policy.rego
+++ b/policies/gcp/cloud_storage_batch_operations/google_storage_batch_operations_job/rewrite_requires_cmek/policy.rego
@@ -1,6 +1,6 @@
 package terraform.gcp.security.cloud_storage_batch_operations.google_storage_batch_operations_job.rewrite_requires_cmek
 
-import data.terraform.gcp.helpers
+import data.terraform.helpers
 import data.terraform.gcp.security.cloud_storage_batch_operations.google_storage_batch_operations_job.vars
 
 conditions := [[

--- a/policies/gcp/cloud_vmware_engine/external_access_rule/block_broad_external_access/policy.rego
+++ b/policies/gcp/cloud_vmware_engine/external_access_rule/block_broad_external_access/policy.rego
@@ -1,6 +1,6 @@
 package terraform.gcp.security.cloud_vmware_engine.external_access_rule.block_broad_external_access
 
-import data.terraform.gcp.helpers
+import data.terraform.helpers
 import data.terraform.gcp.security.cloud_vmware_engine.external_access_rule.vars
 
 conditions := [[

--- a/policies/gcp/cloud_vmware_engine/network/allowed_location/policy.rego
+++ b/policies/gcp/cloud_vmware_engine/network/allowed_location/policy.rego
@@ -1,6 +1,6 @@
 package terraform.gcp.security.cloud_vmware_engine.network.allowed_location
 
-import data.terraform.gcp.helpers
+import data.terraform.helpers
 import data.terraform.gcp.security.cloud_vmware_engine.network.vars
 
 conditions := [[

--- a/policies/gcp/cloud_vmware_engine/network/block_legacy/policy.rego
+++ b/policies/gcp/cloud_vmware_engine/network/block_legacy/policy.rego
@@ -1,6 +1,6 @@
 package terraform.gcp.security.cloud_vmware_engine.network.block_legacy
 
-import data.terraform.gcp.helpers
+import data.terraform.helpers
 import data.terraform.gcp.security.cloud_vmware_engine.network.vars
 
 conditions := [[

--- a/policies/gcp/cloud_vmware_engine/network_peering/block_custom_routes/policy.rego
+++ b/policies/gcp/cloud_vmware_engine/network_peering/block_custom_routes/policy.rego
@@ -1,6 +1,6 @@
 package terraform.gcp.security.cloud_vmware_engine.network_peering.block_custom_routes
 
-import data.terraform.gcp.helpers
+import data.terraform.helpers
 import data.terraform.gcp.security.cloud_vmware_engine.network_peering.vars
 
 conditions := [[

--- a/policies/gcp/cloud_vmware_engine/network_peering/block_thirdparty/policy.rego
+++ b/policies/gcp/cloud_vmware_engine/network_peering/block_thirdparty/policy.rego
@@ -1,6 +1,6 @@
 package terraform.gcp.security.cloud_vmware_engine.network_peering.block_thirdparty
 
-import data.terraform.gcp.helpers
+import data.terraform.helpers
 import data.terraform.gcp.security.cloud_vmware_engine.network_peering.vars
 
 conditions := [[

--- a/policies/gcp/cloud_vmware_engine/network_policy/allowed_location/policy.rego
+++ b/policies/gcp/cloud_vmware_engine/network_policy/allowed_location/policy.rego
@@ -1,6 +1,6 @@
 package terraform.gcp.security.cloud_vmware_engine.network_policy.allowed_location
 
-import data.terraform.gcp.helpers
+import data.terraform.helpers
 import data.terraform.gcp.security.cloud_vmware_engine.network_policy.vars
 
 conditions := [[

--- a/policies/gcp/cloud_vmware_engine/network_policy/block_external_ip/policy.rego
+++ b/policies/gcp/cloud_vmware_engine/network_policy/block_external_ip/policy.rego
@@ -1,6 +1,6 @@
 package terraform.gcp.security.cloud_vmware_engine.network_policy.block_external_ip
 
-import data.terraform.gcp.helpers
+import data.terraform.helpers
 import data.terraform.gcp.security.cloud_vmware_engine.network_policy.vars
 
 conditions := [[

--- a/policies/gcp/cloud_vmware_engine/network_policy/block_internet_access/policy.rego
+++ b/policies/gcp/cloud_vmware_engine/network_policy/block_internet_access/policy.rego
@@ -1,6 +1,6 @@
 package terraform.gcp.security.cloud_vmware_engine.network_policy.block_internet_access
 
-import data.terraform.gcp.helpers
+import data.terraform.helpers
 import data.terraform.gcp.security.cloud_vmware_engine.network_policy.vars
 
 conditions := [[

--- a/policies/gcp/cloud_vmware_engine/private_cloud/allowed_location/policy.rego
+++ b/policies/gcp/cloud_vmware_engine/private_cloud/allowed_location/policy.rego
@@ -1,6 +1,6 @@
 package terraform.gcp.security.cloud_vmware_engine.private_cloud.allowed_location
 
-import data.terraform.gcp.helpers
+import data.terraform.helpers
 import data.terraform.gcp.security.cloud_vmware_engine.private_cloud.vars
 
 conditions := [[

--- a/policies/gcp/cloud_vmware_engine/private_cloud/zonal_location/policy.rego
+++ b/policies/gcp/cloud_vmware_engine/private_cloud/zonal_location/policy.rego
@@ -1,6 +1,6 @@
 package terraform.gcp.security.cloud_vmware_engine.private_cloud.zonal_location
 
-import data.terraform.gcp.helpers
+import data.terraform.helpers
 import data.terraform.gcp.security.cloud_vmware_engine.private_cloud.vars
 
 conditions := [[

--- a/policies/gcp/connection/policy.rego
+++ b/policies/gcp/connection/policy.rego
@@ -1,6 +1,6 @@
 package terraform.gcp.security.service_networking.connection
 
-import data.terraform.gcp.helpers
+import data.terraform.helpers
 import data.terraform.gcp.security.service_networking.connection.vars
 
 allowed_ranges := vars.variables["allowed_ip_ranges"]

--- a/policies/gcp/database_migration_service/connection_profile/cloudsql_authorized_networks/policy.rego
+++ b/policies/gcp/database_migration_service/connection_profile/cloudsql_authorized_networks/policy.rego
@@ -1,5 +1,5 @@
 package terraform.gcp.security.database_migration_service.connection_profile.cloudsql_authorized_networks
-import data.terraform.gcp.helpers
+import data.terraform.helpers
 import data.terraform.gcp.security.database_migration_service.connection_profile.vars
 
 conditions := [

--- a/policies/gcp/database_migration_service/connection_profile/cloudsql_cmek/policy.rego
+++ b/policies/gcp/database_migration_service/connection_profile/cloudsql_cmek/policy.rego
@@ -1,5 +1,5 @@
 package terraform.gcp.security.database_migration_service.connection_profile.cloudsql_cmek
-import data.terraform.gcp.helpers
+import data.terraform.helpers
 import data.terraform.gcp.security.database_migration_service.connection_profile.vars
 
 conditions := [

--- a/policies/gcp/database_migration_service/connection_profile/cloudsql_private_network/policy.rego
+++ b/policies/gcp/database_migration_service/connection_profile/cloudsql_private_network/policy.rego
@@ -1,5 +1,5 @@
 package terraform.gcp.security.database_migration_service.connection_profile.cloudsql_private_network
-import data.terraform.gcp.helpers
+import data.terraform.helpers
 import data.terraform.gcp.security.database_migration_service.connection_profile.vars
 
 conditions := [

--- a/policies/gcp/database_migration_service/connection_profile/cloudsql_require_ssl/policy.rego
+++ b/policies/gcp/database_migration_service/connection_profile/cloudsql_require_ssl/policy.rego
@@ -1,5 +1,5 @@
 package terraform.gcp.security.database_migration_service.connection_profile.cloudsql_require_ssl
-import data.terraform.gcp.helpers
+import data.terraform.helpers
 import data.terraform.gcp.security.database_migration_service.connection_profile.vars
 
 conditions := [

--- a/policies/gcp/database_migration_service/connection_profile/forward_ssh_connectivity/policy.rego
+++ b/policies/gcp/database_migration_service/connection_profile/forward_ssh_connectivity/policy.rego
@@ -1,5 +1,5 @@
 package terraform.gcp.security.database_migration_service.connection_profile.forward_ssh_connectivity
-import data.terraform.gcp.helpers
+import data.terraform.helpers
 import data.terraform.gcp.security.database_migration_service.connection_profile.vars
 
 conditions := [

--- a/policies/gcp/database_migration_service/connection_profile/location/policy.rego
+++ b/policies/gcp/database_migration_service/connection_profile/location/policy.rego
@@ -1,5 +1,5 @@
 package terraform.gcp.security.database_migration_service.connection_profile.location
-import data.terraform.gcp.helpers
+import data.terraform.helpers
 import data.terraform.gcp.security.database_migration_service.connection_profile.vars
 
 conditions := [

--- a/policies/gcp/database_migration_service/connection_profile/mysql_ssl_type/policy.rego
+++ b/policies/gcp/database_migration_service/connection_profile/mysql_ssl_type/policy.rego
@@ -1,5 +1,5 @@
 package terraform.gcp.security.database_migration_service.connection_profile.mysql_ssl_type
-import data.terraform.gcp.helpers
+import data.terraform.helpers
 import data.terraform.gcp.security.database_migration_service.connection_profile.vars
 
 conditions := [

--- a/policies/gcp/database_migration_service/connection_profile/postgresql_ssl_type/policy.rego
+++ b/policies/gcp/database_migration_service/connection_profile/postgresql_ssl_type/policy.rego
@@ -1,5 +1,5 @@
 package terraform.gcp.security.database_migration_service.connection_profile.postgresql_ssl_type
-import data.terraform.gcp.helpers
+import data.terraform.helpers
 import data.terraform.gcp.security.database_migration_service.connection_profile.vars
 
 conditions := [

--- a/policies/gcp/database_migration_service/connection_profile/private_connectivity/policy.rego
+++ b/policies/gcp/database_migration_service/connection_profile/private_connectivity/policy.rego
@@ -1,5 +1,5 @@
 package terraform.gcp.security.database_migration_service.connection_profile.private_connectivity
-import data.terraform.gcp.helpers
+import data.terraform.helpers
 import data.terraform.gcp.security.database_migration_service.connection_profile.vars
 
 conditions := [

--- a/policies/gcp/database_migration_service/connection_profile/static_service_ip_connectivity/policy.rego
+++ b/policies/gcp/database_migration_service/connection_profile/static_service_ip_connectivity/policy.rego
@@ -1,5 +1,5 @@
 package terraform.gcp.security.database_migration_service.connection_profile.static_service_ip_connectivity
-import data.terraform.gcp.helpers
+import data.terraform.helpers
 import data.terraform.gcp.security.database_migration_service.connection_profile.vars
 
 conditions := [

--- a/policies/gcp/database_migration_service/migration_job/dump_type/policy.rego
+++ b/policies/gcp/database_migration_service/migration_job/dump_type/policy.rego
@@ -1,5 +1,5 @@
 package terraform.gcp.security.database_migration_service.migration_job.dump_type
-import data.terraform.gcp.helpers
+import data.terraform.helpers
 import data.terraform.gcp.security.database_migration_service.migration_job.vars
 
 conditions := [

--- a/policies/gcp/database_migration_service/migration_job/location/policy.rego
+++ b/policies/gcp/database_migration_service/migration_job/location/policy.rego
@@ -1,5 +1,5 @@
 package terraform.gcp.security.database_migration_service.migration_job.location
-import data.terraform.gcp.helpers
+import data.terraform.helpers
 import data.terraform.gcp.security.database_migration_service.migration_job.vars
 
 conditions := [

--- a/policies/gcp/database_migration_service/migration_job/reverse_ssh_connectivity/policy.rego
+++ b/policies/gcp/database_migration_service/migration_job/reverse_ssh_connectivity/policy.rego
@@ -1,5 +1,5 @@
 package terraform.gcp.security.database_migration_service.migration_job.reverse_ssh_connectivity
-import data.terraform.gcp.helpers
+import data.terraform.helpers
 import data.terraform.gcp.security.database_migration_service.migration_job.vars
 
 conditions := [

--- a/policies/gcp/database_migration_service/migration_job/static_ip_connectivity/policy.rego
+++ b/policies/gcp/database_migration_service/migration_job/static_ip_connectivity/policy.rego
@@ -1,5 +1,5 @@
 package terraform.gcp.security.database_migration_service.migration_job.static_ip_connectivity
-import data.terraform.gcp.helpers
+import data.terraform.helpers
 import data.terraform.gcp.security.database_migration_service.migration_job.vars
 
 conditions := [

--- a/policies/gcp/database_migration_service/migration_job/type/policy.rego
+++ b/policies/gcp/database_migration_service/migration_job/type/policy.rego
@@ -1,5 +1,5 @@
 package terraform.gcp.security.database_migration_service.migration_job.type
-import data.terraform.gcp.helpers
+import data.terraform.helpers
 import data.terraform.gcp.security.database_migration_service.migration_job.vars
 
 conditions := [

--- a/policies/gcp/database_migration_service/migration_job/vpc_peering_connectivity/policy.rego
+++ b/policies/gcp/database_migration_service/migration_job/vpc_peering_connectivity/policy.rego
@@ -1,5 +1,5 @@
 package terraform.gcp.security.database_migration_service.migration_job.vpc_peering_connectivity
-import data.terraform.gcp.helpers
+import data.terraform.helpers
 import data.terraform.gcp.security.database_migration_service.migration_job.vars
 
 conditions := [

--- a/policies/gcp/database_migration_service/private_connection/create_without_validation/policy.rego
+++ b/policies/gcp/database_migration_service/private_connection/create_without_validation/policy.rego
@@ -1,5 +1,5 @@
 package terraform.gcp.security.database_migration_service.private_connection.create_without_validation
-import data.terraform.gcp.helpers
+import data.terraform.helpers
 import data.terraform.gcp.security.database_migration_service.private_connection.vars
 
 conditions := [

--- a/policies/gcp/database_migration_service/private_connection/location/policy.rego
+++ b/policies/gcp/database_migration_service/private_connection/location/policy.rego
@@ -1,5 +1,5 @@
 package terraform.gcp.security.database_migration_service.private_connection.location
-import data.terraform.gcp.helpers
+import data.terraform.helpers
 import data.terraform.gcp.security.database_migration_service.private_connection.vars
 
 conditions := [

--- a/policies/gcp/dataform/google_dataform_repository/deletion_policy/policy.rego
+++ b/policies/gcp/dataform/google_dataform_repository/deletion_policy/policy.rego
@@ -1,6 +1,6 @@
 package terraform.gcp.security.dataform.google_dataform_repository.deletion_policy
 
-import data.terraform.gcp.helpers
+import data.terraform.helpers
 import data.terraform.gcp.security.dataform.google_dataform_repository as repo
 
 # Disallow FORCE deletion policy on Dataform repositories.

--- a/policies/gcp/dataform/google_dataform_repository/encryption/policy.rego
+++ b/policies/gcp/dataform/google_dataform_repository/encryption/policy.rego
@@ -1,6 +1,6 @@
 package terraform.gcp.security.dataform.google_dataform_repository.encryption
 
-import data.terraform.gcp.helpers
+import data.terraform.helpers
 import data.terraform.gcp.security.dataform.google_dataform_repository as repo
 
 # Require CMEK on repositories (kms_key_name must be set)

--- a/policies/gcp/dataform/google_dataform_repository/git_https_secret/policy.rego
+++ b/policies/gcp/dataform/google_dataform_repository/git_https_secret/policy.rego
@@ -1,6 +1,6 @@
 package terraform.gcp.security.dataform.google_dataform_repository.git_https_secret
 
-import data.terraform.gcp.helpers
+import data.terraform.helpers
 import data.terraform.gcp.security.dataform.google_dataform_repository as repo
 
 # Situation: If a Git remote is configured over HTTPS, 

--- a/policies/gcp/dataform/google_dataform_repository/git_required/policy.rego
+++ b/policies/gcp/dataform/google_dataform_repository/git_required/policy.rego
@@ -1,6 +1,6 @@
 package terraform.gcp.security.dataform.google_dataform_repository.git_required
 
-import data.terraform.gcp.helpers
+import data.terraform.helpers
 import data.terraform.gcp.security.dataform.google_dataform_repository as repo
 
 # This policy enforces: if a repo configures git_remote_settings,

--- a/policies/gcp/dataform/google_dataform_repository/git_ssh_auth/policy.rego
+++ b/policies/gcp/dataform/google_dataform_repository/git_ssh_auth/policy.rego
@@ -1,6 +1,6 @@
 package terraform.gcp.security.dataform.google_dataform_repository.git_ssh_auth
 
-import data.terraform.gcp.helpers
+import data.terraform.helpers
 import data.terraform.gcp.security.dataform.google_dataform_repository as repo
 
 # This policy enforces: if a repo uses SSH authentication,

--- a/policies/gcp/dataform/google_dataform_repository/labels_security_required/policy.rego
+++ b/policies/gcp/dataform/google_dataform_repository/labels_security_required/policy.rego
@@ -1,6 +1,6 @@
 package terraform.gcp.security.dataform.google_dataform_repository.labels_security_required
 
-import data.terraform.gcp.helpers
+import data.terraform.helpers
 import data.terraform.gcp.security.dataform.google_dataform_repository as repo
 
 # Security-oriented required labels

--- a/policies/gcp/dataform/google_dataform_repository/region_allowlist/policy.rego
+++ b/policies/gcp/dataform/google_dataform_repository/region_allowlist/policy.rego
@@ -1,6 +1,6 @@
 package terraform.gcp.security.dataform.google_dataform_repository.region_allowlist
 
-import data.terraform.gcp.helpers
+import data.terraform.helpers
 import data.terraform.gcp.security.dataform.google_dataform_repository as repo
 
 # Adjust the allowlist as needed

--- a/policies/gcp/dataform/google_dataform_repository_iam/iam_no_public/policy.rego
+++ b/policies/gcp/dataform/google_dataform_repository_iam/iam_no_public/policy.rego
@@ -1,6 +1,6 @@
 package terraform.gcp.security.dataform.google_dataform_repository_iam.iam_no_public
 
-import data.terraform.gcp.helpers
+import data.terraform.helpers
 import data.terraform.gcp.security.dataform.google_dataform_repository_iam as repo
 
 # Disallow public principals on repository IAM bindings

--- a/policies/gcp/dataform/google_dataform_repository_release_config/cron_required/policy.rego
+++ b/policies/gcp/dataform/google_dataform_repository_release_config/cron_required/policy.rego
@@ -1,6 +1,6 @@
 package terraform.gcp.security.dataform.google_dataform_repository_release_config.cron_required
 
-import data.terraform.gcp.helpers
+import data.terraform.helpers
 import data.terraform.gcp.security.dataform.google_dataform_repository_release_config as repo
 
 conditions := [

--- a/policies/gcp/dataform/google_dataform_repository_workflow_config/service_account_required/policy.rego
+++ b/policies/gcp/dataform/google_dataform_repository_workflow_config/service_account_required/policy.rego
@@ -1,6 +1,6 @@
 package terraform.gcp.security.dataform.google_dataform_repository_workflow_config.service_account_required
 
-import data.terraform.gcp.helpers
+import data.terraform.helpers
 import data.terraform.gcp.security.dataform.google_dataform_repository_workflow_config as repo
 
 # Require a service account in invocation_config

--- a/policies/gcp/dataproc_metastore/federation/deletion_protection/policy.rego
+++ b/policies/gcp/dataproc_metastore/federation/deletion_protection/policy.rego
@@ -1,6 +1,6 @@
 package terraform.gcp.security.dataproc_metastore.federation.deletion_protection
 
-import data.terraform.gcp.helpers
+import data.terraform.helpers
 import data.terraform.gcp.security.dataproc_metastore.federation.vars
 
 conditions := [

--- a/policies/gcp/dataproc_metastore/federation/location/policy.rego
+++ b/policies/gcp/dataproc_metastore/federation/location/policy.rego
@@ -1,5 +1,5 @@
 package terraform.gcp.security.dataproc_metastore.federation.location
-import data.terraform.gcp.helpers
+import data.terraform.helpers
 import data.terraform.gcp.security.dataproc_metastore.federation.vars
 
 conditions := [

--- a/policies/gcp/dataproc_metastore/federation/metastore_type/policy.rego
+++ b/policies/gcp/dataproc_metastore/federation/metastore_type/policy.rego
@@ -1,6 +1,6 @@
 package terraform.gcp.security.dataproc_metastore.federation.metastore_type
 
-import data.terraform.gcp.helpers
+import data.terraform.helpers
 import data.terraform.gcp.security.dataproc_metastore.federation.vars
 
 

--- a/policies/gcp/dataproc_metastore/federation/name/policy.rego
+++ b/policies/gcp/dataproc_metastore/federation/name/policy.rego
@@ -1,6 +1,6 @@
 package terraform.gcp.security.dataproc_metastore.federation.name
 
-import data.terraform.gcp.helpers
+import data.terraform.helpers
 import data.terraform.gcp.security.dataproc_metastore.federation.vars
 
 

--- a/policies/gcp/dataproc_metastore/federation/version/policy.rego
+++ b/policies/gcp/dataproc_metastore/federation/version/policy.rego
@@ -1,6 +1,6 @@
 package terraform.gcp.security.dataproc_metastore.federation.version
 
-import data.terraform.gcp.helpers
+import data.terraform.helpers
 import data.terraform.gcp.security.dataproc_metastore.federation.vars
 
 conditions := [

--- a/policies/gcp/dataproc_metastore/service/database_type/policy.rego
+++ b/policies/gcp/dataproc_metastore/service/database_type/policy.rego
@@ -1,5 +1,5 @@
 package terraform.gcp.security.dataproc_metastore.service.database_type
-import data.terraform.gcp.helpers
+import data.terraform.helpers
 import data.terraform.gcp.security.dataproc_metastore.service.vars
 
 

--- a/policies/gcp/dataproc_metastore/service/deletion_protection/policy.rego
+++ b/policies/gcp/dataproc_metastore/service/deletion_protection/policy.rego
@@ -1,5 +1,5 @@
 package terraform.gcp.security.dataproc_metastore.service.deletion_protection
-import data.terraform.gcp.helpers
+import data.terraform.helpers
 import data.terraform.gcp.security.dataproc_metastore.service.vars
 
 

--- a/policies/gcp/dataproc_metastore/service/encryption_config/policy.rego
+++ b/policies/gcp/dataproc_metastore/service/encryption_config/policy.rego
@@ -1,5 +1,5 @@
 package terraform.gcp.security.dataproc_metastore.service.encryption_config
-import data.terraform.gcp.helpers
+import data.terraform.helpers
 import data.terraform.gcp.security.dataproc_metastore.service.vars
 
 

--- a/policies/gcp/dataproc_metastore/service/location/policy.rego
+++ b/policies/gcp/dataproc_metastore/service/location/policy.rego
@@ -1,5 +1,5 @@
 package terraform.gcp.security.dataproc_metastore.service.location
-import data.terraform.gcp.helpers
+import data.terraform.helpers
 import data.terraform.gcp.security.dataproc_metastore.service.vars
 
 conditions := [

--- a/policies/gcp/dataproc_metastore/service/metadata_integration/policy.rego
+++ b/policies/gcp/dataproc_metastore/service/metadata_integration/policy.rego
@@ -1,5 +1,5 @@
 package terraform.gcp.security.dataproc_metastore.service.metadata_integration 
-import data.terraform.gcp.helpers
+import data.terraform.helpers
 import data.terraform.gcp.security.dataproc_metastore.service.vars
 
 

--- a/policies/gcp/dataproc_metastore/service/port/policy.rego
+++ b/policies/gcp/dataproc_metastore/service/port/policy.rego
@@ -1,5 +1,5 @@
 package terraform.gcp.security.dataproc_metastore.service.port
-import data.terraform.gcp.helpers
+import data.terraform.helpers
 import data.terraform.gcp.security.dataproc_metastore.service.vars
 
 conditions := [

--- a/policies/gcp/dataproc_metastore/service/scheduled_backup/policy.rego
+++ b/policies/gcp/dataproc_metastore/service/scheduled_backup/policy.rego
@@ -1,6 +1,6 @@
 package terraform.gcp.security.dataproc_metastore.service.scheduled_backup
 
-import data.terraform.gcp.helpers
+import data.terraform.helpers
 import data.terraform.gcp.security.dataproc_metastore.service.vars
 
 conditions := [

--- a/policies/gcp/deploy/automation/service_account_validation/policy.rego
+++ b/policies/gcp/deploy/automation/service_account_validation/policy.rego
@@ -1,5 +1,5 @@
 package terraform.gcp.security.deploy.automation.service_account_validation
-import data.terraform.gcp.helpers
+import data.terraform.helpers
 import data.terraform.gcp.security.deploy.automation.vars
 
 conditions := [

--- a/policies/gcp/deploy/automation/suspended_check/policy.rego
+++ b/policies/gcp/deploy/automation/suspended_check/policy.rego
@@ -1,5 +1,5 @@
 package terraform.gcp.security.deploy.automation.suspended_check
-import data.terraform.gcp.helpers
+import data.terraform.helpers
 import data.terraform.gcp.security.deploy.automation.vars
 
 conditions := [

--- a/policies/gcp/deploy/custom_target_type/custom_actions_validation/policy.rego
+++ b/policies/gcp/deploy/custom_target_type/custom_actions_validation/policy.rego
@@ -1,5 +1,5 @@
 package terraform.gcp.security.deploy.custom_target_type.custom_actions_validation
-import data.terraform.gcp.helpers
+import data.terraform.helpers
 import data.terraform.gcp.security.deploy.custom_target_type.vars
 
 conditions := [

--- a/policies/gcp/deploy/custom_target_type_iam_binding/prohibited_members/policy.rego
+++ b/policies/gcp/deploy/custom_target_type_iam_binding/prohibited_members/policy.rego
@@ -1,5 +1,5 @@
 package terraform.gcp.security.deploy.custom_target_type_iam_binding.prohibited_members
-import data.terraform.gcp.helpers
+import data.terraform.helpers
 import data.terraform.gcp.security.deploy.custom_target_type_iam_binding.vars
 
 conditions := [

--- a/policies/gcp/deploy/custom_target_type_iam_binding/required_role/policy.rego
+++ b/policies/gcp/deploy/custom_target_type_iam_binding/required_role/policy.rego
@@ -1,5 +1,5 @@
 package terraform.gcp.security.deploy.custom_target_type_iam_binding.required_role
-import data.terraform.gcp.helpers
+import data.terraform.helpers
 import data.terraform.gcp.security.deploy.custom_target_type_iam_binding.vars
 
 conditions := [

--- a/policies/gcp/deploy/custom_target_type_iam_member/prohibited_member/policy.rego
+++ b/policies/gcp/deploy/custom_target_type_iam_member/prohibited_member/policy.rego
@@ -1,5 +1,5 @@
 package terraform.gcp.security.deploy.custom_target_type_iam_member.prohibited_member
-import data.terraform.gcp.helpers
+import data.terraform.helpers
 import data.terraform.gcp.security.deploy.custom_target_type_iam_member.vars
 
 conditions := [

--- a/policies/gcp/deploy/custom_target_type_iam_member/required_role/policy.rego
+++ b/policies/gcp/deploy/custom_target_type_iam_member/required_role/policy.rego
@@ -1,5 +1,5 @@
 package terraform.gcp.security.deploy.custom_target_type_iam_member.required_role
-import data.terraform.gcp.helpers
+import data.terraform.helpers
 import data.terraform.gcp.security.deploy.custom_target_type_iam_member.vars
 
 conditions := [

--- a/policies/gcp/deploy/custom_target_type_iam_policy/required_role/policy.rego
+++ b/policies/gcp/deploy/custom_target_type_iam_policy/required_role/policy.rego
@@ -1,5 +1,5 @@
 package terraform.gcp.security.deploy.custom_target_type_iam_policy.required_role
-import data.terraform.gcp.helpers
+import data.terraform.helpers
 import data.terraform.gcp.security.deploy.custom_target_type_iam_policy.vars
 
 conditions := [

--- a/policies/gcp/deploy/delivery_pipeline/serial_pipeline_validation/policy.rego
+++ b/policies/gcp/deploy/delivery_pipeline/serial_pipeline_validation/policy.rego
@@ -1,5 +1,5 @@
 package terraform.gcp.security.deploy.delivery_pipeline.serial_pipeline_validation
-import data.terraform.gcp.helpers
+import data.terraform.helpers
 import data.terraform.gcp.security.deploy.delivery_pipeline.vars
 
 conditions := [

--- a/policies/gcp/deploy/delivery_pipeline/suspended_check/policy.rego
+++ b/policies/gcp/deploy/delivery_pipeline/suspended_check/policy.rego
@@ -1,5 +1,5 @@
 package terraform.gcp.security.deploy.delivery_pipeline.suspended_check
-import data.terraform.gcp.helpers
+import data.terraform.helpers
 import data.terraform.gcp.security.deploy.delivery_pipeline.vars
 
 conditions := [

--- a/policies/gcp/deploy/delivery_pipeline_iam_binding/prohibited_members/policy.rego
+++ b/policies/gcp/deploy/delivery_pipeline_iam_binding/prohibited_members/policy.rego
@@ -1,5 +1,5 @@
 package terraform.gcp.security.deploy.delivery_pipeline_iam_binding.prohibited_members
-import data.terraform.gcp.helpers
+import data.terraform.helpers
 import data.terraform.gcp.security.deploy.delivery_pipeline_iam_binding.vars
 
 conditions := [

--- a/policies/gcp/deploy/delivery_pipeline_iam_binding/required_role/policy.rego
+++ b/policies/gcp/deploy/delivery_pipeline_iam_binding/required_role/policy.rego
@@ -1,5 +1,5 @@
 package terraform.gcp.security.deploy.delivery_pipeline_iam_binding.required_role
-import data.terraform.gcp.helpers
+import data.terraform.helpers
 import data.terraform.gcp.security.deploy.delivery_pipeline_iam_binding.vars
 
 conditions := [

--- a/policies/gcp/deploy/delivery_pipeline_iam_member/prohibited_member/policy.rego
+++ b/policies/gcp/deploy/delivery_pipeline_iam_member/prohibited_member/policy.rego
@@ -1,5 +1,5 @@
 package terraform.gcp.security.deploy.delivery_pipeline_iam_member.prohibited_member
-import data.terraform.gcp.helpers
+import data.terraform.helpers
 import data.terraform.gcp.security.deploy.delivery_pipeline_iam_member.vars
 
 conditions := [

--- a/policies/gcp/deploy/delivery_pipeline_iam_member/required_role/policy.rego
+++ b/policies/gcp/deploy/delivery_pipeline_iam_member/required_role/policy.rego
@@ -1,5 +1,5 @@
 package terraform.gcp.security.deploy.delivery_pipeline_iam_member.required_role 
-import data.terraform.gcp.helpers
+import data.terraform.helpers
 import data.terraform.gcp.security.deploy.delivery_pipeline_iam_member.vars
 
 conditions := [

--- a/policies/gcp/deploy/delivery_pipeline_iam_policy/required_role/policy.rego
+++ b/policies/gcp/deploy/delivery_pipeline_iam_policy/required_role/policy.rego
@@ -1,5 +1,5 @@
 package terraform.gcp.security.deploy.delivery_pipeline_iam_policy.required_role 
-import data.terraform.gcp.helpers
+import data.terraform.helpers
 import data.terraform.gcp.security.deploy.delivery_pipeline_iam_policy.vars
 
 conditions := [

--- a/policies/gcp/deploy/deploy_policy/suspended_check/policy.rego
+++ b/policies/gcp/deploy/deploy_policy/suspended_check/policy.rego
@@ -1,5 +1,5 @@
 package terraform.gcp.security.deploy.deploy_policy.suspended_check
-import data.terraform.gcp.helpers
+import data.terraform.helpers
 import data.terraform.gcp.security.deploy.deploy_policy.vars
 
 conditions := [

--- a/policies/gcp/deploy/target/gke_configuration/policy.rego
+++ b/policies/gcp/deploy/target/gke_configuration/policy.rego
@@ -1,5 +1,5 @@
 package terraform.gcp.security.deploy.target.gke_configuration
-import data.terraform.gcp.helpers
+import data.terraform.helpers
 import data.terraform.gcp.security.deploy.target.vars
 
 conditions := [

--- a/policies/gcp/deploy/target/require_approval_check/policy.rego
+++ b/policies/gcp/deploy/target/require_approval_check/policy.rego
@@ -1,5 +1,5 @@
 package terraform.gcp.security.deploy.target.require_approval_check 
-import data.terraform.gcp.helpers
+import data.terraform.helpers
 import data.terraform.gcp.security.deploy.target.vars
 
 conditions := [

--- a/policies/gcp/deploy/target/run_configuration/policy.rego
+++ b/policies/gcp/deploy/target/run_configuration/policy.rego
@@ -1,5 +1,5 @@
 package terraform.gcp.security.deploy.target.run_configuration
-import data.terraform.gcp.helpers
+import data.terraform.helpers
 import data.terraform.gcp.security.deploy.target.vars
 
 conditions := [

--- a/policies/gcp/deploy/target_iam_binding/prohibited_members/policy.rego
+++ b/policies/gcp/deploy/target_iam_binding/prohibited_members/policy.rego
@@ -1,5 +1,5 @@
 package terraform.gcp.security.deploy.target_iam_binding.prohibited_members
-import data.terraform.gcp.helpers
+import data.terraform.helpers
 import data.terraform.gcp.security.deploy.target_iam_binding.vars
 
 conditions := [

--- a/policies/gcp/deploy/target_iam_binding/required_role/policy.rego
+++ b/policies/gcp/deploy/target_iam_binding/required_role/policy.rego
@@ -1,5 +1,5 @@
 package terraform.gcp.security.deploy.target_iam_binding.required_role
-import data.terraform.gcp.helpers
+import data.terraform.helpers
 import data.terraform.gcp.security.deploy.target_iam_binding.vars
 
 conditions := [

--- a/policies/gcp/deploy/target_iam_member/prohibited_member/policy.rego
+++ b/policies/gcp/deploy/target_iam_member/prohibited_member/policy.rego
@@ -1,5 +1,5 @@
 package terraform.gcp.security.deploy.target_iam_member.prohibited_member
-import data.terraform.gcp.helpers
+import data.terraform.helpers
 import data.terraform.gcp.security.deploy.target_iam_member.vars
 
 conditions := [

--- a/policies/gcp/deploy/target_iam_member/required_role/policy.rego
+++ b/policies/gcp/deploy/target_iam_member/required_role/policy.rego
@@ -1,5 +1,5 @@
 package terraform.gcp.security.deploy.target_iam_member.required_role
-import data.terraform.gcp.helpers
+import data.terraform.helpers
 import data.terraform.gcp.security.deploy.target_iam_member.vars
 
 conditions := [

--- a/policies/gcp/deploy/target_iam_policy/required_role/policy.rego
+++ b/policies/gcp/deploy/target_iam_policy/required_role/policy.rego
@@ -1,5 +1,5 @@
 package terraform.gcp.security.deploy.target_iam_policy.required_role
-import data.terraform.gcp.helpers
+import data.terraform.helpers
 import data.terraform.gcp.security.deploy.target_iam_policy.vars
 
 conditions := [

--- a/policies/gcp/developer_connect/google_developer_connect_account_connector/approved_locations/policy.rego
+++ b/policies/gcp/developer_connect/google_developer_connect_account_connector/approved_locations/policy.rego
@@ -1,5 +1,5 @@
 package terraform.gcp.security.developer_connect.google_developer_connect_account_connector.approved_locations
-import data.terraform.gcp.helpers
+import data.terraform.helpers
 import data.terraform.gcp.security.developer_connect.google_developer_connect_account_connector.vars
 
 conditions := [

--- a/policies/gcp/developer_connect/google_developer_connect_account_connector/least_privilege_scopes/policy.rego
+++ b/policies/gcp/developer_connect/google_developer_connect_account_connector/least_privilege_scopes/policy.rego
@@ -1,5 +1,5 @@
 package terraform.gcp.security.developer_connect.google_developer_connect_account_connector.least_privilege_scopes
-import data.terraform.gcp.helpers
+import data.terraform.helpers
 import data.terraform.gcp.security.developer_connect.google_developer_connect_account_connector.vars
 
 conditions := [

--- a/policies/gcp/developer_connect/google_developer_connect_account_connector/system_provider_id/policy.rego
+++ b/policies/gcp/developer_connect/google_developer_connect_account_connector/system_provider_id/policy.rego
@@ -1,5 +1,5 @@
 package terraform.gcp.security.developer_connect.google_developer_connect_account_connector.system_provider_id
-import data.terraform.gcp.helpers
+import data.terraform.helpers
 import data.terraform.gcp.security.developer_connect.google_developer_connect_account_connector.vars
 
 conditions := [

--- a/policies/gcp/developer_connect/google_developer_connect_connection/approved_location/policy.rego
+++ b/policies/gcp/developer_connect/google_developer_connect_connection/approved_location/policy.rego
@@ -1,5 +1,5 @@
 package terraform.gcp.security.developer_connect.google_developer_connect_connection.approved_location
-import data.terraform.gcp.helpers
+import data.terraform.helpers
 import data.terraform.gcp.security.developer_connect.google_developer_connect_connection.vars
 
 conditions := [

--- a/policies/gcp/developer_connect/google_developer_connect_connection/bitbucket_cloud_config_sub_attributes/policy.rego
+++ b/policies/gcp/developer_connect/google_developer_connect_connection/bitbucket_cloud_config_sub_attributes/policy.rego
@@ -1,5 +1,5 @@
 package terraform.gcp.security.developer_connect.google_developer_connect_connection.bitbucket_cloud_config_sub_attributes
-import data.terraform.gcp.helpers
+import data.terraform.helpers
 import data.terraform.gcp.security.developer_connect.google_developer_connect_connection.vars
 
 common := ["projects/*/secrets/*/versions/*", [["pde2025"], ["bbc-webhook","bbc-read-cred","bbc-auth-cred"], ["latest"]]]

--- a/policies/gcp/developer_connect/google_developer_connect_connection/bitbucket_data_center_config_sub_attributes/policy.rego
+++ b/policies/gcp/developer_connect/google_developer_connect_connection/bitbucket_data_center_config_sub_attributes/policy.rego
@@ -1,5 +1,5 @@
 package terraform.gcp.security.developer_connect.google_developer_connect_connection.bitbucket_data_center_config_sub_attributes
-import data.terraform.gcp.helpers
+import data.terraform.helpers
 import data.terraform.gcp.security.developer_connect.google_developer_connect_connection.vars
 
 conditions := [

--- a/policies/gcp/developer_connect/google_developer_connect_connection/cmek_key_reference/policy.rego
+++ b/policies/gcp/developer_connect/google_developer_connect_connection/cmek_key_reference/policy.rego
@@ -1,5 +1,5 @@
 package terraform.gcp.security.developer_connect.google_developer_connect_connection.cmek_key_reference
-import data.terraform.gcp.helpers
+import data.terraform.helpers
 import data.terraform.gcp.security.developer_connect.google_developer_connect_connection.vars
 
 conditions := [

--- a/policies/gcp/developer_connect/google_developer_connect_connection/github_config_sub_attributes/policy.rego
+++ b/policies/gcp/developer_connect/google_developer_connect_connection/github_config_sub_attributes/policy.rego
@@ -1,5 +1,5 @@
 package terraform.gcp.security.developer_connect.google_developer_connect_connection.github_config_sub_attributes
-import data.terraform.gcp.helpers
+import data.terraform.helpers
 import data.terraform.gcp.security.developer_connect.google_developer_connect_connection.vars
 
 conditions := [

--- a/policies/gcp/developer_connect/google_developer_connect_connection/github_enterprise_config_sub_attributes/policy.rego
+++ b/policies/gcp/developer_connect/google_developer_connect_connection/github_enterprise_config_sub_attributes/policy.rego
@@ -1,5 +1,5 @@
 package terraform.gcp.security.developer_connect.google_developer_connect_connection.github_enterprise_config_sub_attributes
-import data.terraform.gcp.helpers
+import data.terraform.helpers
 import data.terraform.gcp.security.developer_connect.google_developer_connect_connection.vars
 
 conditions := [

--- a/policies/gcp/developer_connect/google_developer_connect_connection/gitlab_config_sub_attributes/policy.rego
+++ b/policies/gcp/developer_connect/google_developer_connect_connection/gitlab_config_sub_attributes/policy.rego
@@ -1,5 +1,5 @@
 package terraform.gcp.security.developer_connect.google_developer_connect_connection.gitlab_config_sub_attributes
-import data.terraform.gcp.helpers
+import data.terraform.helpers
 import data.terraform.gcp.security.developer_connect.google_developer_connect_connection.vars
 
 common := ["projects/*/secrets/*/versions/*", [["pde2025"], ["gitlab-webhook","gitlab-read-cred","gitlab-auth-cred"], ["latest"]]]

--- a/policies/gcp/developer_connect/google_developer_connect_connection/gitlab_enterprise_config_sub_attributes/policy.rego
+++ b/policies/gcp/developer_connect/google_developer_connect_connection/gitlab_enterprise_config_sub_attributes/policy.rego
@@ -1,5 +1,5 @@
 package terraform.gcp.security.developer_connect.google_developer_connect_connection.gitlab_enterprise_config_sub_attributes
-import data.terraform.gcp.helpers
+import data.terraform.helpers
 import data.terraform.gcp.security.developer_connect.google_developer_connect_connection.vars
 
 conditions := [

--- a/policies/gcp/developer_connect/google_developer_connect_git_repository_link/approved_clone_uri/policy.rego
+++ b/policies/gcp/developer_connect/google_developer_connect_git_repository_link/approved_clone_uri/policy.rego
@@ -1,5 +1,5 @@
 package terraform.gcp.security.developer_connect.google_developer_connect_git_repository_link.approved_clone_uri
-import data.terraform.gcp.helpers
+import data.terraform.helpers
 import data.terraform.gcp.security.developer_connect.google_developer_connect_git_repository_link.vars
 
 conditions := [

--- a/policies/gcp/developer_connect/google_developer_connect_git_repository_link/approved_location/policy.rego
+++ b/policies/gcp/developer_connect/google_developer_connect_git_repository_link/approved_location/policy.rego
@@ -1,5 +1,5 @@
 package terraform.gcp.security.developer_connect.google_developer_connect_git_repository_link.approved_location
-import data.terraform.gcp.helpers
+import data.terraform.helpers
 import data.terraform.gcp.security.developer_connect.google_developer_connect_git_repository_link.vars
 
 conditions := [

--- a/policies/gcp/developer_connect/google_developer_connect_git_repository_link/approved_parent_connection/policy.rego
+++ b/policies/gcp/developer_connect/google_developer_connect_git_repository_link/approved_parent_connection/policy.rego
@@ -1,5 +1,5 @@
 package terraform.gcp.security.developer_connect.google_developer_connect_git_repository_link.approved_parent_connection
-import data.terraform.gcp.helpers
+import data.terraform.helpers
 import data.terraform.gcp.security.developer_connect.google_developer_connect_git_repository_link.vars
 
 conditions := [

--- a/policies/gcp/developer_connect/google_developer_connect_insights_config/approved_location/policy.rego
+++ b/policies/gcp/developer_connect/google_developer_connect_insights_config/approved_location/policy.rego
@@ -1,5 +1,5 @@
 package terraform.gcp.security.developer_connect.google_developer_connect_insights_config.approved_location
-import data.terraform.gcp.helpers
+import data.terraform.helpers
 import data.terraform.gcp.security.developer_connect.google_developer_connect_insights_config.vars
 
 conditions := [

--- a/policies/gcp/developer_connect/google_developer_connect_insights_config/insights_security_baseline/policy.rego
+++ b/policies/gcp/developer_connect/google_developer_connect_insights_config/insights_security_baseline/policy.rego
@@ -1,5 +1,5 @@
 package terraform.gcp.security.developer_connect.google_developer_connect_insights_config.insights_security_baseline
-import data.terraform.gcp.helpers
+import data.terraform.helpers
 import data.terraform.gcp.security.developer_connect.google_developer_connect_insights_config.vars
 
 allowed_ar_uri := ["*-docker.pkg.dev/*/*/*", [["australia-southeast1","australia-southeast2"], ["pde2025"], ["my-repo"], ["my-image"]]]

--- a/policies/gcp/discovery_engine/chat_engine/chat_engine_config/policy.rego
+++ b/policies/gcp/discovery_engine/chat_engine/chat_engine_config/policy.rego
@@ -1,5 +1,5 @@
 package terraform.gcp.security.discovery_engine.chat_engine.chat_engine_config
-import data.terraform.gcp.helpers
+import data.terraform.helpers
 import data.terraform.gcp.security.discovery_engine.chat_engine.vars
 
 #allow_cross_region

--- a/policies/gcp/discovery_engine/chat_engine/chat_engine_location/policy.rego
+++ b/policies/gcp/discovery_engine/chat_engine/chat_engine_location/policy.rego
@@ -1,5 +1,5 @@
 package terraform.gcp.security.discovery_engine.chat_engine.chat_engine_location # Edit here 
-import data.terraform.gcp.helpers
+import data.terraform.helpers
 import data.terraform.gcp.security.discovery_engine.chat_engine.vars
 
 #location check

--- a/policies/gcp/discovery_engine/cmek_config/cmek_config_kms_key/policy.rego
+++ b/policies/gcp/discovery_engine/cmek_config/cmek_config_kms_key/policy.rego
@@ -1,5 +1,5 @@
 package terraform.gcp.security.discovery_engine.cmek_config.cmek_config_kms_key 
-import data.terraform.gcp.helpers
+import data.terraform.helpers
 import data.terraform.gcp.security.discovery_engine.cmek_config.vars
 
 #cmek_config

--- a/policies/gcp/discovery_engine/cmek_config/cmek_config_location/policy.rego
+++ b/policies/gcp/discovery_engine/cmek_config/cmek_config_location/policy.rego
@@ -1,5 +1,5 @@
 package terraform.gcp.security.discovery_engine.cmek_config.cmek_config_location
-import data.terraform.gcp.helpers
+import data.terraform.helpers
 import data.terraform.gcp.security.discovery_engine.cmek_config.vars
 
 #cmek_config_location

--- a/policies/gcp/discovery_engine/cmek_config/cmek_config_single_region_keys/policy.rego
+++ b/policies/gcp/discovery_engine/cmek_config/cmek_config_single_region_keys/policy.rego
@@ -1,5 +1,5 @@
 package terraform.gcp.security.discovery_engine.cmek_config.cmek_config_single_region_keys 
-import data.terraform.gcp.helpers
+import data.terraform.helpers
 import data.terraform.gcp.security.discovery_engine.cmek_config.vars
 
 #cmek_config_single_region_keys

--- a/policies/gcp/discovery_engine/data_store/data_store_content_config/policy.rego
+++ b/policies/gcp/discovery_engine/data_store/data_store_content_config/policy.rego
@@ -1,5 +1,5 @@
 package terraform.gcp.security.discovery_engine.data_store.data_store_content_config 
-import data.terraform.gcp.helpers
+import data.terraform.helpers
 import data.terraform.gcp.security.discovery_engine.data_store.vars
 
 #Data_store_config

--- a/policies/gcp/discovery_engine/data_store/data_store_document_processing_config/policy.rego
+++ b/policies/gcp/discovery_engine/data_store/data_store_document_processing_config/policy.rego
@@ -1,5 +1,5 @@
 package terraform.gcp.security.discovery_engine.data_store.data_store_document_processing_config
-import data.terraform.gcp.helpers
+import data.terraform.helpers
 import data.terraform.gcp.security.discovery_engine.data_store.vars
 
 #document_processing_config

--- a/policies/gcp/discovery_engine/data_store/data_store_kms_key_name/policy.rego
+++ b/policies/gcp/discovery_engine/data_store/data_store_kms_key_name/policy.rego
@@ -1,5 +1,5 @@
 package terraform.gcp.security.discovery_engine.data_store.data_store_kms_key_name
-import data.terraform.gcp.helpers
+import data.terraform.helpers
 import data.terraform.gcp.security.discovery_engine.data_store.vars
 
 #KMS_Key_Name

--- a/policies/gcp/discovery_engine/data_store/data_store_location/policy.rego
+++ b/policies/gcp/discovery_engine/data_store/data_store_location/policy.rego
@@ -1,5 +1,5 @@
 package terraform.gcp.security.discovery_engine.data_store.data_store_location
-import data.terraform.gcp.helpers
+import data.terraform.helpers
 import data.terraform.gcp.security.discovery_engine.data_store.vars
 
 #Data_store_location

--- a/policies/gcp/discovery_engine/engine_schema/engine_schema_json/policy.rego
+++ b/policies/gcp/discovery_engine/engine_schema/engine_schema_json/policy.rego
@@ -1,5 +1,5 @@
 package terraform.gcp.security.discovery_engine.engine_schema.engine_schema_json
-import data.terraform.gcp.helpers
+import data.terraform.helpers
 import data.terraform.gcp.security.discovery_engine.engine_schema.vars
 
 #engine_schema_json

--- a/policies/gcp/discovery_engine/engine_schema/engine_schema_location/policy.rego
+++ b/policies/gcp/discovery_engine/engine_schema/engine_schema_location/policy.rego
@@ -1,5 +1,5 @@
 package terraform.gcp.security.discovery_engine.engine_schema.engine_schema_location
-import data.terraform.gcp.helpers
+import data.terraform.helpers
 import data.terraform.gcp.security.discovery_engine.engine_schema.vars
 
 #engine_schema_location

--- a/policies/gcp/discovery_engine/search_engine/search_engine_industry_vertical/policy.rego
+++ b/policies/gcp/discovery_engine/search_engine/search_engine_industry_vertical/policy.rego
@@ -1,5 +1,5 @@
 package terraform.gcp.security.discovery_engine.search_engine.search_engine_industry_vertical
-import data.terraform.gcp.helpers
+import data.terraform.helpers
 import data.terraform.gcp.security.discovery_engine.search_engine.vars
 
 #search_engine_industry_vertical

--- a/policies/gcp/firebase_app_hosting/backend/codebase_repository/policy.rego
+++ b/policies/gcp/firebase_app_hosting/backend/codebase_repository/policy.rego
@@ -1,6 +1,6 @@
 package terraform.gcp.security.firebase_app_hosting.backend.codebase_repository
 
-import data.terraform.gcp.helpers
+import data.terraform.helpers
 import data.terraform.gcp.security.firebase_app_hosting.backend.vars
 
 conditions := [

--- a/policies/gcp/firebase_app_hosting/backend/location/policy.rego
+++ b/policies/gcp/firebase_app_hosting/backend/location/policy.rego
@@ -1,6 +1,6 @@
 package terraform.gcp.security.firebase_app_hosting.backend.location
 
-import data.terraform.gcp.helpers
+import data.terraform.helpers
 import data.terraform.gcp.security.firebase_app_hosting.backend.vars
 
 conditions := [

--- a/policies/gcp/firebase_app_hosting/backend/serving_locality/policy.rego
+++ b/policies/gcp/firebase_app_hosting/backend/serving_locality/policy.rego
@@ -1,6 +1,6 @@
 package terraform.gcp.security.firebase_app_hosting.backend.serving_locality
 
-import data.terraform.gcp.helpers
+import data.terraform.helpers
 import data.terraform.gcp.security.firebase_app_hosting.backend.vars
 
 conditions := [

--- a/policies/gcp/firebase_app_hosting/traffic/rollout_policy_codebase_branch/policy.rego
+++ b/policies/gcp/firebase_app_hosting/traffic/rollout_policy_codebase_branch/policy.rego
@@ -1,6 +1,6 @@
 package terraform.gcp.security.firebase_app_hosting.traffic.rollout_policy_codebase_branch
 
-import data.terraform.gcp.helpers
+import data.terraform.helpers
 import data.terraform.gcp.security.firebase_app_hosting.traffic.vars
 
 conditions := [

--- a/policies/gcp/firebase_hosting/google_firebase_hosting_custom_domain/custom_domain_verification/policy.rego
+++ b/policies/gcp/firebase_hosting/google_firebase_hosting_custom_domain/custom_domain_verification/policy.rego
@@ -1,6 +1,6 @@
 package terraform.gcp.security.firebase_hosting.google_firebase_hosting_custom_domain.custom_domain_verification
 
-import data.terraform.gcp.helpers
+import data.terraform.helpers
 import data.terraform.gcp.security.firebase_hosting.google_firebase_hosting_custom_domain.vars
 
 conditions := [

--- a/policies/gcp/firebase_hosting/google_firebase_hosting_version/cache_control_secure/policy.rego
+++ b/policies/gcp/firebase_hosting/google_firebase_hosting_version/cache_control_secure/policy.rego
@@ -1,6 +1,6 @@
 package terraform.gcp.security.firebase_hosting.google_firebase_hosting_version.cache_control_secure
 
-import data.terraform.gcp.helpers
+import data.terraform.helpers
 import data.terraform.gcp.security.firebase_hosting.google_firebase_hosting_version.vars
 
 conditions := [

--- a/policies/gcp/firebase_hosting/google_firebase_hosting_version/cors_policy_secure/policy.rego
+++ b/policies/gcp/firebase_hosting/google_firebase_hosting_version/cors_policy_secure/policy.rego
@@ -1,6 +1,6 @@
 package terraform.gcp.security.firebase_hosting.google_firebase_hosting_version.cors_policy_secure
 
-import data.terraform.gcp.helpers
+import data.terraform.helpers
 import data.terraform.gcp.security.firebase_hosting.google_firebase_hosting_version.vars
 
 # NOTE

--- a/policies/gcp/firebase_hosting/google_firebase_hosting_version/headers_security/policy.rego
+++ b/policies/gcp/firebase_hosting/google_firebase_hosting_version/headers_security/policy.rego
@@ -1,6 +1,6 @@
 package terraform.gcp.security.firebase_hosting.google_firebase_hosting_version.headers_security
 
-import data.terraform.gcp.helpers
+import data.terraform.helpers
 import data.terraform.gcp.security.firebase_hosting.google_firebase_hosting_version.vars
 
 # We validate concrete, safe values so presence + correctness are both enforced.

--- a/policies/gcp/firebase_hosting/google_firebase_hosting_version/redirect_rules_secure/policy.rego
+++ b/policies/gcp/firebase_hosting/google_firebase_hosting_version/redirect_rules_secure/policy.rego
@@ -1,6 +1,6 @@
 package terraform.gcp.security.firebase_hosting.google_firebase_hosting_version.redirect_rules_secure
 
-import data.terraform.gcp.helpers
+import data.terraform.helpers
 import data.terraform.gcp.security.firebase_hosting.google_firebase_hosting_version.vars
 
 conditions := [

--- a/policies/gcp/firebase_hosting/google_firebase_hosting_version/rewrite_rules_secure/policy.rego
+++ b/policies/gcp/firebase_hosting/google_firebase_hosting_version/rewrite_rules_secure/policy.rego
@@ -1,6 +1,6 @@
 package terraform.gcp.security.firebase_hosting.google_firebase_hosting_version.rewrite_rules_secure
 
-import data.terraform.gcp.helpers
+import data.terraform.helpers
 import data.terraform.gcp.security.firebase_hosting.google_firebase_hosting_version.vars
 
 conditions := [

--- a/policies/gcp/firebase_realtime_database/google_firebase_database_instance/desired_state/policy.rego
+++ b/policies/gcp/firebase_realtime_database/google_firebase_database_instance/desired_state/policy.rego
@@ -1,5 +1,5 @@
 package terraform.gcp.security.firebase_realtime_database.google_firebase_database_instance.desired_state  
-import data.terraform.gcp.helpers
+import data.terraform.helpers
 import data.terraform.gcp.security.firebase_realtime_database.google_firebase_database_instance.vars
 
 conditions := [

--- a/policies/gcp/firebase_realtime_database/google_firebase_database_instance/type/policy.rego
+++ b/policies/gcp/firebase_realtime_database/google_firebase_database_instance/type/policy.rego
@@ -1,5 +1,5 @@
 package terraform.gcp.security.firebase_realtime_database.google_firebase_database_instance.type 
-import data.terraform.gcp.helpers
+import data.terraform.helpers
 import data.terraform.gcp.security.firebase_realtime_database.google_firebase_database_instance.vars
 
 conditions := [

--- a/policies/gcp/firestore/firestore_backup_schedule/daily_recurrence/policy.rego
+++ b/policies/gcp/firestore/firestore_backup_schedule/daily_recurrence/policy.rego
@@ -1,6 +1,6 @@
 package terraform.gcp.security.firestore_backup_schedule.daily_recurrence
 
-import data.terraform.gcp.helpers
+import data.terraform.helpers
 import data.terraform.gcp.security.firestore.firestore_backup_schedule.vars
 
 conditions := [

--- a/policies/gcp/firestore/firestore_backup_schedule/retention/policy.rego
+++ b/policies/gcp/firestore/firestore_backup_schedule/retention/policy.rego
@@ -1,6 +1,6 @@
 package terraform.gcp.security.firestore_backup_schedule.retention
 
-import data.terraform.gcp.helpers
+import data.terraform.helpers
 import data.terraform.gcp.security.firestore.firestore_backup_schedule.vars
 
 conditions := [

--- a/policies/gcp/firestore/firestore_backup_schedule/weekly_recurrence/policy.rego
+++ b/policies/gcp/firestore/firestore_backup_schedule/weekly_recurrence/policy.rego
@@ -1,6 +1,6 @@
 package terraform.gcp.security.firestore_backup_schedule.weekly_recurrence
 
-import data.terraform.gcp.helpers
+import data.terraform.helpers
 import data.terraform.gcp.security.firestore.firestore_backup_schedule.vars
 
 conditions := [

--- a/policies/gcp/firestore/firestore_database/app_engine_integration_mode/policy.rego
+++ b/policies/gcp/firestore/firestore_database/app_engine_integration_mode/policy.rego
@@ -1,6 +1,6 @@
 package terraform.gcp.security.firestore_database.app_engine_integration_mode
 
-import data.terraform.gcp.helpers
+import data.terraform.helpers
 import data.terraform.gcp.security.firestore.firestore_database.vars
 
 conditions := [

--- a/policies/gcp/firestore/firestore_database/concurrency_mode/policy.rego
+++ b/policies/gcp/firestore/firestore_database/concurrency_mode/policy.rego
@@ -1,6 +1,6 @@
 package terraform.gcp.security.firestore_database.concurrency_mode
 
-import data.terraform.gcp.helpers
+import data.terraform.helpers
 import data.terraform.gcp.security.firestore.firestore_database.vars
 
 conditions := [

--- a/policies/gcp/firestore/firestore_database/location_id/policy.rego
+++ b/policies/gcp/firestore/firestore_database/location_id/policy.rego
@@ -1,6 +1,6 @@
 package terraform.gcp.security.firestore_database.location_id
 
-import data.terraform.gcp.helpers
+import data.terraform.helpers
 import data.terraform.gcp.security.firestore.firestore_database.vars
 
 conditions := [

--- a/policies/gcp/firestore/firestore_document/collection/policy.rego
+++ b/policies/gcp/firestore/firestore_document/collection/policy.rego
@@ -1,6 +1,6 @@
 package terraform.gcp.security.firestore_document.collection
 
-import data.terraform.gcp.helpers
+import data.terraform.helpers
 import data.terraform.gcp.security.firestore.firestore_document.vars
 
 conditions := [

--- a/policies/gcp/firestore/firestore_document/fields/policy.rego
+++ b/policies/gcp/firestore/firestore_document/fields/policy.rego
@@ -1,6 +1,6 @@
 package terraform.gcp.security.firestore_document.fields
 
-import data.terraform.gcp.helpers
+import data.terraform.helpers
 import data.terraform.gcp.security.firestore.firestore_document.vars
 import future.keywords.if
 

--- a/policies/gcp/firestore/firestore_document/project/policy.rego
+++ b/policies/gcp/firestore/firestore_document/project/policy.rego
@@ -1,6 +1,6 @@
 package terraform.gcp.security.firestore_document.project
 
-import data.terraform.gcp.helpers
+import data.terraform.helpers
 import data.terraform.gcp.security.firestore.firestore_document.vars
 
 conditions := [

--- a/policies/gcp/gdce/cluster/cidr_blocks/policy.rego
+++ b/policies/gcp/gdce/cluster/cidr_blocks/policy.rego
@@ -1,5 +1,5 @@
 package terraform.gcp.security.gdce.cluster.cidr_blocks
-import data.terraform.gcp.helpers
+import data.terraform.helpers
 import data.terraform.gcp.security.gdce.cluster.vars
 
 conditions := [

--- a/policies/gcp/gdce/cluster/maintenance_policy/policy.rego
+++ b/policies/gcp/gdce/cluster/maintenance_policy/policy.rego
@@ -1,5 +1,5 @@
 package terraform.gcp.security.gdce.cluster.maintenance_policy
-import data.terraform.gcp.helpers
+import data.terraform.helpers
 import data.terraform.gcp.security.gdce.cluster.vars
 
 conditions := [

--- a/policies/gcp/gdce/cluster/target_version/policy.rego
+++ b/policies/gcp/gdce/cluster/target_version/policy.rego
@@ -1,5 +1,5 @@
 package terraform.gcp.security.gdce.cluster.target_version
-import data.terraform.gcp.helpers
+import data.terraform.helpers
 import data.terraform.gcp.security.gdce.cluster.vars
 
 conditions := [

--- a/policies/gcp/gdce/node_pool/basic_checks/policy.rego
+++ b/policies/gcp/gdce/node_pool/basic_checks/policy.rego
@@ -1,6 +1,6 @@
 package terraform.gcp.security.gdce.node_pool.basic_checks
 
-import data.terraform.gcp.helpers
+import data.terraform.helpers
 import data.terraform.gcp.security.gdce.node_pool.vars # Shared vars
 
 conditions := [

--- a/policies/gcp/gdce/node_pool/disk_encryption/policy.rego
+++ b/policies/gcp/gdce/node_pool/disk_encryption/policy.rego
@@ -1,5 +1,5 @@
 package terraform.gcp.security.gdce.node_pool.disk_encryption
-import data.terraform.gcp.helpers
+import data.terraform.helpers
 import data.terraform.gcp.security.gdce.node_pool.vars
 
 conditions := [

--- a/policies/gcp/gdce/vpn_connection/vpc/policy.rego
+++ b/policies/gcp/gdce/vpn_connection/vpc/policy.rego
@@ -1,5 +1,5 @@
 package terraform.gcp.security.gdce.vpn_connection.vpc
-import data.terraform.gcp.helpers
+import data.terraform.helpers
 import data.terraform.gcp.security.gdce.vpn_connection.vars
 
 conditions := [

--- a/policies/gcp/google_cloud_netapp_volumes/google_netapp_active_directory/required_domain/policy.rego
+++ b/policies/gcp/google_cloud_netapp_volumes/google_netapp_active_directory/required_domain/policy.rego
@@ -1,5 +1,5 @@
 package terraform.gcp.security.google_cloud_netapp_volumes.google_netapp_active_directory.required_domain  
-import data.terraform.gcp.helpers
+import data.terraform.helpers
 import data.terraform.gcp.security.google_cloud_netapp_volumes.google_netapp_active_directory.vars
 
 

--- a/policies/gcp/google_cloud_netapp_volumes/google_netapp_active_directory/valid_dns/policy.rego
+++ b/policies/gcp/google_cloud_netapp_volumes/google_netapp_active_directory/valid_dns/policy.rego
@@ -1,6 +1,6 @@
 package terraform.gcp.security.google_cloud_netapp_volumes.google_netapp_active_directory.valid_dns
 
-import data.terraform.gcp.helpers
+import data.terraform.helpers
 import data.terraform.gcp.security.google_cloud_netapp_volumes.google_netapp_active_directory.vars
 
 conditions := [

--- a/policies/gcp/google_cloud_netapp_volumes/google_netapp_active_directory/valid_password/policy.rego
+++ b/policies/gcp/google_cloud_netapp_volumes/google_netapp_active_directory/valid_password/policy.rego
@@ -1,6 +1,6 @@
 package terraform.gcp.security.google_cloud_netapp_volumes.google_netapp_active_directory.valid_password
 
-import data.terraform.gcp.helpers
+import data.terraform.helpers
 import data.terraform.gcp.security.google_cloud_netapp_volumes.google_netapp_active_directory.vars
 
 conditions := [

--- a/policies/gcp/google_cloud_netapp_volumes/google_netapp_active_directory/valid_username/policy.rego
+++ b/policies/gcp/google_cloud_netapp_volumes/google_netapp_active_directory/valid_username/policy.rego
@@ -1,6 +1,6 @@
 package terraform.gcp.security.google_cloud_netapp_volumes.google_netapp_active_directory.valid_username
 
-import data.terraform.gcp.helpers
+import data.terraform.helpers
 import data.terraform.gcp.security.google_cloud_netapp_volumes.google_netapp_active_directory.vars
 
 conditions := [

--- a/policies/gcp/google_cloud_netapp_volumes/google_netapp_backup/allowed_location/policy.rego
+++ b/policies/gcp/google_cloud_netapp_volumes/google_netapp_backup/allowed_location/policy.rego
@@ -1,6 +1,6 @@
 package terraform.gcp.security.google_cloud_netapp_volumes.google_netapp_backup.allowed_location
 
-import data.terraform.gcp.helpers
+import data.terraform.helpers
 import data.terraform.gcp.security.google_cloud_netapp_volumes.google_netapp_backup.vars
 
 conditions := [

--- a/policies/gcp/google_cloud_netapp_volumes/google_netapp_backup/allowed_source_volume/policy.rego
+++ b/policies/gcp/google_cloud_netapp_volumes/google_netapp_backup/allowed_source_volume/policy.rego
@@ -1,6 +1,6 @@
 package terraform.gcp.security.google_cloud_netapp_volumes.google_netapp_backup.allowed_source_volume
 
-import data.terraform.gcp.helpers
+import data.terraform.helpers
 import data.terraform.gcp.security.google_cloud_netapp_volumes.google_netapp_backup.vars
 
 conditions := [

--- a/policies/gcp/google_cloud_netapp_volumes/google_netapp_backup/approved_vault_name/policy.rego
+++ b/policies/gcp/google_cloud_netapp_volumes/google_netapp_backup/approved_vault_name/policy.rego
@@ -1,6 +1,6 @@
 package terraform.gcp.security.google_cloud_netapp_volumes.google_netapp_backup.approved_vault_name
 
-import data.terraform.gcp.helpers
+import data.terraform.helpers
 import data.terraform.gcp.security.google_cloud_netapp_volumes.google_netapp_backup.vars
 
 conditions := [

--- a/policies/gcp/google_cloud_netapp_volumes/google_netapp_backup_policy/allowed_location/policy.rego
+++ b/policies/gcp/google_cloud_netapp_volumes/google_netapp_backup_policy/allowed_location/policy.rego
@@ -1,6 +1,6 @@
 package terraform.gcp.security.google_cloud_netapp_volumes.google_netapp_backup_policy.allowed_location
 
-import data.terraform.gcp.helpers
+import data.terraform.helpers
 import data.terraform.gcp.security.google_cloud_netapp_volumes.google_netapp_backup_policy.vars
 
 conditions := [

--- a/policies/gcp/google_cloud_netapp_volumes/google_netapp_backup_policy/required_daily_backup_limit/policy.rego
+++ b/policies/gcp/google_cloud_netapp_volumes/google_netapp_backup_policy/required_daily_backup_limit/policy.rego
@@ -1,6 +1,6 @@
 package terraform.gcp.security.google_cloud_netapp_volumes.google_netapp_backup_policy.required_daily_backup_limit
 
-import data.terraform.gcp.helpers
+import data.terraform.helpers
 import data.terraform.gcp.security.google_cloud_netapp_volumes.google_netapp_backup_policy.vars
 
 conditions := [

--- a/policies/gcp/google_cloud_netapp_volumes/google_netapp_backup_vault/allowed_location/policy.rego
+++ b/policies/gcp/google_cloud_netapp_volumes/google_netapp_backup_vault/allowed_location/policy.rego
@@ -1,6 +1,6 @@
 package terraform.gcp.security.google_cloud_netapp_volumes.google_netapp_backup_vault.allowed_location
 
-import data.terraform.gcp.helpers
+import data.terraform.helpers
 import data.terraform.gcp.security.google_cloud_netapp_volumes.google_netapp_backup_vault.vars
 
 conditions := [

--- a/policies/gcp/google_cloud_netapp_volumes/google_netapp_kmsconfig/allowed_location/policy.rego
+++ b/policies/gcp/google_cloud_netapp_volumes/google_netapp_kmsconfig/allowed_location/policy.rego
@@ -1,6 +1,6 @@
 package terraform.gcp.security.google_cloud_netapp_volumes.google_netapp_kmsconfig.allowed_location
 
-import data.terraform.gcp.helpers
+import data.terraform.helpers
 import data.terraform.gcp.security.google_cloud_netapp_volumes.google_netapp_kmsconfig.vars
 
 conditions := [

--- a/policies/gcp/google_cloud_netapp_volumes/google_netapp_kmsconfig/valid_crypto_key_name/policy.rego
+++ b/policies/gcp/google_cloud_netapp_volumes/google_netapp_kmsconfig/valid_crypto_key_name/policy.rego
@@ -1,6 +1,6 @@
 package terraform.gcp.security.google_cloud_netapp_volumes.google_netapp_kmsconfig.valid_crypto_key_name
 
-import data.terraform.gcp.helpers
+import data.terraform.helpers
 import data.terraform.gcp.security.google_cloud_netapp_volumes.google_netapp_kmsconfig.vars
 
 conditions := [

--- a/policies/gcp/google_cloud_netapp_volumes/google_netapp_storage_pool/allowed_location/policy.rego
+++ b/policies/gcp/google_cloud_netapp_volumes/google_netapp_storage_pool/allowed_location/policy.rego
@@ -1,6 +1,6 @@
 package terraform.gcp.security.google_cloud_netapp_volumes.google_netapp_storage_pool.allowed_location
 
-import data.terraform.gcp.helpers
+import data.terraform.helpers
 import data.terraform.gcp.security.google_cloud_netapp_volumes.google_netapp_storage_pool.vars
 
 conditions := [

--- a/policies/gcp/google_cloud_netapp_volumes/google_netapp_storage_pool/allowed_network/policy.rego
+++ b/policies/gcp/google_cloud_netapp_volumes/google_netapp_storage_pool/allowed_network/policy.rego
@@ -1,6 +1,6 @@
 package terraform.gcp.security.google_cloud_netapp_volumes.google_netapp_storage_pool.allowed_network
 
-import data.terraform.gcp.helpers
+import data.terraform.helpers
 import data.terraform.gcp.security.google_cloud_netapp_volumes.google_netapp_storage_pool.vars
 
 conditions := [

--- a/policies/gcp/google_cloud_netapp_volumes/google_netapp_volume/valid_protocols/policy.rego
+++ b/policies/gcp/google_cloud_netapp_volumes/google_netapp_volume/valid_protocols/policy.rego
@@ -1,5 +1,5 @@
 package terraform.gcp.security.google_cloud_netapp_volumes.google_netapp_volume.valid_protocols  
-import data.terraform.gcp.helpers
+import data.terraform.helpers
 import data.terraform.gcp.security.google_cloud_netapp_volumes.google_netapp_volume.vars
 
 

--- a/policies/gcp/google_cloud_netapp_volumes/google_netapp_volume_quota_rule/allowed_location/policy.rego
+++ b/policies/gcp/google_cloud_netapp_volumes/google_netapp_volume_quota_rule/allowed_location/policy.rego
@@ -1,6 +1,6 @@
 package terraform.gcp.security.google_cloud_netapp_volumes.google_netapp_volume_quota_rule.allowed_location
 
-import data.terraform.gcp.helpers
+import data.terraform.helpers
 import data.terraform.gcp.security.google_cloud_netapp_volumes.google_netapp_volume_quota_rule.vars
 
 conditions := [

--- a/policies/gcp/google_cloud_netapp_volumes/google_netapp_volume_quota_rule/disk_limit_mib_range/policy.rego
+++ b/policies/gcp/google_cloud_netapp_volumes/google_netapp_volume_quota_rule/disk_limit_mib_range/policy.rego
@@ -1,6 +1,6 @@
 package terraform.gcp.security.google_cloud_netapp_volumes.google_netapp_volume_quota_rule.disk_limit_mib_range
 
-import data.terraform.gcp.helpers
+import data.terraform.helpers
 import data.terraform.gcp.security.google_cloud_netapp_volumes.google_netapp_volume_quota_rule.vars
 
 conditions := [

--- a/policies/gcp/google_cloud_netapp_volumes/google_netapp_volume_replication/allowed_location/policy.rego
+++ b/policies/gcp/google_cloud_netapp_volumes/google_netapp_volume_replication/allowed_location/policy.rego
@@ -1,6 +1,6 @@
 package terraform.gcp.security.google_cloud_netapp_volumes.google_netapp_volume_replication.allowed_location
 
-import data.terraform.gcp.helpers
+import data.terraform.helpers
 import data.terraform.gcp.security.google_cloud_netapp_volumes.google_netapp_volume_replication.vars
 
 conditions := [

--- a/policies/gcp/google_cloud_netapp_volumes/google_netapp_volume_replication/required_replication_schedule/policy.rego
+++ b/policies/gcp/google_cloud_netapp_volumes/google_netapp_volume_replication/required_replication_schedule/policy.rego
@@ -1,6 +1,6 @@
 package terraform.gcp.security.google_cloud_netapp_volumes.google_netapp_volume_replication.required_replication_schedule
 
-import data.terraform.gcp.helpers
+import data.terraform.helpers
 import data.terraform.gcp.security.google_cloud_netapp_volumes.google_netapp_volume_replication.vars
 
 conditions := [

--- a/policies/gcp/google_cloud_netapp_volumes/google_netapp_volume_snapshot/allowed_location/policy.rego
+++ b/policies/gcp/google_cloud_netapp_volumes/google_netapp_volume_snapshot/allowed_location/policy.rego
@@ -1,6 +1,6 @@
 package terraform.gcp.security.google_cloud_netapp_volumes.google_netapp_volume_snapshot.allowed_location
 
-import data.terraform.gcp.helpers
+import data.terraform.helpers
 import data.terraform.gcp.security.google_cloud_netapp_volumes.google_netapp_volume_snapshot.vars
 
 conditions := [

--- a/policies/gcp/google_cloud_netapp_volumes/google_netapp_volume_snapshot/allowed_volume_name/policy.rego
+++ b/policies/gcp/google_cloud_netapp_volumes/google_netapp_volume_snapshot/allowed_volume_name/policy.rego
@@ -1,6 +1,6 @@
 package terraform.gcp.security.google_cloud_netapp_volumes.google_netapp_volume_snapshot.allowed_volume_name
 
-import data.terraform.gcp.helpers
+import data.terraform.helpers
 import data.terraform.gcp.security.google_cloud_netapp_volumes.google_netapp_volume_snapshot.vars
 
 conditions := [

--- a/policies/gcp/google_cloudfunction/google_cloudfunctions2_function/env_variable/policy.rego
+++ b/policies/gcp/google_cloudfunction/google_cloudfunctions2_function/env_variable/policy.rego
@@ -1,6 +1,6 @@
 package terraform.gcp.security.google_cloudfunction.google_cloudfunctions2_function.env_variable
 
-import data.terraform.gcp.helpers
+import data.terraform.helpers
 import data.terraform.gcp.security.google_cloudfunction.google_cloudfunctions2_function.vars
 
 

--- a/policies/gcp/google_cloudfunction/google_cloudfunctions2_function/ingress_settings/policy.rego
+++ b/policies/gcp/google_cloudfunction/google_cloudfunctions2_function/ingress_settings/policy.rego
@@ -1,6 +1,6 @@
 package terraform.gcp.security.google_cloudfunction.google_cloudfunctions2_function.ingress
 
-import data.terraform.gcp.helpers
+import data.terraform.helpers
 import data.terraform.gcp.security.google_cloudfunction.google_cloudfunctions2_function.vars
 
 conditions := [

--- a/policies/gcp/google_cloudfunction/google_cloudfunctions2_function/location/policy.rego
+++ b/policies/gcp/google_cloudfunction/google_cloudfunctions2_function/location/policy.rego
@@ -1,6 +1,6 @@
 package terraform.gcp.security.google_cloudfunction.google_cloudfunctions2_function.location
 
-import data.terraform.gcp.helpers
+import data.terraform.helpers
 import data.terraform.gcp.security.google_cloudfunction.google_cloudfunctions2_function.vars
 
 

--- a/policies/gcp/google_cloudfunction/google_cloudfunctions2_function/timeout/policy.rego
+++ b/policies/gcp/google_cloudfunction/google_cloudfunctions2_function/timeout/policy.rego
@@ -1,6 +1,6 @@
 package terraform.gcp.security.google_cloudfunction.google_cloudfunctions2_function.timeout
 
-import data.terraform.gcp.helpers
+import data.terraform.helpers
 import data.terraform.gcp.security.google_cloudfunction.google_cloudfunctions2_function.vars
 
 conditions := [

--- a/policies/gcp/google_cloudfunction/google_cloudfunctions2_function/vpc_connector/policy.rego
+++ b/policies/gcp/google_cloudfunction/google_cloudfunctions2_function/vpc_connector/policy.rego
@@ -1,6 +1,6 @@
 package terraform.gcp.security.google_cloudfunction.google_cloudfunctions2_function.vpc
 
-import data.terraform.gcp.helpers
+import data.terraform.helpers
 import data.terraform.gcp.security.google_cloudfunction.google_cloudfunctions2_function.vars
 
 conditions := [

--- a/policies/gcp/google_cloudfunction/google_cloudfunctions2_function_iam/google_cloudfunctions2_function_iam_member/member/policy.rego
+++ b/policies/gcp/google_cloudfunction/google_cloudfunctions2_function_iam/google_cloudfunctions2_function_iam_member/member/policy.rego
@@ -1,6 +1,6 @@
 package terraform.gcp.security.google_cloudfunction.google_cloudfunctions2_function_iam.member
 
-import data.terraform.gcp.helpers
+import data.terraform.helpers
 import data.terraform.gcp.security.google_cloudfunction.google_cloudfunctions2_function_iam.google_cloudfunctions2_function_iam_member.vars
 
 conditions := [

--- a/policies/gcp/google_cloudfunction/google_cloudfunctions2_function_iam/google_cloudfunctions2_function_iam_member/role/policy.rego
+++ b/policies/gcp/google_cloudfunction/google_cloudfunctions2_function_iam/google_cloudfunctions2_function_iam_member/role/policy.rego
@@ -1,6 +1,6 @@
 package terraform.gcp.security.google_cloudfunction.google_cloudfunctions2_function_iam.policy
 
-import data.terraform.gcp.helpers
+import data.terraform.helpers
 import data.terraform.gcp.security.google_cloudfunction.google_cloudfunctions2_function_iam.google_cloudfunctions2_function_iam_member.vars
 
 conditions := [

--- a/policies/gcp/google_cloudfunction/google_cloudfunctions2_function_iam/google_cloudfunctions2_function_iam_policy/cloud_function/policy.rego
+++ b/policies/gcp/google_cloudfunction/google_cloudfunctions2_function_iam/google_cloudfunctions2_function_iam_policy/cloud_function/policy.rego
@@ -1,5 +1,5 @@
 package terraform.gcp.security.google_cloudfunction.google_cloudfunctions2_function_iam.cloud_function
-import data.terraform.gcp.helpers
+import data.terraform.helpers
 import data.terraform.gcp.security.google_cloudfunction.google_cloudfunctions2_function_iam.google_cloudfunctions2_function_iam_policy.vars
 
 

--- a/policies/gcp/google_dataproc_on_gdc/application_environment/spark_application_environment_config/policy.rego
+++ b/policies/gcp/google_dataproc_on_gdc/application_environment/spark_application_environment_config/policy.rego
@@ -1,5 +1,5 @@
 package terraform.gcp.security.google_dataproc_on_gdc.application_environment.spark_application_environment_config  
-import data.terraform.gcp.helpers
+import data.terraform.helpers
 import data.terraform.gcp.security.google_dataproc_on_gdc.application_environment.vars
 
 conditions := [

--- a/policies/gcp/google_kms/google_kms_crypto_key/complaint_purpose/policy.rego
+++ b/policies/gcp/google_kms/google_kms_crypto_key/complaint_purpose/policy.rego
@@ -1,5 +1,5 @@
 package terraform.gcp.security.google_kms.google_kms_crypto_key.complaint_purpose
-import data.terraform.gcp.helpers
+import data.terraform.helpers
 import data.terraform.gcp.security.google_kms.google_kms_crypto_key.vars 
 
 conditions := [

--- a/policies/gcp/google_kms/google_kms_crypto_key/scheduled_destroy_duration/policy.rego
+++ b/policies/gcp/google_kms/google_kms_crypto_key/scheduled_destroy_duration/policy.rego
@@ -1,5 +1,5 @@
 package terraform.gcp.security.google_kms.google_kms_crypto_key.scheduled_destroy_duration
-import data.terraform.gcp.helpers as helpers
+import data.terraform.helpers as helpers
 import data.terraform.gcp.security.google_kms.google_kms_crypto_key.vars as vars
 
 

--- a/policies/gcp/google_kms/google_kms_crypto_key/scheduled_rotation_period/policy.rego
+++ b/policies/gcp/google_kms/google_kms_crypto_key/scheduled_rotation_period/policy.rego
@@ -1,5 +1,5 @@
 package terraform.gcp.security.google_kms.google_kms_crypto_key.scheduled_rotation_period
-import data.terraform.gcp.helpers as helpers
+import data.terraform.helpers as helpers
 import data.terraform.gcp.security.google_kms.google_kms_crypto_key.vars as vars
 
 

--- a/policies/gcp/google_kms/google_kms_crypto_key_iam_binding/approved_role/policy.rego
+++ b/policies/gcp/google_kms/google_kms_crypto_key_iam_binding/approved_role/policy.rego
@@ -1,5 +1,5 @@
 package terraform.gcp.security.google_kms.google_kms_crypto_key_iam_binding.approved_role
-import data.terraform.gcp.helpers as helpers
+import data.terraform.helpers as helpers
 import data.terraform.gcp.security.google_kms.google_kms_crypto_key_iam_binding.vars as vars
 
 conditions := [

--- a/policies/gcp/google_kms/google_kms_crypto_key_version/state_allowed/policy.rego
+++ b/policies/gcp/google_kms/google_kms_crypto_key_version/state_allowed/policy.rego
@@ -1,5 +1,5 @@
 package terraform.gcp.security.google_kms.google_kms_crypto_key_version.state_allowed
-import data.terraform.gcp.helpers as helpers
+import data.terraform.helpers as helpers
 import data.terraform.gcp.security.google_kms.google_kms_crypto_key_version.vars
 
 conditions :=[

--- a/policies/gcp/google_kms/google_kms_ekm_connection/approved_location/policy.rego
+++ b/policies/gcp/google_kms/google_kms_ekm_connection/approved_location/policy.rego
@@ -1,5 +1,5 @@
 package terraform.gcp.security.google_kms.google_kms_ekm_connection.approved_location
-import data.terraform.gcp.helpers as helpers
+import data.terraform.helpers as helpers
 import data.terraform.gcp.security.google_kms.google_kms_ekm_connection.vars as vars
 
 conditions := [

--- a/policies/gcp/google_kms/google_kms_ekm_connection/cert_hostname_match/policy.rego
+++ b/policies/gcp/google_kms/google_kms_ekm_connection/cert_hostname_match/policy.rego
@@ -1,5 +1,5 @@
 package terraform.gcp.security.google_kms.google_kms_ekm_connection.cert_hostname_match
-import data.terraform.gcp.helpers as helpers
+import data.terraform.helpers as helpers
 import data.terraform.gcp.security.google_kms.google_kms_ekm_connection.vars as vars
 
 conditions := [

--- a/policies/gcp/google_kms/google_kms_key_handle/approved_location/policy.rego
+++ b/policies/gcp/google_kms/google_kms_key_handle/approved_location/policy.rego
@@ -1,5 +1,5 @@
 package terraform.gcp.security.google_kms.google_kms_key_handle.approved_location
-import data.terraform.gcp.helpers
+import data.terraform.helpers
 import data.terraform.gcp.security.google_kms.google_kms_key_handle.vars
 
 conditions := [

--- a/policies/gcp/google_kms/google_kms_key_handle/approved_resources/policy.rego
+++ b/policies/gcp/google_kms/google_kms_key_handle/approved_resources/policy.rego
@@ -1,5 +1,5 @@
 package terraform.gcp.security.google_kms.google_kms_key_handle.approved_resources
-import data.terraform.gcp.helpers
+import data.terraform.helpers
 import data.terraform.gcp.security.google_kms.google_kms_key_handle.vars
 
 conditions := [

--- a/policies/gcp/google_kms/google_kms_key_ring/allowed_location/policy.rego
+++ b/policies/gcp/google_kms/google_kms_key_ring/allowed_location/policy.rego
@@ -1,5 +1,5 @@
 package terraform.gcp.security.google_kms.google_kms_key_ring.allowed_location
-import data.terraform.gcp.helpers as helpers
+import data.terraform.helpers as helpers
 import data.terraform.gcp.security.google_kms.google_kms_key_ring.vars as vars
 
 conditions :=[

--- a/policies/gcp/google_kms/google_kms_key_ring_import_job/import_method/policy.rego
+++ b/policies/gcp/google_kms/google_kms_key_ring_import_job/import_method/policy.rego
@@ -1,5 +1,5 @@
 package terraform.gcp.security.google_kms.google_kms_key_ring_import_job.import_method
-import data.terraform.gcp.helpers as helpers
+import data.terraform.helpers as helpers
 import data.terraform.gcp.security.google_kms.google_kms_key_ring_import_job.vars as vars
 
 conditions := [

--- a/policies/gcp/google_kms/google_kms_key_ring_import_job/protection_level/policy.rego
+++ b/policies/gcp/google_kms/google_kms_key_ring_import_job/protection_level/policy.rego
@@ -1,5 +1,5 @@
 package terraform.gcp.security.google_kms.google_kms_key_ring_import_job.protection_level
-import data.terraform.gcp.helpers as helpers
+import data.terraform.helpers as helpers
 import data.terraform.gcp.security.google_kms.google_kms_key_ring_import_job.vars as vars
 
 conditions := [

--- a/policies/gcp/google_kms/google_kms_secret_ciphertext/crypto_key/policy.rego
+++ b/policies/gcp/google_kms/google_kms_secret_ciphertext/crypto_key/policy.rego
@@ -1,5 +1,5 @@
 package terraform.gcp.security.google_kms.google_kms_secret_ciphertext.crypto_key
-import data.terraform.gcp.helpers
+import data.terraform.helpers
 import data.terraform.gcp.security.google_kms.google_kms_secret_ciphertext.vars
 
 situations := [

--- a/policies/gcp/identity_aware_proxy/google_iap_app_engine_service_iam/member/policy.rego
+++ b/policies/gcp/identity_aware_proxy/google_iap_app_engine_service_iam/member/policy.rego
@@ -1,6 +1,6 @@
 package terraform.gcp.security.identity_aware_proxy.google_iap_app_engine_service_iam.member
 
-import data.terraform.gcp.helpers
+import data.terraform.helpers
 import data.terraform.gcp.security.identity_aware_proxy.google_iap_app_engine_service_iam.vars
 
 conditions := [

--- a/policies/gcp/identity_aware_proxy/google_iap_app_engine_service_iam/role/policy.rego
+++ b/policies/gcp/identity_aware_proxy/google_iap_app_engine_service_iam/role/policy.rego
@@ -1,6 +1,6 @@
 package terraform.gcp.security.identity_aware_proxy.google_iap_app_engine_service_iam.role
 
-import data.terraform.gcp.helpers
+import data.terraform.helpers
 import data.terraform.gcp.security.identity_aware_proxy.google_iap_app_engine_service_iam.vars
 
 # SECURITY POLICY for `role` (exact-match, helper-friendly)

--- a/policies/gcp/identity_aware_proxy/google_iap_brand/application_title/policy.rego
+++ b/policies/gcp/identity_aware_proxy/google_iap_brand/application_title/policy.rego
@@ -1,6 +1,6 @@
 package terraform.gcp.security.identity_aware_proxy.google_iap_brand.application_title
 
-import data.terraform.gcp.helpers
+import data.terraform.helpers
 import data.terraform.gcp.security.identity_aware_proxy.google_iap_brand.vars
 
 # c.tf title (allowed): "Cloud IAP – Customer Portal"

--- a/policies/gcp/identity_aware_proxy/google_iap_brand/support_email/policy.rego
+++ b/policies/gcp/identity_aware_proxy/google_iap_brand/support_email/policy.rego
@@ -1,6 +1,6 @@
 package terraform.gcp.security.identity_aware_proxy.google_iap_brand.support_email
 
-import data.terraform.gcp.helpers
+import data.terraform.helpers
 import data.terraform.gcp.security.identity_aware_proxy.google_iap_brand.vars
 
 # SECURITY POLICY (exact-match; helper-friendly)

--- a/policies/gcp/identity_aware_proxy/google_iap_settings/allowed_domain/policy.rego
+++ b/policies/gcp/identity_aware_proxy/google_iap_settings/allowed_domain/policy.rego
@@ -1,6 +1,6 @@
 package terraform.gcp.security.identity_aware_proxy.google_iap_settings.allowed_domain
 
-import data.terraform.gcp.helpers
+import data.terraform.helpers
 import data.terraform.gcp.security.identity_aware_proxy.google_iap_settings.vars
 
 # Enforce Allowed Domains: feature enabled + corporate domain only

--- a/policies/gcp/identity_aware_proxy/google_iap_settings/cookie_domain/policy.rego
+++ b/policies/gcp/identity_aware_proxy/google_iap_settings/cookie_domain/policy.rego
@@ -1,6 +1,6 @@
 package terraform.gcp.security.identity_aware_proxy.google_iap_settings.cookie_domain
 
-import data.terraform.gcp.helpers
+import data.terraform.helpers
 import data.terraform.gcp.security.identity_aware_proxy.google_iap_settings.vars
 
 # SECURITY POLICY (exact-match; helper-friendly)

--- a/policies/gcp/identity_aware_proxy/google_iap_web_backend_service_iam/member/policy.rego
+++ b/policies/gcp/identity_aware_proxy/google_iap_web_backend_service_iam/member/policy.rego
@@ -1,6 +1,6 @@
 package terraform.gcp.security.identity_aware_proxy.google_iap_web_backend_service_iam.member
 
-import data.terraform.gcp.helpers
+import data.terraform.helpers
 import data.terraform.gcp.security.identity_aware_proxy.google_iap_web_backend_service_iam as vars
 
 # Exact-match conditions (helper-friendly)

--- a/policies/gcp/identity_aware_proxy/google_iap_web_backend_service_iam/role/policy.rego
+++ b/policies/gcp/identity_aware_proxy/google_iap_web_backend_service_iam/role/policy.rego
@@ -1,6 +1,6 @@
 package terraform.gcp.security.identity_aware_proxy.google_iap_web_backend_service_iam.role
 
-import data.terraform.gcp.helpers
+import data.terraform.helpers
 import data.terraform.gcp.security.identity_aware_proxy.google_iap_web_backend_service_iam as vars
 
 conditions := [

--- a/policies/gcp/identity_aware_proxy/google_iap_web_backend_service_iam/web_backend_service/policy.rego
+++ b/policies/gcp/identity_aware_proxy/google_iap_web_backend_service_iam/web_backend_service/policy.rego
@@ -1,6 +1,6 @@
 package terraform.gcp.security.identity_aware_proxy.google_iap_web_backend_service_iam.web_backend_service
 
-import data.terraform.gcp.helpers
+import data.terraform.helpers
 import data.terraform.gcp.security.identity_aware_proxy.google_iap_web_backend_service_iam as vars
 
 conditions := [

--- a/policies/gcp/identity_aware_proxy/google_iap_web_cloud_run_service_iam/cloud_run_service_name/policy.rego
+++ b/policies/gcp/identity_aware_proxy/google_iap_web_cloud_run_service_iam/cloud_run_service_name/policy.rego
@@ -1,6 +1,6 @@
 package terraform.gcp.security.identity_aware_proxy.google_iap_web_cloud_run_service_iam.cloud_run_service_name
 
-import data.terraform.gcp.helpers
+import data.terraform.helpers
 import data.terraform.gcp.security.identity_aware_proxy.google_iap_web_cloud_run_service_iam as vars
 
 # 1) Block sensitive admin consoles

--- a/policies/gcp/identity_aware_proxy/google_iap_web_cloud_run_service_iam/location/policy.rego
+++ b/policies/gcp/identity_aware_proxy/google_iap_web_cloud_run_service_iam/location/policy.rego
@@ -1,6 +1,6 @@
 package terraform.gcp.security.identity_aware_proxy.google_iap_web_cloud_run_service_iam.location
 
-import data.terraform.gcp.helpers
+import data.terraform.helpers
 import data.terraform.gcp.security.identity_aware_proxy.google_iap_web_cloud_run_service_iam as vars
 
 conditions := [

--- a/policies/gcp/identity_aware_proxy/google_iap_web_cloud_run_service_iam/member/policy.rego
+++ b/policies/gcp/identity_aware_proxy/google_iap_web_cloud_run_service_iam/member/policy.rego
@@ -1,6 +1,6 @@
 package terraform.gcp.security.identity_aware_proxy.google_iap_web_cloud_run_service_iam.member
 
-import data.terraform.gcp.helpers
+import data.terraform.helpers
 import data.terraform.gcp.security.identity_aware_proxy.google_iap_web_cloud_run_service_iam as vars
 
 conditions := [

--- a/policies/gcp/identity_aware_proxy/google_iap_web_cloud_run_service_iam/role/policy.rego
+++ b/policies/gcp/identity_aware_proxy/google_iap_web_cloud_run_service_iam/role/policy.rego
@@ -1,6 +1,6 @@
 package terraform.gcp.security.identity_aware_proxy.google_iap_web_cloud_run_service_iam.role
 
-import data.terraform.gcp.helpers
+import data.terraform.helpers
 import data.terraform.gcp.security.identity_aware_proxy.google_iap_web_cloud_run_service_iam as vars
 
 conditions := [

--- a/policies/gcp/identity_aware_proxy/google_iap_web_forwarding_rule_service_iam/forwarding_rule/policy.rego
+++ b/policies/gcp/identity_aware_proxy/google_iap_web_forwarding_rule_service_iam/forwarding_rule/policy.rego
@@ -1,6 +1,6 @@
 package terraform.gcp.security.identity_aware_proxy.google_iap_web_forwarding_rule_service_iam.forwarding_rule_service_name
 
-import data.terraform.gcp.helpers
+import data.terraform.helpers
 import data.terraform.gcp.security.identity_aware_proxy.google_iap_web_forwarding_rule_service_iam as vars
 
 conditions := [

--- a/policies/gcp/identity_aware_proxy/google_iap_web_forwarding_rule_service_iam/project/policy.rego
+++ b/policies/gcp/identity_aware_proxy/google_iap_web_forwarding_rule_service_iam/project/policy.rego
@@ -1,6 +1,6 @@
 package terraform.gcp.security.identity_aware_proxy.google_iap_web_forwarding_rule_service_iam.project
 
-import data.terraform.gcp.helpers
+import data.terraform.helpers
 import data.terraform.gcp.security.identity_aware_proxy.google_iap_web_forwarding_rule_service_iam as vars
 
 # Security goals:

--- a/policies/gcp/identity_aware_proxy/google_iap_web_iam/condition/policy.rego
+++ b/policies/gcp/identity_aware_proxy/google_iap_web_iam/condition/policy.rego
@@ -1,6 +1,6 @@
 package terraform.gcp.security.identity_aware_proxy.google_iap_web_iam.condition
 
-import data.terraform.gcp.helpers
+import data.terraform.helpers
 import data.terraform.gcp.security.identity_aware_proxy.google_iap_web_iam as vars
 
 # Enforce: every IAP Web IAM binding must include a non-empty 'condition' block.

--- a/policies/gcp/identity_aware_proxy/google_iap_web_iam/member/policy.rego
+++ b/policies/gcp/identity_aware_proxy/google_iap_web_iam/member/policy.rego
@@ -1,6 +1,6 @@
 package terraform.gcp.security.identity_aware_proxy.google_iap_web_iam.member
 
-import data.terraform.gcp.helpers
+import data.terraform.helpers
 import data.terraform.gcp.security.identity_aware_proxy.google_iap_web_iam as vars
 
 # Exact-match conditions to work with your helpers.

--- a/policies/gcp/identity_aware_proxy/google_iap_web_iam/role/policy.rego
+++ b/policies/gcp/identity_aware_proxy/google_iap_web_iam/role/policy.rego
@@ -1,6 +1,6 @@
 package terraform.gcp.security.identity_aware_proxy.google_iap_web_iam.role
 
-import data.terraform.gcp.helpers
+import data.terraform.helpers
 import data.terraform.gcp.security.identity_aware_proxy.google_iap_web_iam as vars
 
 # Enforce least-privilege role for IAP Web access.

--- a/policies/gcp/identity_aware_proxy/google_iap_web_type_compute_iam/member/policy.rego
+++ b/policies/gcp/identity_aware_proxy/google_iap_web_type_compute_iam/member/policy.rego
@@ -1,6 +1,6 @@
 package terraform.gcp.security.identity_aware_proxy.google_iap_web_type_compute_iam.member
 
-import data.terraform.gcp.helpers
+import data.terraform.helpers
 import data.terraform.gcp.security.identity_aware_proxy.google_iap_web_type_compute_iam.vars
 
 # Exact-match conditions (helper-friendly)

--- a/policies/gcp/identity_aware_proxy/google_iap_web_type_compute_iam/role/policy.rego
+++ b/policies/gcp/identity_aware_proxy/google_iap_web_type_compute_iam/role/policy.rego
@@ -1,6 +1,6 @@
 package terraform.gcp.security.identity_aware_proxy.google_iap_web_type_compute_iam.role
 
-import data.terraform.gcp.helpers
+import data.terraform.helpers
 import data.terraform.gcp.security.identity_aware_proxy.google_iap_web_type_compute_iam.vars
 
 conditions := [

--- a/policies/gcp/looker/core/cmek_required/policy.rego
+++ b/policies/gcp/looker/core/cmek_required/policy.rego
@@ -1,5 +1,5 @@
 package terraform.gcp.security.looker.core.cmek_required
-import data.terraform.gcp.helpers
+import data.terraform.helpers
 import data.terraform.gcp.security.looker.core.vars
 
 conditions := [

--- a/policies/gcp/looker/core/consumer_network_set/policy.rego
+++ b/policies/gcp/looker/core/consumer_network_set/policy.rego
@@ -1,5 +1,5 @@
 package terraform.gcp.security.looker.core.consumer_network_set
-import data.terraform.gcp.helpers
+import data.terraform.helpers
 import data.terraform.gcp.security.looker.core.vars
 
 conditions := [

--- a/policies/gcp/looker/core/custom_domain_when_private/policy.rego
+++ b/policies/gcp/looker/core/custom_domain_when_private/policy.rego
@@ -1,7 +1,7 @@
 # policies/gcp/looker/core/custom_domain_when_private/policy.rego
 package terraform.gcp.security.looker.core.custom_domain_when_private
 
-import data.terraform.gcp.helpers
+import data.terraform.helpers
 import data.terraform.gcp.security.looker.core.vars
 
 # IF public_ip_enabled == false THEN custom_domain.domain must be set

--- a/policies/gcp/looker/core/disallow_trial_editions/policy.rego
+++ b/policies/gcp/looker/core/disallow_trial_editions/policy.rego
@@ -1,5 +1,5 @@
 package terraform.gcp.security.looker.core.disallow_trial_editions
-import data.terraform.gcp.helpers
+import data.terraform.helpers
 import data.terraform.gcp.security.looker.core.vars
 
 conditions := [

--- a/policies/gcp/looker/core/fips_required/policy.rego
+++ b/policies/gcp/looker/core/fips_required/policy.rego
@@ -1,5 +1,5 @@
 package terraform.gcp.security.looker.core.fips_required
-import data.terraform.gcp.helpers
+import data.terraform.helpers
 import data.terraform.gcp.security.looker.core.vars
 
 conditions := [

--- a/policies/gcp/looker/core/maintenance_window_set/policy.rego
+++ b/policies/gcp/looker/core/maintenance_window_set/policy.rego
@@ -1,5 +1,5 @@
 package terraform.gcp.security.looker.core.maintenance_window_set
-import data.terraform.gcp.helpers
+import data.terraform.helpers
 import data.terraform.gcp.security.looker.core.vars
 
 conditions := [

--- a/policies/gcp/looker/core/no_public_ip/policy.rego
+++ b/policies/gcp/looker/core/no_public_ip/policy.rego
@@ -1,5 +1,5 @@
 package terraform.gcp.security.looker.core.no_public_ip
-import data.terraform.gcp.helpers
+import data.terraform.helpers
 import data.terraform.gcp.security.looker.core.vars
 
 conditions := [

--- a/policies/gcp/looker/core/oauth_config_present/policy.rego
+++ b/policies/gcp/looker/core/oauth_config_present/policy.rego
@@ -1,5 +1,5 @@
 package terraform.gcp.security.looker.core.oauth_config_present
-import data.terraform.gcp.helpers
+import data.terraform.helpers
 import data.terraform.gcp.security.looker.core.vars
 
 conditions := [

--- a/policies/gcp/looker/core/private_connectivity_required/policy.rego
+++ b/policies/gcp/looker/core/private_connectivity_required/policy.rego
@@ -1,7 +1,7 @@
 # policies/gcp/looker/core/private_connectivity_required/policy.rego
 package terraform.gcp.security.looker.core.private_connectivity_required
 
-import data.terraform.gcp.helpers
+import data.terraform.helpers
 import data.terraform.gcp.security.looker.core.vars
 
 # Policy intent:

--- a/policies/gcp/looker/core/psc_mode_hygiene/policy.rego
+++ b/policies/gcp/looker/core/psc_mode_hygiene/policy.rego
@@ -1,7 +1,7 @@
 # policies/gcp/looker/core/psc_mode_hygiene/policy.rego
 package terraform.gcp.security.looker.core.psc_mode_hygiene
 
-import data.terraform.gcp.helpers
+import data.terraform.helpers
 import data.terraform.gcp.security.looker.core.vars
 
 # Intent: If PSC is enabled, BOTH public_ip_enabled and private_ip_enabled must be false.

--- a/policies/gcp/looker/core/reserved_range_for_psa_psc/policy.rego
+++ b/policies/gcp/looker/core/reserved_range_for_psa_psc/policy.rego
@@ -1,5 +1,5 @@
 package terraform.gcp.security.looker.core.reserved_range_for_psa_psc
-import data.terraform.gcp.helpers
+import data.terraform.helpers
 import data.terraform.gcp.security.looker.core.vars
 
 conditions := [

--- a/policies/gcp/lustre/lustre_instance/allowed_location/policy.rego
+++ b/policies/gcp/lustre/lustre_instance/allowed_location/policy.rego
@@ -1,5 +1,5 @@
 package terraform.gcp.security.lustre.lustre_instance.allowed_location
-import data.terraform.gcp.helpers
+import data.terraform.helpers
 import data.terraform.gcp.security.lustre.lustre_instance.vars
 
 

--- a/policies/gcp/lustre/lustre_instance/allowed_vpc_network/policy.rego
+++ b/policies/gcp/lustre/lustre_instance/allowed_vpc_network/policy.rego
@@ -1,6 +1,6 @@
 package terraform.gcp.security.lustre.lustre_instance.allowed_vpc_network
 
-import data.terraform.gcp.helpers
+import data.terraform.helpers
 import data.terraform.gcp.security.lustre.lustre_instance.vars
 
 conditions := [

--- a/policies/gcp/lustre/lustre_instance/gke_support_enabled/policy.rego
+++ b/policies/gcp/lustre/lustre_instance/gke_support_enabled/policy.rego
@@ -1,6 +1,6 @@
 package terraform.gcp.security.lustre.lustre_instance.gke_support_enabled
 
-import data.terraform.gcp.helpers
+import data.terraform.helpers
 import data.terraform.gcp.security.lustre.lustre_instance.vars
 
 conditions := [

--- a/policies/gcp/lustre/lustre_instance/valid_per_unit_storage_throughput/policy.rego
+++ b/policies/gcp/lustre/lustre_instance/valid_per_unit_storage_throughput/policy.rego
@@ -1,6 +1,6 @@
 package terraform.gcp.security.lustre.lustre_instance.valid_per_unit_storage_throughput
 
-import data.terraform.gcp.helpers
+import data.terraform.helpers
 import data.terraform.gcp.security.lustre.lustre_instance.vars
 
 conditions := [

--- a/policies/gcp/managed_kafka/google_managed_kafka_acl/global_acls/policy.rego
+++ b/policies/gcp/managed_kafka/google_managed_kafka_acl/global_acls/policy.rego
@@ -1,5 +1,5 @@
 package terraform.gcp.security.managed_kafka.google_managed_kafka_acl.global_acls
-import data.terraform.gcp.helpers
+import data.terraform.helpers
 import data.terraform.gcp.security.managed_kafka.google_managed_kafka_acl.vars
 
 conditions := [

--- a/policies/gcp/managed_kafka/google_managed_kafka_acl/secured_acl_entries/policy.rego
+++ b/policies/gcp/managed_kafka/google_managed_kafka_acl/secured_acl_entries/policy.rego
@@ -1,5 +1,5 @@
 package terraform.gcp.security.managed_kafka.google_managed_kafka_acl.secured_acl_entries
-import data.terraform.gcp.helpers
+import data.terraform.helpers
 import data.terraform.gcp.security.managed_kafka.google_managed_kafka_acl.vars
 
 conditions := [

--- a/policies/gcp/managed_kafka/google_managed_kafka_acl/wildcard_principals/policy.rego
+++ b/policies/gcp/managed_kafka/google_managed_kafka_acl/wildcard_principals/policy.rego
@@ -1,5 +1,5 @@
 package terraform.gcp.security.managed_kafka.google_managed_kafka_acl.wildcard_principals 
-import data.terraform.gcp.helpers
+import data.terraform.helpers
 import data.terraform.gcp.security.managed_kafka.google_managed_kafka_acl.vars
 
 

--- a/policies/gcp/managed_kafka/google_managed_kafka_cluster/kafka_cluster/policy.rego
+++ b/policies/gcp/managed_kafka/google_managed_kafka_cluster/kafka_cluster/policy.rego
@@ -1,6 +1,6 @@
 package terraform.gcp.security.managed_kafka.google_managed_kafka_cluster.kafka_cluster
 
-import data.terraform.gcp.helpers
+import data.terraform.helpers
 import data.terraform.gcp.security.managed_kafka.google_managed_kafka_cluster.vars
 
 conditions := [

--- a/policies/gcp/managed_kafka/google_managed_kafka_cluster/kafka_cmek_enforcement/policy.rego
+++ b/policies/gcp/managed_kafka/google_managed_kafka_cluster/kafka_cmek_enforcement/policy.rego
@@ -1,6 +1,6 @@
 package terraform.gcp.security.managed_kafka.google_managed_kafka_cluster.kafka_cmek_enforcement
 
-import data.terraform.gcp.helpers
+import data.terraform.helpers
 import data.terraform.gcp.security.managed_kafka.google_managed_kafka_cluster.vars
 
 conditions := [

--- a/policies/gcp/managed_kafka/google_managed_kafka_cluster/kafka_mtls_enforcement/policy.rego
+++ b/policies/gcp/managed_kafka/google_managed_kafka_cluster/kafka_mtls_enforcement/policy.rego
@@ -1,5 +1,5 @@
 package terraform.gcp.security.managed_kafka.google_managed_kafka_cluster.kafka_mtls_enforcement
-import data.terraform.gcp.helpers
+import data.terraform.helpers
 import data.terraform.gcp.security.managed_kafka.google_managed_kafka_cluster.vars
 
 

--- a/policies/gcp/managed_kafka/google_managed_kafka_connect_cluster/cluster_binding/policy.rego
+++ b/policies/gcp/managed_kafka/google_managed_kafka_connect_cluster/cluster_binding/policy.rego
@@ -1,6 +1,6 @@
 package terraform.gcp.security.managed_kafka.google_managed_kafka_connect_cluster.cluster_binding
 
-import data.terraform.gcp.helpers
+import data.terraform.helpers
 import data.terraform.gcp.security.managed_kafka.google_managed_kafka_connect_cluster.vars
 
 conditions := [

--- a/policies/gcp/managed_kafka/google_managed_kafka_connect_cluster/disallow_public_exposure/policy.rego
+++ b/policies/gcp/managed_kafka/google_managed_kafka_connect_cluster/disallow_public_exposure/policy.rego
@@ -1,6 +1,6 @@
 package terraform.gcp.security.managed_kafka.google_managed_kafka_connect_cluster.disallow_public_exposure
 
-import data.terraform.gcp.helpers
+import data.terraform.helpers
 import data.terraform.gcp.security.managed_kafka.google_managed_kafka_connect_cluster.vars
 
 conditions := [

--- a/policies/gcp/managed_kafka/google_managed_kafka_connect_cluster/enforce_private_networking/policy.rego
+++ b/policies/gcp/managed_kafka/google_managed_kafka_connect_cluster/enforce_private_networking/policy.rego
@@ -1,5 +1,5 @@
 package terraform.gcp.security.managed_kafka.google_managed_kafka_connect_cluster.enforce_private_networking
-import data.terraform.gcp.helpers
+import data.terraform.helpers
 import data.terraform.gcp.security.managed_kafka.google_managed_kafka_connect_cluster.vars
 
 conditions := [

--- a/policies/gcp/managed_kafka/google_managed_kafka_connector/enforce_connector/policy.rego
+++ b/policies/gcp/managed_kafka/google_managed_kafka_connector/enforce_connector/policy.rego
@@ -1,5 +1,5 @@
 package terraform.gcp.security.managed_kafka.google_managed_kafka_connector.enforce_connector
-import data.terraform.gcp.helpers
+import data.terraform.helpers
 import data.terraform.gcp.security.managed_kafka.google_managed_kafka_connector.vars
 
 

--- a/policies/gcp/managed_kafka/google_managed_kafka_connector/task_restart/policy.rego
+++ b/policies/gcp/managed_kafka/google_managed_kafka_connector/task_restart/policy.rego
@@ -1,5 +1,5 @@
 package terraform.gcp.security.managed_kafka.google_managed_kafka_connector.task_restart
-import data.terraform.gcp.helpers
+import data.terraform.helpers
 import data.terraform.gcp.security.managed_kafka.google_managed_kafka_connector.vars
 
 conditions := [

--- a/policies/gcp/managed_kafka/google_managed_kafka_topic/secure_topic_config/policy.rego
+++ b/policies/gcp/managed_kafka/google_managed_kafka_topic/secure_topic_config/policy.rego
@@ -1,6 +1,6 @@
 package terraform.gcp.security.managed_kafka.google_managed_kafka_topic.secure_topic_config
 
-import data.terraform.gcp.helpers
+import data.terraform.helpers
 import data.terraform.gcp.security.managed_kafka.google_managed_kafka_topic.vars
 
 conditions := [

--- a/policies/gcp/memcache/google_memcache_instance/authorized_network/policy.rego
+++ b/policies/gcp/memcache/google_memcache_instance/authorized_network/policy.rego
@@ -1,5 +1,5 @@
 package terraform.gcp.security.memcache.google_memcache_instance.authorized_network 
-import data.terraform.gcp.helpers
+import data.terraform.helpers
 import data.terraform.gcp.security.memcache.google_memcache_instance.vars
 
 conditions := [

--- a/policies/gcp/memcache/google_memcache_instance/maintenance_policy/policy.rego
+++ b/policies/gcp/memcache/google_memcache_instance/maintenance_policy/policy.rego
@@ -1,5 +1,5 @@
 package terraform.gcp.security.memcache.google_memcache_instance.maintenance_policy 
-import data.terraform.gcp.helpers
+import data.terraform.helpers
 import data.terraform.gcp.security.memcache.google_memcache_instance.vars
 
 conditions := [

--- a/policies/gcp/memcache/google_memcache_instance/memcache_version/policy.rego
+++ b/policies/gcp/memcache/google_memcache_instance/memcache_version/policy.rego
@@ -1,5 +1,5 @@
 package terraform.gcp.security.memcache.google_memcache_instance.memcache_version
-import data.terraform.gcp.helpers
+import data.terraform.helpers
 import data.terraform.gcp.security.memcache.google_memcache_instance.vars
 
 conditions := [

--- a/policies/gcp/memcache/google_memcache_instance/reserved_ip_range_id/policy.rego
+++ b/policies/gcp/memcache/google_memcache_instance/reserved_ip_range_id/policy.rego
@@ -1,5 +1,5 @@
 package terraform.gcp.security.memcache.google_memcache_instance.reserved_ip_range_id
-import data.terraform.gcp.helpers
+import data.terraform.helpers
 import data.terraform.gcp.security.memcache.google_memcache_instance.vars
 
 conditions := [

--- a/policies/gcp/memorystore/memorystore_instance/authorization_mode/policy.rego
+++ b/policies/gcp/memorystore/memorystore_instance/authorization_mode/policy.rego
@@ -1,6 +1,6 @@
 package terraform.gcp.security.memorystore_instance.authorization_mode
 
-import data.terraform.gcp.helpers
+import data.terraform.helpers
 import data.terraform.gcp.security.memorystore.memorystore_instance.vars
 
 conditions := [

--- a/policies/gcp/memorystore/memorystore_instance/deletion_protection_config/policy.rego
+++ b/policies/gcp/memorystore/memorystore_instance/deletion_protection_config/policy.rego
@@ -1,6 +1,6 @@
 package terraform.gcp.security.memorystore_instance.deletion_protection_config
 
-import data.terraform.gcp.helpers
+import data.terraform.helpers
 import data.terraform.gcp.security.memorystore.memorystore_instance.vars
 
 conditions := [

--- a/policies/gcp/model_armor/google_model_armor_floorsetting/confidence_level/policy.rego
+++ b/policies/gcp/model_armor/google_model_armor_floorsetting/confidence_level/policy.rego
@@ -1,6 +1,6 @@
 package terraform.gcp.security.model_Armor.google_model_armor_floorsetting.confidence_level
 
-import data.terraform.gcp.helpers
+import data.terraform.helpers
 import data.terraform.gcp.security.model_Armor.google_model_armor_floorsetting.vars
 
 

--- a/policies/gcp/model_armor/google_model_armor_floorsetting/filter_config/policy.rego
+++ b/policies/gcp/model_armor/google_model_armor_floorsetting/filter_config/policy.rego
@@ -1,6 +1,6 @@
 package terraform.gcp.security.model_Armor.google_model_armor_floorsetting.filter_config
 
-import data.terraform.gcp.helpers
+import data.terraform.helpers
 import data.terraform.gcp.security.model_Armor.google_model_armor_floorsetting.vars
 
 

--- a/policies/gcp/model_armor/google_model_armor_floorsetting/filter_config_sub_attributes/policy.rego
+++ b/policies/gcp/model_armor/google_model_armor_floorsetting/filter_config_sub_attributes/policy.rego
@@ -1,6 +1,6 @@
 package terraform.gcp.security.model_Armor.google_model_armor_floorsetting.filter_config_sub_attributes
 
-import data.terraform.gcp.helpers
+import data.terraform.helpers
 import data.terraform.gcp.security.model_Armor.google_model_armor_floorsetting.vars
 
 

--- a/policies/gcp/model_armor/google_model_armor_floorsetting/filter_type/policy.rego
+++ b/policies/gcp/model_armor/google_model_armor_floorsetting/filter_type/policy.rego
@@ -1,6 +1,6 @@
 package terraform.gcp.security.model_Armor.google_model_armor_floorsetting.filter_type
 
-import data.terraform.gcp.helpers
+import data.terraform.helpers
 import data.terraform.gcp.security.model_Armor.google_model_armor_floorsetting.vars
 
 

--- a/policies/gcp/model_armor/google_model_armor_floorsetting/location/policy.rego
+++ b/policies/gcp/model_armor/google_model_armor_floorsetting/location/policy.rego
@@ -1,6 +1,6 @@
 package terraform.gcp.security.model_Armor.google_model_armor_floorsetting.location
 
-import data.terraform.gcp.helpers
+import data.terraform.helpers
 import data.terraform.gcp.security.model_Armor.google_model_armor_floorsetting.vars
 
 # Condition: location must always be "global"

--- a/policies/gcp/model_armor/google_model_armor_template/confidence_level/policy.rego
+++ b/policies/gcp/model_armor/google_model_armor_template/confidence_level/policy.rego
@@ -1,6 +1,6 @@
 package terraform.gcp.security.model_Armor.google_model_armor_template.confidence_level
 
-import data.terraform.gcp.helpers
+import data.terraform.helpers
 import data.terraform.gcp.security.model_Armor.google_model_armor_template.vars
 
 

--- a/policies/gcp/model_armor/google_model_armor_template/filter_config/policy.rego
+++ b/policies/gcp/model_armor/google_model_armor_template/filter_config/policy.rego
@@ -1,6 +1,6 @@
 package terraform.gcp.security.model_Armor.google_model_armor_template.filter_config
 
-import data.terraform.gcp.helpers
+import data.terraform.helpers
 import data.terraform.gcp.security.model_Armor.google_model_armor_template.vars
 
 

--- a/policies/gcp/model_armor/google_model_armor_template/filter_config_sub_attributes/policy.rego
+++ b/policies/gcp/model_armor/google_model_armor_template/filter_config_sub_attributes/policy.rego
@@ -1,6 +1,6 @@
 package terraform.gcp.security.model_Armor.google_model_armor_template.filter_config_sub_attributes
 
-import data.terraform.gcp.helpers
+import data.terraform.helpers
 import data.terraform.gcp.security.model_Armor.google_model_armor_template.vars
 
 

--- a/policies/gcp/model_armor/google_model_armor_template/filter_type/policy.rego
+++ b/policies/gcp/model_armor/google_model_armor_template/filter_type/policy.rego
@@ -1,6 +1,6 @@
 package terraform.gcp.security.model_Armor.google_model_armor_template.filter_type
 
-import data.terraform.gcp.helpers
+import data.terraform.helpers
 import data.terraform.gcp.security.model_Armor.google_model_armor_template.vars
 
 

--- a/policies/gcp/model_armor/google_model_armor_template/location/policy.rego
+++ b/policies/gcp/model_armor/google_model_armor_template/location/policy.rego
@@ -1,6 +1,6 @@
 package terraform.gcp.security.model_Armor.google_model_armor_template.location
 
-import data.terraform.gcp.helpers
+import data.terraform.helpers
 import data.terraform.gcp.security.model_Armor.google_model_armor_template.vars
 
 # Condition: location must always be "global"

--- a/policies/gcp/network/policy.rego
+++ b/policies/gcp/network/policy.rego
@@ -1,6 +1,6 @@
 package terraform.gcp.security.service_networking.network
 
-import data.terraform.gcp.helpers
+import data.terraform.helpers
 import data.terraform.gcp.security.service_networking.network.vars
 
 allowed_networks := vars.variables["allowed_networks"]

--- a/policies/gcp/new_integration_connectors/google_integration_connectors_connection/port/policy.rego
+++ b/policies/gcp/new_integration_connectors/google_integration_connectors_connection/port/policy.rego
@@ -1,5 +1,5 @@
 package terraform.gcp.security.integration_connectors.google_integration_connectors_connection.port
-import data.terraform.gcp.helpers
+import data.terraform.helpers
 import data.terraform.gcp.security.integration_connectors.google_integration_connectors_connection.vars
  
  conditions := [

--- a/policies/gcp/new_integration_connectors/google_integration_connectors_connection/secret_manager_secret/policy.rego
+++ b/policies/gcp/new_integration_connectors/google_integration_connectors_connection/secret_manager_secret/policy.rego
@@ -1,5 +1,5 @@
 package terraform.gcp.security.integration_connectors.google_integration_connectors_connection.secret_manager_secret
-import data.terraform.gcp.helpers
+import data.terraform.helpers
 import data.terraform.gcp.security.integration_connectors.google_integration_connectors_connection.vars
 
 conditions := [[

--- a/policies/gcp/new_integration_connectors/google_integration_connectors_connection/ssl_config_trust_model/policy.rego
+++ b/policies/gcp/new_integration_connectors/google_integration_connectors_connection/ssl_config_trust_model/policy.rego
@@ -1,5 +1,5 @@
 package terraform.gcp.security.integration_connectors.google_integration_connectors_connection.ssl_config_trust_model
-import data.terraform.gcp.helpers
+import data.terraform.helpers
 import data.terraform.gcp.security.integration_connectors.google_integration_connectors_connection.vars
 
 conditions := [

--- a/policies/gcp/new_integration_connectors/google_integration_connectors_connection/ssl_config_use_ssl/policy.rego
+++ b/policies/gcp/new_integration_connectors/google_integration_connectors_connection/ssl_config_use_ssl/policy.rego
@@ -1,5 +1,5 @@
 package terraform.gcp.security.integration_connectors.google_integration_connectors_connection.ssl_config_use_ssl
-import data.terraform.gcp.helpers
+import data.terraform.helpers
 import data.terraform.gcp.security.integration_connectors.google_integration_connectors_connection.vars
 
 conditions := [

--- a/policies/gcp/new_integration_connectors/google_integration_connectors_connection/user_password/policy.rego
+++ b/policies/gcp/new_integration_connectors/google_integration_connectors_connection/user_password/policy.rego
@@ -1,5 +1,5 @@
 package terraform.gcp.security.integration_connectors.google_integration_connectors_connection.user_password
-import data.terraform.gcp.helpers
+import data.terraform.helpers
 import data.terraform.gcp.security.integration_connectors.google_integration_connectors_connection.vars
 
 conditions := [

--- a/policies/gcp/new_integration_connectors/google_integration_connectors_endpoint/service_attachment/policy.rego
+++ b/policies/gcp/new_integration_connectors/google_integration_connectors_endpoint/service_attachment/policy.rego
@@ -1,5 +1,5 @@
 package terraform.gcp.security.integration_connectors.google_integration_connectors_endpoint.service_attachment
-import data.terraform.gcp.helpers
+import data.terraform.helpers
 import data.terraform.gcp.security.integration_connectors.google_integration_connectors_endpoint.vars
 
 conditions := [[

--- a/policies/gcp/new_integration_connectors/google_integration_connectors_managed_zone/dns_peer_binding/policy.rego
+++ b/policies/gcp/new_integration_connectors/google_integration_connectors_managed_zone/dns_peer_binding/policy.rego
@@ -1,5 +1,5 @@
 package terraform.gcp.security.integration_connectors.google_integration_connectors_managed_zone.dns_peer_binding
-import data.terraform.gcp.helpers
+import data.terraform.helpers
 import data.terraform.gcp.security.integration_connectors.google_integration_connectors_managed_zone.vars
 
 conditions := [[

--- a/policies/gcp/new_integration_connectors/google_integration_connectors_managed_zone/managed_zone/policy.rego
+++ b/policies/gcp/new_integration_connectors/google_integration_connectors_managed_zone/managed_zone/policy.rego
@@ -1,5 +1,5 @@
 package terraform.gcp.security.integration_connectors.google_integration_connectors_managed_zone.managed_zone
-import data.terraform.gcp.helpers
+import data.terraform.helpers
 import data.terraform.gcp.security.integration_connectors.google_integration_connectors_managed_zone.vars
 
 conditions := [[

--- a/policies/gcp/os_config_v2/policy_orchestrator/action/policy.rego
+++ b/policies/gcp/os_config_v2/policy_orchestrator/action/policy.rego
@@ -1,5 +1,5 @@
 package terraform.gcp.security.os_config_v2.policy_orchestrator.action
-import data.terraform.gcp.helpers
+import data.terraform.helpers
 import data.terraform.gcp.security.os_config_v2.policy_orchestrator.vars
 
 conditions := [

--- a/policies/gcp/os_config_v2/policy_orchestrator/orchestrated_resource/policy.rego
+++ b/policies/gcp/os_config_v2/policy_orchestrator/orchestrated_resource/policy.rego
@@ -1,5 +1,5 @@
 package terraform.gcp.security.os_config_v2.policy_orchestrator.orchestrated_resource
-import data.terraform.gcp.helpers
+import data.terraform.helpers
 import data.terraform.gcp.security.os_config_v2.policy_orchestrator.vars
 
 conditions := [

--- a/policies/gcp/os_config_v2/policy_orchestrator/orchestration_scope/policy.rego
+++ b/policies/gcp/os_config_v2/policy_orchestrator/orchestration_scope/policy.rego
@@ -1,5 +1,5 @@
 package terraform.gcp.security.os_config_v2.policy_orchestrator.orchestration_scope
-import data.terraform.gcp.helpers
+import data.terraform.helpers
 import data.terraform.gcp.security.os_config_v2.policy_orchestrator.vars
 
 conditions := [

--- a/policies/gcp/os_config_v2/policy_orchestrator_for_folder/action/policy.rego
+++ b/policies/gcp/os_config_v2/policy_orchestrator_for_folder/action/policy.rego
@@ -1,5 +1,5 @@
 package terraform.gcp.security.os_config_v2.policy_orchestrator_for_folder.action
-import data.terraform.gcp.helpers
+import data.terraform.helpers
 import data.terraform.gcp.security.os_config_v2.policy_orchestrator_for_folder.vars
 
 conditions := [

--- a/policies/gcp/os_config_v2/policy_orchestrator_for_folder/orchestrated_resource/policy.rego
+++ b/policies/gcp/os_config_v2/policy_orchestrator_for_folder/orchestrated_resource/policy.rego
@@ -1,5 +1,5 @@
 package terraform.gcp.security.os_config_v2.policy_orchestrator_for_folder.orchestrated_resource
-import data.terraform.gcp.helpers
+import data.terraform.helpers
 import data.terraform.gcp.security.os_config_v2.policy_orchestrator_for_folder.vars
 
 conditions := [

--- a/policies/gcp/os_config_v2/policy_orchestrator_for_folder/orchestration_scope/policy.rego
+++ b/policies/gcp/os_config_v2/policy_orchestrator_for_folder/orchestration_scope/policy.rego
@@ -1,5 +1,5 @@
 package terraform.gcp.security.os_config_v2.policy_orchestrator_for_folder.orchestration_scope
-import data.terraform.gcp.helpers
+import data.terraform.helpers
 import data.terraform.gcp.security.os_config_v2.policy_orchestrator_for_folder.vars
 
 conditions := [

--- a/policies/gcp/os_config_v2/policy_orchestrator_for_organization/action/policy.rego
+++ b/policies/gcp/os_config_v2/policy_orchestrator_for_organization/action/policy.rego
@@ -1,5 +1,5 @@
 package terraform.gcp.security.os_config_v2.policy_orchestrator_for_organization.action
-import data.terraform.gcp.helpers
+import data.terraform.helpers
 import data.terraform.gcp.security.os_config_v2.policy_orchestrator_for_organization.vars
 
 conditions := [

--- a/policies/gcp/os_config_v2/policy_orchestrator_for_organization/orchestrated_resource/policy.rego
+++ b/policies/gcp/os_config_v2/policy_orchestrator_for_organization/orchestrated_resource/policy.rego
@@ -1,5 +1,5 @@
 package terraform.gcp.security.os_config_v2.policy_orchestrator_for_organization.orchestrated_resource
-import data.terraform.gcp.helpers
+import data.terraform.helpers
 import data.terraform.gcp.security.os_config_v2.policy_orchestrator_for_organization.vars
 
 conditions := [

--- a/policies/gcp/os_config_v2/policy_orchestrator_for_organization/organization_id/policy.rego
+++ b/policies/gcp/os_config_v2/policy_orchestrator_for_organization/organization_id/policy.rego
@@ -1,5 +1,5 @@
 package terraform.gcp.security.os_config_v2.policy_orchestrator_for_organization.organization_id
-import data.terraform.gcp.helpers
+import data.terraform.helpers
 import data.terraform.gcp.security.os_config_v2.policy_orchestrator_for_organization.vars
 
 conditions := [

--- a/policies/gcp/os_config_v2/policy_orchestrator_for_organization/policy_orchestrator_id/policy.rego
+++ b/policies/gcp/os_config_v2/policy_orchestrator_for_organization/policy_orchestrator_id/policy.rego
@@ -1,5 +1,5 @@
 package terraform.gcp.security.os_config_v2.policy_orchestrator_for_organization.policy_orchestrator_id
-import data.terraform.gcp.helpers
+import data.terraform.helpers
 import data.terraform.gcp.security.os_config_v2.policy_orchestrator_for_organization.vars
 
 conditions := [

--- a/policies/gcp/oslogin/google_compute_instance/block_project_ssh_keys/policy.rego
+++ b/policies/gcp/oslogin/google_compute_instance/block_project_ssh_keys/policy.rego
@@ -1,6 +1,6 @@
 package terraform.gcp.security.oslogin.google_compute_instance.block_project_ssh_keys
 
-import data.terraform.gcp.helpers
+import data.terraform.helpers
 import data.terraform.gcp.security.oslogin.google_compute_instance.vars
 
 conditions := [

--- a/policies/gcp/oslogin/google_compute_instance/disallow_legacy_metadata_ssh_keys/policy.rego
+++ b/policies/gcp/oslogin/google_compute_instance/disallow_legacy_metadata_ssh_keys/policy.rego
@@ -1,6 +1,6 @@
 package terraform.gcp.security.oslogin.google_compute_instance.disallow_legacy_metadata_ssh_keys
 
-import data.terraform.gcp.helpers
+import data.terraform.helpers
 import data.terraform.gcp.security.oslogin.google_compute_instance.vars
 
 conditions := [

--- a/policies/gcp/oslogin/google_compute_instance/enabled/policy.rego
+++ b/policies/gcp/oslogin/google_compute_instance/enabled/policy.rego
@@ -1,6 +1,6 @@
 package terraform.gcp.security.oslogin.google_compute_instance.enabled
 
-import data.terraform.gcp.helpers
+import data.terraform.helpers
 import data.terraform.gcp.security.oslogin.google_compute_instance.vars
 
 conditions := [

--- a/policies/gcp/oslogin/google_compute_instance/require_service_account/policy.rego
+++ b/policies/gcp/oslogin/google_compute_instance/require_service_account/policy.rego
@@ -1,6 +1,6 @@
 package terraform.gcp.security.oslogin.google_compute_instance.require_service_account
 
-import data.terraform.gcp.helpers
+import data.terraform.helpers
 import data.terraform.gcp.security.oslogin.google_compute_instance.vars
 
 

--- a/policies/gcp/oslogin/google_compute_instance/require_shielded_vm/policy.rego
+++ b/policies/gcp/oslogin/google_compute_instance/require_shielded_vm/policy.rego
@@ -1,6 +1,6 @@
 package terraform.gcp.security.oslogin.google_compute_instance.require_shielded_vm
 
-import data.terraform.gcp.helpers
+import data.terraform.helpers
 import data.terraform.gcp.security.oslogin.google_compute_instance.vars
 
 conditions := [

--- a/policies/gcp/oslogin/google_compute_instance/restrict_external_ip/policy.rego
+++ b/policies/gcp/oslogin/google_compute_instance/restrict_external_ip/policy.rego
@@ -1,6 +1,6 @@
 package terraform.gcp.security.oslogin.google_compute_instance.restrict_external_ip
 
-import data.terraform.gcp.helpers
+import data.terraform.helpers
 import data.terraform.gcp.security.oslogin.google_compute_instance.vars
 
 conditions := [

--- a/policies/gcp/oslogin/google_compute_instance/twofa/policy.rego
+++ b/policies/gcp/oslogin/google_compute_instance/twofa/policy.rego
@@ -1,6 +1,6 @@
 package terraform.gcp.security.oslogin.google_compute_instance.twofa
 
-import data.terraform.gcp.helpers
+import data.terraform.helpers
 import data.terraform.gcp.security.oslogin.google_compute_instance.vars
 
 conditions := [

--- a/policies/gcp/parallelstore/google_parallelstore_instance/location/policy.rego
+++ b/policies/gcp/parallelstore/google_parallelstore_instance/location/policy.rego
@@ -1,6 +1,6 @@
 package terraform.gcp.security.parallelstore.google_parallelstore_instance.location
 
-import data.terraform.gcp.helpers
+import data.terraform.helpers
 import data.terraform.gcp.security.parallelstore.google_parallelstore_instance.vars
 
 conditions := [

--- a/policies/gcp/parameter_manager/parameter/encryption/policy.rego
+++ b/policies/gcp/parameter_manager/parameter/encryption/policy.rego
@@ -1,6 +1,6 @@
 package terraform.gcp.security.parameter_manager.parameter.encryption
 
-import data.terraform.gcp.helpers
+import data.terraform.helpers
 import data.terraform.gcp.security.parameter_manager.parameter.vars
 
 conditions := [[

--- a/policies/gcp/parameter_manager/regional_parameter/allowed_location/policy.rego
+++ b/policies/gcp/parameter_manager/regional_parameter/allowed_location/policy.rego
@@ -1,6 +1,6 @@
 package terraform.gcp.security.parameter_manager.regional_parameter.allowed_location
 
-import data.terraform.gcp.helpers
+import data.terraform.helpers
 import data.terraform.gcp.security.parameter_manager.regional_parameter.vars
 
 conditions := [[

--- a/policies/gcp/parameter_manager/regional_parameter/encryption/policy.rego
+++ b/policies/gcp/parameter_manager/regional_parameter/encryption/policy.rego
@@ -1,6 +1,6 @@
 package terraform.gcp.security.parameter_manager.regional_parameter.encryption
 
-import data.terraform.gcp.helpers
+import data.terraform.helpers
 import data.terraform.gcp.security.parameter_manager.regional_parameter.vars
 
 conditions := [[

--- a/policies/gcp/privileged_access_manager/entitlement/additional_notification_targets/policy.rego
+++ b/policies/gcp/privileged_access_manager/entitlement/additional_notification_targets/policy.rego
@@ -1,6 +1,6 @@
 package terraform.gcp.security.privileged_access_manager.entitlement.additional_notification_targets
 
-import data.terraform.gcp.helpers
+import data.terraform.helpers
 import data.terraform.gcp.security.privileged_access_manager.entitlement.vars
 
 conditions := [

--- a/policies/gcp/privileged_access_manager/entitlement/approval_workflow/policy.rego
+++ b/policies/gcp/privileged_access_manager/entitlement/approval_workflow/policy.rego
@@ -1,6 +1,6 @@
 package terraform.gcp.security.privileged_access_manager.entitlement.approval_workflow
 
-import data.terraform.gcp.helpers
+import data.terraform.helpers
 import data.terraform.gcp.security.privileged_access_manager.entitlement.vars
 
 conditions := [

--- a/policies/gcp/privileged_access_manager/entitlement/eligible_users/policy.rego
+++ b/policies/gcp/privileged_access_manager/entitlement/eligible_users/policy.rego
@@ -1,6 +1,6 @@
 package terraform.gcp.security.privileged_access_manager.entitlement.eligible_users
 
-import data.terraform.gcp.helpers
+import data.terraform.helpers
 import data.terraform.gcp.security.privileged_access_manager.entitlement.vars
 
 conditions := [

--- a/policies/gcp/privileged_access_manager/entitlement/location/policy.rego
+++ b/policies/gcp/privileged_access_manager/entitlement/location/policy.rego
@@ -1,5 +1,5 @@
 package terraform.gcp.security.privileged_access_manager.entitlement.location
-import data.terraform.gcp.helpers
+import data.terraform.helpers
 import data.terraform.gcp.security.privileged_access_manager.entitlement.vars
 
 conditions := [

--- a/policies/gcp/privileged_access_manager/entitlement/max_request_duration/policy.rego
+++ b/policies/gcp/privileged_access_manager/entitlement/max_request_duration/policy.rego
@@ -1,6 +1,6 @@
 package terraform.gcp.security.privileged_access_manager.entitlement.max_request_duration
 
-import data.terraform.gcp.helpers
+import data.terraform.helpers
 import data.terraform.gcp.security.privileged_access_manager.entitlement.vars
 
 conditions := [

--- a/policies/gcp/privileged_access_manager/entitlement/privileged_access/policy.rego
+++ b/policies/gcp/privileged_access_manager/entitlement/privileged_access/policy.rego
@@ -1,5 +1,5 @@
 package terraform.gcp.security.privileged_access_manager.entitlement.privileged_access
-import data.terraform.gcp.helpers
+import data.terraform.helpers
 import data.terraform.gcp.security.privileged_access_manager.entitlement.vars
 
 conditions := [

--- a/policies/gcp/privileged_access_manager/entitlement/requester_justification_config/policy.rego
+++ b/policies/gcp/privileged_access_manager/entitlement/requester_justification_config/policy.rego
@@ -1,6 +1,6 @@
 package terraform.gcp.security.privileged_access_manager.entitlement.requester_justification_config
 
-import data.terraform.gcp.helpers
+import data.terraform.helpers
 import data.terraform.gcp.security.privileged_access_manager.entitlement.vars
 
 conditions := [

--- a/policies/gcp/recaptchaenterprise/key/allow_all_domains/policy.rego
+++ b/policies/gcp/recaptchaenterprise/key/allow_all_domains/policy.rego
@@ -1,5 +1,5 @@
 package terraform.gcp.security.recaptchaenterprise.key.allow_all_domains
-import data.terraform.gcp.helpers
+import data.terraform.helpers
 import data.terraform.gcp.security.recaptchaenterprise.key.vars
 
 conditions := [

--- a/policies/gcp/recaptchaenterprise/key/allow_amp_traffic/policy.rego
+++ b/policies/gcp/recaptchaenterprise/key/allow_amp_traffic/policy.rego
@@ -1,5 +1,5 @@
 package terraform.gcp.security.recaptchaenterprise.key.allow_amp_traffic
-import data.terraform.gcp.helpers
+import data.terraform.helpers
 import data.terraform.gcp.security.recaptchaenterprise.key.vars
 
 conditions := [

--- a/policies/gcp/recaptchaenterprise/key/challenge_security_preference/policy.rego
+++ b/policies/gcp/recaptchaenterprise/key/challenge_security_preference/policy.rego
@@ -1,5 +1,5 @@
 package terraform.gcp.security.recaptchaenterprise.key.challenge_security_preference
-import data.terraform.gcp.helpers
+import data.terraform.helpers
 import data.terraform.gcp.security.recaptchaenterprise.key.vars
 
 conditions := [

--- a/policies/gcp/recaptchaenterprise/key/integration_type/policy.rego
+++ b/policies/gcp/recaptchaenterprise/key/integration_type/policy.rego
@@ -1,5 +1,5 @@
 package terraform.gcp.security.recaptchaenterprise.key.integration_type
-import data.terraform.gcp.helpers
+import data.terraform.helpers
 import data.terraform.gcp.security.recaptchaenterprise.key.vars
 
 conditions := [

--- a/policies/gcp/registries/analysis_note/expiration_time/policy.rego
+++ b/policies/gcp/registries/analysis_note/expiration_time/policy.rego
@@ -1,6 +1,6 @@
 package terraform.gcp.security.analysis_note.expiration_time
 
-import data.terraform.gcp.helpers
+import data.terraform.helpers
 import data.terraform.gcp.security.analysis_note.expiration_time.vars
 
 conditions := [

--- a/policies/gcp/scc/event_threat_detection_custom_module/config/policy.rego
+++ b/policies/gcp/scc/event_threat_detection_custom_module/config/policy.rego
@@ -1,6 +1,6 @@
 package terraform.gcp.security.scc.event_threat_detection_custom_module.config
 
-import data.terraform.gcp.helpers
+import data.terraform.helpers
 import data.terraform.gcp.security.scc.event_threat_detection_custom_module.vars
 
 conditions := [

--- a/policies/gcp/scc/event_threat_detection_custom_module/enablement_state/policy.rego
+++ b/policies/gcp/scc/event_threat_detection_custom_module/enablement_state/policy.rego
@@ -1,5 +1,5 @@
 package terraform.gcp.security.scc.event_threat_detection_custom_module.enablement_state
-import data.terraform.gcp.helpers
+import data.terraform.helpers
 import data.terraform.gcp.security.scc.event_threat_detection_custom_module.vars
 
 conditions := [

--- a/policies/gcp/scc/folder_custom_module/enablement_state/policy.rego
+++ b/policies/gcp/scc/folder_custom_module/enablement_state/policy.rego
@@ -1,5 +1,5 @@
 package terraform.gcp.security.scc.folder_custom_module.enablement_state
-import data.terraform.gcp.helpers
+import data.terraform.helpers
 import data.terraform.gcp.security.scc.folder_custom_module.vars
 
 conditions := [

--- a/policies/gcp/scc/google_scc_notification_config/allowed_organization/policy.rego
+++ b/policies/gcp/scc/google_scc_notification_config/allowed_organization/policy.rego
@@ -1,6 +1,6 @@
 package terraform.gcp.security.scc.google_scc_notification_config.allowed_organization
 
-import data.terraform.gcp.helpers
+import data.terraform.helpers
 import data.terraform.gcp.security.scc.google_scc_notification_config.vars
 
 conditions := [

--- a/policies/gcp/scc/google_scc_notification_config/pubsub_topic/policy.rego
+++ b/policies/gcp/scc/google_scc_notification_config/pubsub_topic/policy.rego
@@ -1,6 +1,6 @@
 package terraform.gcp.security.scc.google_scc_notification_config.pubsub_topic
 
-import data.terraform.gcp.helpers
+import data.terraform.helpers
 import data.terraform.gcp.security.scc.google_scc_notification_config.vars
 
 conditions := [

--- a/policies/gcp/scc/google_scc_notification_config/streaming_config/policy.rego
+++ b/policies/gcp/scc/google_scc_notification_config/streaming_config/policy.rego
@@ -1,6 +1,6 @@
 package terraform.gcp.security.scc.google_scc_notification_config.streaming_config
 
-import data.terraform.gcp.helpers
+import data.terraform.helpers
 import data.terraform.gcp.security.scc.google_scc_notification_config.vars
 
 conditions := [

--- a/policies/gcp/scc/google_scc_organization_scc_big_query_export/big_query_export_id/policy.rego
+++ b/policies/gcp/scc/google_scc_organization_scc_big_query_export/big_query_export_id/policy.rego
@@ -1,6 +1,6 @@
 package terraform.gcp.security.scc.google_scc_organization_scc_big_query_export.big_query_export_id
 
-import data.terraform.gcp.helpers
+import data.terraform.helpers
 import data.terraform.gcp.security.scc.google_scc_organization_scc_big_query_export.vars
 
 conditions := [

--- a/policies/gcp/scc/google_scc_organization_scc_big_query_export/dataset/policy.rego
+++ b/policies/gcp/scc/google_scc_organization_scc_big_query_export/dataset/policy.rego
@@ -1,6 +1,6 @@
 package terraform.gcp.security.scc.google_scc_organization_scc_big_query_export.dataset
 
-import data.terraform.gcp.helpers
+import data.terraform.helpers
 import data.terraform.gcp.security.scc.google_scc_organization_scc_big_query_export.vars
 
 conditions := [

--- a/policies/gcp/scc/google_scc_organization_scc_big_query_export/required_filter/policy.rego
+++ b/policies/gcp/scc/google_scc_organization_scc_big_query_export/required_filter/policy.rego
@@ -1,6 +1,6 @@
 package terraform.gcp.security.scc.google_scc_organization_scc_big_query_export.required_filter
 
-import data.terraform.gcp.helpers
+import data.terraform.helpers
 import data.terraform.gcp.security.scc.google_scc_organization_scc_big_query_export.vars
 
 conditions := [

--- a/policies/gcp/scc/google_scc_source_iam_binding/allowed_role/policy.rego
+++ b/policies/gcp/scc/google_scc_source_iam_binding/allowed_role/policy.rego
@@ -1,6 +1,6 @@
 package terraform.gcp.security.scc.google_scc_source_iam_binding.allowed_role
 
-import data.terraform.gcp.helpers
+import data.terraform.helpers
 import data.terraform.gcp.security.scc.google_scc_source_iam_binding.vars
 
 conditions := [

--- a/policies/gcp/scc/google_scc_source_iam_binding/members/policy.rego
+++ b/policies/gcp/scc/google_scc_source_iam_binding/members/policy.rego
@@ -1,6 +1,6 @@
 package terraform.gcp.security.scc.google_scc_source_iam_binding.members
 
-import data.terraform.gcp.helpers
+import data.terraform.helpers
 import data.terraform.gcp.security.scc.google_scc_source_iam_binding.vars
 
 conditions := [

--- a/policies/gcp/scc/mute_config/filter/policy.rego
+++ b/policies/gcp/scc/mute_config/filter/policy.rego
@@ -1,6 +1,6 @@
 package terraform.gcp.security.scc.mute_config.filter
 
-import data.terraform.gcp.helpers
+import data.terraform.helpers
 import data.terraform.gcp.security.scc.mute_config.vars
 
 conditions := [

--- a/policies/gcp/scc/organization_custom_module/enablement_state/policy.rego
+++ b/policies/gcp/scc/organization_custom_module/enablement_state/policy.rego
@@ -1,5 +1,5 @@
 package terraform.gcp.security.scc.organization_custom_module.enablement_state
-import data.terraform.gcp.helpers
+import data.terraform.helpers
 import data.terraform.gcp.security.scc.organization_custom_module.vars
 
 conditions := [

--- a/policies/gcp/scc/project_custom_module/enablement_state/policy.rego
+++ b/policies/gcp/scc/project_custom_module/enablement_state/policy.rego
@@ -1,5 +1,5 @@
 package terraform.gcp.security.scc.project_custom_module.enablement_state
-import data.terraform.gcp.helpers
+import data.terraform.helpers
 import data.terraform.gcp.security.scc.project_custom_module.vars
 
 conditions := [

--- a/templates/gcp/policy.rego
+++ b/templates/gcp/policy.rego
@@ -1,5 +1,5 @@
 package terraform.gcp.security.<service>.<resource_type>.<policy_name> # Edit here 
-import data.terraform.gcp.helpers
+import data.terraform.helpers
 import data.terraform.gcp.security.<service>.<resource_type>.vars
 
 # STEP 1: STUDY YOUR RESOURCE AND ITS ATTRIBUTES, THEN FILL IN THE VARS FILE


### PR DESCRIPTION
- Updated import statements in all policy.rego files to replace `data.terraform.gcp.helpers` with `data.terraform.helpers` to point at refactored helpers.