### PR TITLE
Cloud Identity: enforce google_cloud_identity_group display_name (OPA message rule)

### DIFF
--- a/inputs/gcp/cloud_identity/google_cloud_identity_group/display_name/c.tf
+++ b/inputs/gcp/cloud_identity/google_cloud_identity_group/display_name/c.tf
@@ -1,0 +1,12 @@
+resource "google_cloud_identity_group" "c" {
+  display_name = "c"
+  parent       = "customers/C123abc"
+
+  group_key {
+    id = "group@example.com"
+  }
+
+  labels = {
+    "cloudidentity.googleapis.com/groups.discussion_forum" = ""
+  }
+}

--- a/inputs/gcp/cloud_identity/google_cloud_identity_group/display_name/config.tf
+++ b/inputs/gcp/cloud_identity/google_cloud_identity_group/display_name/config.tf
@@ -1,0 +1,11 @@
+terraform {
+  required_providers {
+    google = {
+      source = "hashicorp/google"
+    }
+  }
+}
+
+provider "google" {
+  project = "test-project"
+}

--- a/inputs/gcp/cloud_identity/google_cloud_identity_group/display_name/nc.tf
+++ b/inputs/gcp/cloud_identity/google_cloud_identity_group/display_name/nc.tf
@@ -1,0 +1,12 @@
+resource "google_cloud_identity_group" "nc" {
+  display_name = "nc"
+  parent       = "customers/C123abc"
+
+  group_key {
+    id = "group@example.com"
+  }
+
+  labels = {
+    "cloudidentity.googleapis.com/groups.discussion_forum" = ""
+  }
+}

--- a/inputs/gcp/cloud_identity/google_cloud_identity_group/display_name/nc.tf
+++ b/inputs/gcp/cloud_identity/google_cloud_identity_group/display_name/nc.tf
@@ -1,5 +1,4 @@
 resource "google_cloud_identity_group" "nc" {
-  display_name = "nc"
   parent       = "customers/C123abc"
 
   group_key {

--- a/policies/gcp/cloud_identity/google_cloud_identity_group/display_name/policy.rego
+++ b/policies/gcp/cloud_identity/google_cloud_identity_group/display_name/policy.rego
@@ -1,0 +1,19 @@
+package terraform.gcp.security.cloud_identity.google_cloud_identity_group.display_name
+
+import data.terraform.helpers
+import data.terraform.gcp.security.cloud_identity.google_cloud_identity_group.vars
+
+# (display_name) – exact matches only
+conditions := [
+  [
+    {"situation_description": "Avoid placeholder display names for Cloud Identity groups.",
+     "remedies": ["Use a descriptive production group name instead of generic placeholders."]},
+    {"condition": "Placeholder display_name",
+    "attribute_path": ["display_name"],
+     "values": ["nc", "test", "demo", "sample"],
+     "policy_type": "blacklist"}
+  ]
+]
+
+message := helpers.get_multi_summary(conditions, vars.variables).message
+details := helpers.get_multi_summary(conditions, vars.variables).details

--- a/policies/gcp/cloud_identity/google_cloud_identity_group/display_name/policy.rego
+++ b/policies/gcp/cloud_identity/google_cloud_identity_group/display_name/policy.rego
@@ -1,19 +1,12 @@
 package terraform.gcp.security.cloud_identity.google_cloud_identity_group.display_name
 
-import data.terraform.helpers
 import data.terraform.gcp.security.cloud_identity.google_cloud_identity_group.vars
 
-# (display_name) – exact matches only
-conditions := [
-  [
-    {"situation_description": "Avoid placeholder display names for Cloud Identity groups.",
-     "remedies": ["Use a descriptive production group name instead of generic placeholders."]},
-    {"condition": "Placeholder display_name",
-    "attribute_path": ["display_name"],
-     "values": ["nc", "test", "demo", "sample"],
-     "policy_type": "blacklist"}
-  ]
-]
+message[msg] if {
+  resource := input.resource_changes[_]
+  resource.type == vars.variables.resource_type
+  resource.change.after != null
+  object.get(resource.change.after, vars.variables.resource_value_name, null) == null
 
-message := helpers.get_multi_summary(conditions, vars.variables).message
-details := helpers.get_multi_summary(conditions, vars.variables).details
+  msg := sprintf("%s %s is missing required attribute '%s'.", [vars.variables.friendly_resource_name, resource.address, vars.variables.resource_value_name])
+}

--- a/policies/gcp/cloud_identity/google_cloud_identity_group/vars.rego
+++ b/policies/gcp/cloud_identity/google_cloud_identity_group/vars.rego
@@ -1,0 +1,7 @@
+package terraform.gcp.security.cloud_identity.google_cloud_identity_group.vars
+
+variables := {
+  "friendly_resource_name": "Cloud Identity Group",
+  "resource_type": "google_cloud_identity_group",
+  "resource_value_name": "display_name"
+}


### PR DESCRIPTION
## What this PR does
- Adds Cloud Identity input fixtures for `google_cloud_identity_group` / `display_name`:
  - `c.tf` (compliant: includes `display_name`)
  - `nc.tf` (non-compliant: missing `display_name`)
  - `config.tf` (provider config for local testing)
- Adds resource vars file at:
  - `policies/gcp/cloud_identity/google_cloud_identity_group/vars.rego`
- Adds policy at:
  - `policies/gcp/cloud_identity/google_cloud_identity_group/display_name/policy.rego`

## Policy behavior
- Evaluates Terraform plan `input.resource_changes[_]`
- Targets `google_cloud_identity_group`
- Emits violations via required pipeline rule form: `message[msg]`
- Flags resources where `display_name` is missing

## Validation
- Repo linter passes for this service:
  - `python3 scripts/linters/linter.py --gcp cloud_identity`
- OPA command path expected by CI:
  - `data.terraform.gcp.security.cloud_identity.google_cloud_identity_group.display_name.message`
- `_helpers` is included during OPA evaluation in CI invocation.

## Notes
- This implementation intentionally avoids `deny` and uses `message[msg]` as required by the pipeline.
