### PR TITLE
Add Cloud TPU queued resource allowed_parent policy

### DIFF
--- a/inputs/gcp/cloud_tpu/google_tpu_v2_queued_resource/allowed_parent/c.tf
+++ b/inputs/gcp/cloud_tpu/google_tpu_v2_queued_resource/allowed_parent/c.tf
@@ -1,4 +1,4 @@
-resource "google_tpu_v2_queued_resource" "qr" {
+resource "google_tpu_v2_queued_resource" "qr_compliant" {
   provider = google-beta
 
   name    = "test-qr"

--- a/inputs/gcp/cloud_tpu/google_tpu_v2_queued_resource/allowed_parent/c.tf
+++ b/inputs/gcp/cloud_tpu/google_tpu_v2_queued_resource/allowed_parent/c.tf
@@ -1,4 +1,4 @@
-resource "google_tpu_v2_queued_resource" "qr_compliant" {
+resource "google_tpu_v2_queued_resource" "c" {
   provider = google-beta
 
   name    = "test-qr"

--- a/inputs/gcp/cloud_tpu/google_tpu_v2_queued_resource/allowed_parent/c.tf
+++ b/inputs/gcp/cloud_tpu/google_tpu_v2_queued_resource/allowed_parent/c.tf
@@ -1,0 +1,19 @@
+resource "google_tpu_v2_queued_resource" "qr" {
+  provider = google-beta
+
+  name    = "test-qr"
+  zone    = "us-central1-c"
+  project = "my-project-name"
+
+  tpu {
+    node_spec {
+      parent  = "projects/my-project-name/locations/us-central1-c"
+      node_id = "test-tpu"
+
+      node {
+        runtime_version  = "tpu-vm-tf-2.13.0"
+        accelerator_type = "v2-8"
+      }
+    }
+  }
+}

--- a/inputs/gcp/cloud_tpu/google_tpu_v2_queued_resource/allowed_parent/config.tf
+++ b/inputs/gcp/cloud_tpu/google_tpu_v2_queued_resource/allowed_parent/config.tf
@@ -1,0 +1,4 @@
+provider "google-beta" {
+  project = "my-project-name"
+  region  = "us-central1"
+}

--- a/inputs/gcp/cloud_tpu/google_tpu_v2_queued_resource/allowed_parent/nc.tf
+++ b/inputs/gcp/cloud_tpu/google_tpu_v2_queued_resource/allowed_parent/nc.tf
@@ -1,0 +1,19 @@
+resource "google_tpu_v2_queued_resource" "qr" {
+  provider = google-beta
+
+  name    = "test-qr"
+  zone    = "asia-east1-a"   # ❌ forbidden
+  project = "my-project-name"
+
+  tpu {
+    node_spec {
+      parent  = "projects/my-project-name/locations/asia-east1-a"  # ❌ forbidden
+      node_id = "test-tpu"
+
+      node {
+        runtime_version  = "tpu-vm-tf-2.13.0"
+        accelerator_type = "v2-8"
+      }
+    }
+  }
+}

--- a/inputs/gcp/cloud_tpu/google_tpu_v2_queued_resource/allowed_parent/nc.tf
+++ b/inputs/gcp/cloud_tpu/google_tpu_v2_queued_resource/allowed_parent/nc.tf
@@ -1,4 +1,4 @@
-resource "google_tpu_v2_queued_resource" "qr_non_compliant" {
+resource "google_tpu_v2_queued_resource" "nc" {
   provider = google-beta
 
   name    = "test-qr"

--- a/inputs/gcp/cloud_tpu/google_tpu_v2_queued_resource/allowed_parent/nc.tf
+++ b/inputs/gcp/cloud_tpu/google_tpu_v2_queued_resource/allowed_parent/nc.tf
@@ -1,4 +1,4 @@
-resource "google_tpu_v2_queued_resource" "qr" {
+resource "google_tpu_v2_queued_resource" "qr_non_compliant" {
   provider = google-beta
 
   name    = "test-qr"

--- a/policies/gcp/cloud_tpu/google_tpu_v2_queued_resource/allowed_parent/policy.rego
+++ b/policies/gcp/cloud_tpu/google_tpu_v2_queued_resource/allowed_parent/policy.rego
@@ -1,0 +1,26 @@
+package terraform.gcp.security.cloud_tpu.google_tpu_v2_queued_resource.allowed_parent
+
+import data.terraform.helpers
+import data.terraform.gcp.security.cloud_tpu.google_tpu_v2_queued_resource.vars
+
+conditions := [
+    [
+        {
+            "situation_description": "The parent location is not in the allowed list.",
+            "remedies": [
+                "Use an approved parent location such as 'projects/my-project-name/locations/us-central1-c'.",
+                "Consult Google Cloud TPU documentation for supported locations."
+            ]
+        },
+        {
+            "condition": "Check if parent is not in the allowed whitelist",
+            "attribute_path": ["tpu", 0, "node_spec", 0, "parent"],
+            "values": ["projects/my-project-name/locations/us-central1-c"],
+            "policy_type": "whitelist"
+        }
+    ]
+]
+
+result := helpers.get_multi_summary(conditions, vars.variables)
+message := result.message
+details := result.details

--- a/policies/gcp/cloud_tpu/google_tpu_v2_queued_resource/vars.rego
+++ b/policies/gcp/cloud_tpu/google_tpu_v2_queued_resource/vars.rego
@@ -3,5 +3,5 @@ package terraform.gcp.security.cloud_tpu.google_tpu_v2_queued_resource.vars
 variables := {
   "friendly_resource_name": "Cloud TPU V2 Queued Resource",
   "resource_type": "google_tpu_v2_queued_resource",
-  "resource_value_name": "name"
+  "resource_value_name": "address"
 }

--- a/policies/gcp/cloud_tpu/google_tpu_v2_queued_resource/vars.rego
+++ b/policies/gcp/cloud_tpu/google_tpu_v2_queued_resource/vars.rego
@@ -1,0 +1,7 @@
+package terraform.gcp.security.cloud_tpu.google_tpu_v2_queued_resource.vars
+
+variables := {
+  "friendly_resource_name": "Cloud TPU V2 Queued Resource",
+  "resource_type": "google_tpu_v2_queued_resource",
+  "resource_value_name": "name"
+}


### PR DESCRIPTION
- Added whitelist policy for parent attribute in google_tpu_v2_queued_resource
- Ensures only approved locations are used
- Includes compliant and non-compliant Terraform examples
- Verified using OPA evaluation