### PR TITLE
Add BigQuery Connection security policies

### DIFF
--- a/inputs/gcp/BigQuery/google_bigquery_connection/cloud_sql_password/c.tf
+++ b/inputs/gcp/BigQuery/google_bigquery_connection/cloud_sql_password/c.tf
@@ -1,0 +1,17 @@
+resource "google_bigquery_connection" "c" {
+  connection_id = "c"
+  project       = "PDE"
+  location      = "australia-southeast1"
+
+  cloud_sql {
+    instance_id = "project:region:instance"
+    database    = "mydatabase"
+    type        = "POSTGRES"
+    credential {
+      username = "admin"
+      password = "securepassword123"
+    }
+  }
+
+  kms_key_name = "google_kms_crypto_key.crypto_key.id"
+}

--- a/inputs/gcp/BigQuery/google_bigquery_connection/cloud_sql_password/config.tf
+++ b/inputs/gcp/BigQuery/google_bigquery_connection/cloud_sql_password/config.tf
@@ -1,0 +1,9 @@
+terraform {
+  required_providers {
+    google = {
+      source = "hashicorp/google"
+    }
+  }
+}
+
+provider "google" {}

--- a/inputs/gcp/BigQuery/google_bigquery_connection/cloud_sql_password/nc.tf
+++ b/inputs/gcp/BigQuery/google_bigquery_connection/cloud_sql_password/nc.tf
@@ -1,0 +1,17 @@
+resource "google_bigquery_connection" "nc" {
+  connection_id = "nc"
+  project       = "PDE"
+  location      = "australia-southeast1"
+
+  cloud_sql {
+    instance_id = "project:region:instance"
+    database    = "mydatabase"
+    type        = "POSTGRES"
+    credential {
+      username = "admin"
+      password = ""
+    }
+  }
+
+  kms_key_name = "google_kms_crypto_key.crypto_key.id"
+}

--- a/inputs/gcp/BigQuery/google_bigquery_connection/cloud_sql_username/c.tf
+++ b/inputs/gcp/BigQuery/google_bigquery_connection/cloud_sql_username/c.tf
@@ -1,0 +1,17 @@
+resource "google_bigquery_connection" "c" {
+  connection_id = "c"
+  project       = "PDE"
+  location      = "australia-southeast1"
+
+  cloud_sql {
+    instance_id = "project:region:instance"
+    database    = "mydatabase"
+    type        = "POSTGRES"
+    credential {
+      username = "admin"
+      password = "securepassword123"
+    }
+  }
+
+  kms_key_name = "google_kms_crypto_key.crypto_key.id"
+}

--- a/inputs/gcp/BigQuery/google_bigquery_connection/cloud_sql_username/config.tf
+++ b/inputs/gcp/BigQuery/google_bigquery_connection/cloud_sql_username/config.tf
@@ -1,0 +1,9 @@
+terraform {
+  required_providers {
+    google = {
+      source = "hashicorp/google"
+    }
+  }
+}
+
+provider "google" {}

--- a/inputs/gcp/BigQuery/google_bigquery_connection/cloud_sql_username/nc.tf
+++ b/inputs/gcp/BigQuery/google_bigquery_connection/cloud_sql_username/nc.tf
@@ -1,0 +1,17 @@
+resource "google_bigquery_connection" "nc" {
+  connection_id = "nc"
+  project       = "PDE"
+  location      = "australia-southeast1"
+
+  cloud_sql {
+    instance_id = "project:region:instance"
+    database    = "mydatabase"
+    type        = "POSTGRES"
+    credential {
+      username = ""
+      password = "securepassword123"
+    }
+  }
+
+  kms_key_name = "google_kms_crypto_key.crypto_key.id"
+}

--- a/inputs/gcp/BigQuery/google_bigquery_connection/kms_key_name/c.tf
+++ b/inputs/gcp/BigQuery/google_bigquery_connection/kms_key_name/c.tf
@@ -1,0 +1,17 @@
+resource "google_bigquery_connection" "c" {
+  connection_id = "c"
+  project       = "PDE"
+  location      = "australia-southeast1"
+
+  cloud_sql {
+    instance_id = "project:region:instance"
+    database    = "mydatabase"
+    type        = "POSTGRES"
+    credential {
+      username = "admin"
+      password = "securepassword123"
+    }
+  }
+
+  kms_key_name = "google_kms_crypto_key.crypto_key.id"
+}

--- a/inputs/gcp/BigQuery/google_bigquery_connection/kms_key_name/config.tf
+++ b/inputs/gcp/BigQuery/google_bigquery_connection/kms_key_name/config.tf
@@ -1,0 +1,11 @@
+
+
+terraform {
+  required_providers {
+    google = {
+      source = "hashicorp/google"
+    }
+  }
+}
+
+provider "google" {}

