### PR TITLE
Add Cloud Storage for Firebase documentation

### DIFF
--- a/docs/gcp/Cloud_Storage_for_Firebase/firebase_storage_bucket.md
+++ b/docs/gcp/Cloud_Storage_for_Firebase/firebase_storage_bucket.md
@@ -1,0 +1,14 @@
+## 🛡️ Policy Deployment Engine: `firebase_storage_bucket`
+
+This section provides a concise policy evaluation for the `firebase_storage_bucket` resource in GCP.
+
+Reference: [Terraform Registry – firebase_storage_bucket](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/firebase_storage_bucket)
+
+---
+
+## Argument Reference  
+
+| Argument | Description | Required | Security Impact | Rationale | Compliant | Non-Compliant |
+|----------|-------------|----------|-----------------|-----------|-----------|---------------|
+| `bucket_id` | Required. Immutable. The ID of the underlying Google Cloud Storage bucket | true | false | Identifies the storage bucket used by Firebase. | test_bucket_c | test_bucket_nc |
+| `project` | If it is not provided, the provider project is used. | false | true | Ensures the resource is deployed in an approved and secure project environment. | 83797152308 | my-project-name |

--- a/docs/gcp/Cloud_Storage_for_Firebase/resource_json/firebase_storage_bucket.json
+++ b/docs/gcp/Cloud_Storage_for_Firebase/resource_json/firebase_storage_bucket.json
@@ -4,20 +4,20 @@
   "arguments": {
     "bucket_id": {
       "description": "Required. Immutable. The ID of the underlying Google Cloud Storage bucket",
-      "required": false,
-      "security_impact": null,
-      "rationale": null,
-      "compliant": null,
-      "non-compliant": null,
+      "required": true,
+      "security_impact": false,
+      "rationale": "Identifies the storage bucket used by Firebase.",
+      "compliant": "test_bucket_c",
+      "non-compliant": "test_bucket_nc",
       "parent": null
     },
     "project": {
       "description": "If it is not provided, the provider project is used.",
-      "required": null,
-      "security_impact": null,
-      "rationale": null,
-      "compliant": null,
-      "non-compliant": null,
+      "required": false,
+      "security_impact": true,
+      "rationale": "Ensures the resource is deployed in an approved and secure project environment.",
+      "compliant": "83797152308",
+      "non-compliant": "my-project-name",
       "parent": null
     }
   }


### PR DESCRIPTION
Added resource JSON documentation for google_firebase_storage_bucket and generated Markdown documentation. This service does not require policy enforcement, so only documentation is included.