--- a/inputs/gcp/BigQuery/google_bigquery_connection/kms_key_name/nc.tf
+++ b/inputs/gcp/BigQuery/google_bigquery_connection/kms_key_name/nc.tf
@@ -1,0 +1,15 @@
+resource "google_bigquery_connection" "nc" {
+  connection_id = "nc"
+  project       = "PDE"
+  location      = "australia-southeast1"
+
+  cloud_sql {
+    instance_id = "project:region:instance"
+    database    = "mydatabase"
+    type        = "POSTGRES"
+    credential {
+      username = "admin"
+      password = "securepassword123"
+    }
+  }
+}

--- a/policies/gcp/BigQuery/google_bigquery_connection/cloud_sql_password/policy.rego
+++ b/policies/gcp/BigQuery/google_bigquery_connection/cloud_sql_password/policy.rego
@@ -1,0 +1,18 @@
+package terraform.gcp.security.BigQuery.google_bigquery_connection.cloud_sql_password
+import data.terraform.helpers
+import data.terraform.gcp.security.BigQuery.google_bigquery_connection.vars
+
+conditions := [
+    [
+        {"situation_description": "cloud_sql password is empty, which may allow unauthorised access to the Cloud SQL database", "remedies": ["Set a non-empty password in the cloud_sql credential block"]},
+        {
+            "condition": "Check if cloud_sql password is non-empty",
+            "attribute_path": ["cloud_sql", "credential", "password"],
+            "values": [""],
+            "policy_type": "blacklist"
+        }
+    ]
+]
+
+message := helpers.get_multi_summary(conditions, vars.variables).message
+details := helpers.get_multi_summary(conditions, vars.variables).details

--- a/policies/gcp/BigQuery/google_bigquery_connection/cloud_sql_username/policy.rego
+++ b/policies/gcp/BigQuery/google_bigquery_connection/cloud_sql_username/policy.rego
@@ -1,0 +1,18 @@
+package terraform.gcp.security.BigQuery.google_bigquery_connection.cloud_sql_username
+import data.terraform.helpers
+import data.terraform.gcp.security.BigQuery.google_bigquery_connection.vars
+
+conditions := [
+    [
+        {"situation_description": "cloud_sql username is empty, which may allow unauthorised access to the Cloud SQL database", "remedies": ["Set a non-empty username in the cloud_sql credential block"]},
+        {
+            "condition": "Check if cloud_sql username is non-empty",
+            "attribute_path": ["cloud_sql", "credential", "username"],
+            "values": [""],
+            "policy_type": "blacklist"
+        }
+    ]
+]
+
+message := helpers.get_multi_summary(conditions, vars.variables).message
+details := helpers.get_multi_summary(conditions, vars.variables).details

--- a/policies/gcp/BigQuery/google_bigquery_connection/kms_key_name/policy.rego
+++ b/policies/gcp/BigQuery/google_bigquery_connection/kms_key_name/policy.rego
@@ -1,0 +1,18 @@
+package terraform.gcp.security.BigQuery.google_bigquery_connection.kms_key_name
+import data.terraform.helpers
+import data.terraform.gcp.security.BigQuery.google_bigquery_connection.vars
+
+conditions := [
+    [
+        {"situation_description": "kms_key_name is not set, leaving BigQuery Connection data unencrypted at rest", "remedies": ["Set kms_key_name to a valid Cloud KMS key"]},
+        {
+            "condition": "Check if kms_key_name is configured",
+            "attribute_path": ["kms_key_name"],
+            "values": [""],
+            "policy_type": "blacklist"
+        }
+    ]
+]
+
+message := helpers.get_multi_summary(conditions, vars.variables).message
+details := helpers.get_multi_summary(conditions, vars.variables).details

--- a/policies/gcp/BigQuery/google_bigquery_connection/vars.rego
+++ b/policies/gcp/BigQuery/google_bigquery_connection/vars.rego
@@ -1,0 +1,7 @@
+package terraform.gcp.security.BigQuery.google_bigquery_connection.vars
+
+variables := {
+    "friendly_resource_name": "BigQuery Connection",
+    "resource_type": "google_bigquery_connection",
+    "resource_value_name": "connection_id"
+}

--- a/policies/gcp/bigquery_connection/policy.rego
+++ b/policies/gcp/bigquery_connection/policy.rego
@@ -1,0 +1,24 @@
+package bigquery
+
+deny contains msg if {
+    input.resource.type == "google_bigquery_connection"
+    not input.resource.values.kms_key_name
+
+    msg := "BigQuery Connection must use KMS encryption (kms_key_name is missing)"
+}
+
+deny contains msg if {
+    input.resource.type == "google_bigquery_connection"
+    input.resource.values.cloud_sql
+    input.resource.values.cloud_sql.credential.username == ""
+
+    msg := "Username must not be empty"
+}
+
+deny contains msg if {
+    input.resource.type == "google_bigquery_connection"
+    input.resource.values.cloud_sql
+    input.resource.values.cloud_sql.credential.password == ""
+
+    msg := "Password must not be empty"
+}


### PR DESCRIPTION
This PR adds OPA policies for Google BigQuery Connection to enforce:

- KMS encryption requirement
- Non-empty username
- Non-empty password