### PR TITLE
Gcp/service/cloud tpu

### DIFF
--- a/docs/gcp/Cloud_TPU_v2/tpu_v2_vm.md
+++ b/docs/gcp/Cloud_TPU_v2/tpu_v2_vm.md
@@ -1,0 +1,41 @@
+## 🛡️ Policy Deployment Engine: `google_tpu_v2_vm`
+
+This section provides a concise policy evaluation for the `google_tpu_v2_vm` resource in GCP.
+
+Reference: [Terraform Registry – google_tpu_v2_vm](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/tpu_v2_vm)
+
+---
+
+## Argument Reference
+
+| Argument | Description | Required | Security Impact | Rationale | Compliant | Non-Compliant |
+|----------|-------------|----------|-----------------|-----------|-----------|---------------|
+| `name` | The immutable name of the TPU. | true | false | None | None | None |
+| `runtime_version` | Runtime version for the TPU. | true | false | None | None | None |
+| `accelerator_type` | TPU accelerator type for the TPU. If neither accelerator_type nor accelerator_config is specified, accelerator_type defaults to 'v2-8'. | false | false | None | None | None |
+| `description` | Text description of the TPU. | false | false | None | None | None |
+| `cidr_block` | The CIDR block that the TPU node will use when selecting an IP address. Must be a /29 block. | false | false | None | None | None |
+| `zone` | The GCP location for the TPU. If not provided, the provider zone is used. | false | false | None | None | None |
+| `project` | The ID of the project in which the resource belongs. If not provided, the provider project is used. | false | false | None | None | None |
+| `labels` | Resource labels to represent user-provided metadata. | false | false | None | None | None |
+| `metadata` | Custom metadata to apply to the TPU Node. Can set startup-script and shutdown-script. | false | false | None | None | None |
+| `tags` | Tags to apply to the TPU Node. Tags are used to identify valid sources or targets for network firewalls. | false | false | None | None | None |
+| `network_config` | Network configurations for the TPU node. | false | false | None | None | None |
+| `scheduling_config` | The scheduling options for this node. | false | false | None | None | None |
+| `data_disks` | The additional data disks for the Node. | false | false | None | None | None |
+| `accelerator_config` | The AcceleratorConfig for the TPU Node. Cannot be used at the same time as accelerator_type. | false | false | None | None | None |
+| `shielded_instance_config.enable_secure_boot` | Defines whether the instance has Secure Boot enabled. | true | true | Secure Boot protects the TPU VM from boot-level malware and rootkits by verifying the integrity of the boot process. Disabling it leaves the VM vulnerable to low-level attacks that can compromise the entire workload. | `enable_secure_boot = true` | `enable_secure_boot = false` |
+| `network_config.enable_external_ips` | Indicates that external IP addresses would be associated with the TPU workers. If set to false, the subnetwork should have Private Google Access enabled. | false | true | Enabling external IPs exposes the TPU VM directly to the public internet, increasing the attack surface. TPU workloads should use internal IPs with Private Google Access enabled to limit exposure. | `enable_external_ips = false` | `enable_external_ips = true` |
+| `service_account.email` | Email address of the service account. If empty, default Compute service account will be used. | false | true | Using the default compute service account violates the principle of least privilege by granting excessive permissions to the TPU VM. A dedicated service account with only the required IAM permissions should always be specified. | `email = "tpu-sa@project.iam.gserviceaccount.com"` | `email = ""` |
+| `network_config.network` | The name of the network for the TPU node. If none is provided, default will be used. | false | false | None | None | None |
+| `network_config.subnetwork` | The name of the subnetwork for the TPU node. If none is provided, default will be used. | false | false | None | None | None |
+| `network_config.can_ip_forward` | Allows the TPU node to send and receive packets with non-matching destination or source IPs. | false | false | None | None | None |
+| `network_config.queue_count` | Specifies networking queue count for TPU VM instance's network interface. | false | false | None | None | None |
+| `scheduling_config.preemptible` | Defines whether the node is preemptible. | false | false | None | None | None |
+| `scheduling_config.reserved` | Whether the node is created under a reservation. | false | false | None | None | None |
+| `scheduling_config.spot` | Defines whether the node is Spot VM. | false | false | None | None | None |
+| `data_disks.source_disk` | Specifies the full path to an existing disk. | true | false | None | None | None |
+| `data_disks.mode` | The mode in which to attach this disk. Default is READ_WRITE. | false | false | None | None | None |
+| `accelerator_config.type` | Type of TPU accelerator. | true | false | None | None | None |
+| `accelerator_config.topology` | Topology of TPU in chips. | true | false | None | None | None |
+| `service_account.scope` | The list of scopes to be made available for this service account. If empty, access to all Cloud APIs will be allowed. | false | false | None | None | None |

--- a/inputs/gcp/cloud_tpu/google_tpu_v2_vm/enable_secure_boot/c.tf
+++ b/inputs/gcp/cloud_tpu/google_tpu_v2_vm/enable_secure_boot/c.tf
@@ -1,0 +1,19 @@
+resource "google_tpu_v2_vm" "c" {
+  name             = "c"
+  zone             = "us-central1-c"
+  project          = "fake-project"
+  runtime_version  = "tpu-vm-tf-2.13.0"
+  accelerator_type = "v2-8"
+
+  shielded_instance_config {
+    enable_secure_boot = true
+  }
+
+  service_account {
+    email = "tpu-sa@fake-project.iam.gserviceaccount.com"
+  }
+
+  network_config {
+    enable_external_ips = false
+  }
+}

--- a/inputs/gcp/cloud_tpu/google_tpu_v2_vm/enable_secure_boot/c.tf
+++ b/inputs/gcp/cloud_tpu/google_tpu_v2_vm/enable_secure_boot/c.tf
@@ -1,4 +1,5 @@
 resource "google_tpu_v2_vm" "c" {
+  provider         = google-beta
   name             = "c"
   zone             = "us-central1-c"
   project          = "fake-project"

--- a/inputs/gcp/cloud_tpu/google_tpu_v2_vm/enable_secure_boot/config.tf
+++ b/inputs/gcp/cloud_tpu/google_tpu_v2_vm/enable_secure_boot/config.tf
@@ -1,0 +1,11 @@
+##### DO NOT EDIT ######
+
+terraform {
+  required_providers {
+    google = {
+      source = "hashicorp/google"
+    }
+  }
+}
+
+provider "google" {}

--- a/inputs/gcp/cloud_tpu/google_tpu_v2_vm/enable_secure_boot/config.tf
+++ b/inputs/gcp/cloud_tpu/google_tpu_v2_vm/enable_secure_boot/config.tf
@@ -2,10 +2,10 @@
 
 terraform {
   required_providers {
-    google = {
-      source = "hashicorp/google"
+    google-beta = {
+      source = "hashicorp/google-beta"
     }
   }
 }
 
-provider "google" {}
+provider "google-beta" {}

--- a/inputs/gcp/cloud_tpu/google_tpu_v2_vm/enable_secure_boot/nc.tf
+++ b/inputs/gcp/cloud_tpu/google_tpu_v2_vm/enable_secure_boot/nc.tf
@@ -1,4 +1,5 @@
 resource "google_tpu_v2_vm" "nc" {
+  provider         = google-beta
   name             = "nc"
   zone             = "us-central1-c"
   project          = "fake-project"

--- a/inputs/gcp/cloud_tpu/google_tpu_v2_vm/enable_secure_boot/nc.tf
+++ b/inputs/gcp/cloud_tpu/google_tpu_v2_vm/enable_secure_boot/nc.tf
@@ -1,0 +1,19 @@
+resource "google_tpu_v2_vm" "nc" {
+  name             = "nc"
+  zone             = "us-central1-c"
+  project          = "fake-project"
+  runtime_version  = "tpu-vm-tf-2.13.0"
+  accelerator_type = "v2-8"
+
+  shielded_instance_config {
+    enable_secure_boot = false
+  }
+
+  service_account {
+    email = "tpu-sa@fake-project.iam.gserviceaccount.com"
+  }
+
+  network_config {
+    enable_external_ips = false
+  }
+}

--- a/inputs/gcp/cloud_tpu/google_tpu_v2_vm/no_external_ips/c.tf
+++ b/inputs/gcp/cloud_tpu/google_tpu_v2_vm/no_external_ips/c.tf
@@ -1,0 +1,19 @@
+resource "google_tpu_v2_vm" "c" {
+  name             = "c"
+  zone             = "us-central1-c"
+  project          = "fake-project"
+  runtime_version  = "tpu-vm-tf-2.13.0"
+  accelerator_type = "v2-8"
+
+  shielded_instance_config {
+    enable_secure_boot = true
+  }
+
+  service_account {
+    email = "tpu-sa@fake-project.iam.gserviceaccount.com"
+  }
+
+  network_config {
+    enable_external_ips = false
+  }
+}

--- a/inputs/gcp/cloud_tpu/google_tpu_v2_vm/no_external_ips/c.tf
+++ b/inputs/gcp/cloud_tpu/google_tpu_v2_vm/no_external_ips/c.tf
@@ -1,4 +1,5 @@
 resource "google_tpu_v2_vm" "c" {
+  provider         = google-beta
   name             = "c"
   zone             = "us-central1-c"
   project          = "fake-project"

--- a/inputs/gcp/cloud_tpu/google_tpu_v2_vm/no_external_ips/config.tf
+++ b/inputs/gcp/cloud_tpu/google_tpu_v2_vm/no_external_ips/config.tf
@@ -1,0 +1,11 @@
+##### DO NOT EDIT ######
+
+terraform {
+  required_providers {
+    google = {
+      source = "hashicorp/google"
+    }
+  }
+}
+
+provider "google" {}

--- a/inputs/gcp/cloud_tpu/google_tpu_v2_vm/no_external_ips/config.tf
+++ b/inputs/gcp/cloud_tpu/google_tpu_v2_vm/no_external_ips/config.tf
@@ -2,10 +2,10 @@
 
 terraform {
   required_providers {
-    google = {
-      source = "hashicorp/google"
+    google-beta = {
+      source = "hashicorp/google-beta"
     }
   }
 }
 
-provider "google" {}
+provider "google-beta" {}

--- a/inputs/gcp/cloud_tpu/google_tpu_v2_vm/no_external_ips/nc.tf
+++ b/inputs/gcp/cloud_tpu/google_tpu_v2_vm/no_external_ips/nc.tf
@@ -1,0 +1,19 @@
+resource "google_tpu_v2_vm" "nc" {
+  name             = "nc"
+  zone             = "us-central1-c"
+  project          = "fake-project"
+  runtime_version  = "tpu-vm-tf-2.13.0"
+  accelerator_type = "v2-8"
+
+  shielded_instance_config {
+    enable_secure_boot = true
+  }
+
+  service_account {
+    email = "tpu-sa@fake-project.iam.gserviceaccount.com"
+  }
+
+  network_config {
+    enable_external_ips = true
+  }
+}

--- a/inputs/gcp/cloud_tpu/google_tpu_v2_vm/no_external_ips/nc.tf
+++ b/inputs/gcp/cloud_tpu/google_tpu_v2_vm/no_external_ips/nc.tf
@@ -1,4 +1,5 @@
 resource "google_tpu_v2_vm" "nc" {
+  provider         = google-beta
   name             = "nc"
   zone             = "us-central1-c"
   project          = "fake-project"

--- a/inputs/gcp/cloud_tpu/google_tpu_v2_vm/service_account_configured/c.tf
+++ b/inputs/gcp/cloud_tpu/google_tpu_v2_vm/service_account_configured/c.tf
@@ -1,0 +1,19 @@
+resource "google_tpu_v2_vm" "c" {
+  name             = "c"
+  zone             = "us-central1-c"
+  project          = "fake-project"
+  runtime_version  = "tpu-vm-tf-2.13.0"
+  accelerator_type = "v2-8"
+
+  shielded_instance_config {
+    enable_secure_boot = true
+  }
+
+  service_account {
+    email = "tpu-sa@fake-project.iam.gserviceaccount.com"
+  }
+
+  network_config {
+    enable_external_ips = false
+  }
+}

--- a/inputs/gcp/cloud_tpu/google_tpu_v2_vm/service_account_configured/c.tf
+++ b/inputs/gcp/cloud_tpu/google_tpu_v2_vm/service_account_configured/c.tf
@@ -1,4 +1,5 @@
 resource "google_tpu_v2_vm" "c" {
+  provider         = google-beta
   name             = "c"
   zone             = "us-central1-c"
   project          = "fake-project"

--- a/inputs/gcp/cloud_tpu/google_tpu_v2_vm/service_account_configured/config.tf
+++ b/inputs/gcp/cloud_tpu/google_tpu_v2_vm/service_account_configured/config.tf
@@ -1,0 +1,11 @@
+##### DO NOT EDIT ######
+
+terraform {
+  required_providers {
+    google = {
+      source = "hashicorp/google"
+    }
+  }
+}
+
+provider "google" {}

--- a/inputs/gcp/cloud_tpu/google_tpu_v2_vm/service_account_configured/config.tf
+++ b/inputs/gcp/cloud_tpu/google_tpu_v2_vm/service_account_configured/config.tf
@@ -2,10 +2,10 @@
 
 terraform {
   required_providers {
-    google = {
-      source = "hashicorp/google"
+    google-beta = {
+      source = "hashicorp/google-beta"
     }
   }
 }
 
-provider "google" {}
+provider "google-beta" {}

--- a/inputs/gcp/cloud_tpu/google_tpu_v2_vm/service_account_configured/nc.tf
+++ b/inputs/gcp/cloud_tpu/google_tpu_v2_vm/service_account_configured/nc.tf
@@ -1,0 +1,19 @@
+resource "google_tpu_v2_vm" "nc" {
+  name             = "nc"
+  zone             = "us-central1-c"
+  project          = "fake-project"
+  runtime_version  = "tpu-vm-tf-2.13.0"
+  accelerator_type = "v2-8"
+
+  shielded_instance_config {
+    enable_secure_boot = true
+  }
+
+  service_account {
+    email = ""
+  }
+
+  network_config {
+    enable_external_ips = false
+  }
+}

--- a/inputs/gcp/cloud_tpu/google_tpu_v2_vm/service_account_configured/nc.tf
+++ b/inputs/gcp/cloud_tpu/google_tpu_v2_vm/service_account_configured/nc.tf
@@ -1,4 +1,5 @@
 resource "google_tpu_v2_vm" "nc" {
+  provider         = google-beta
   name             = "nc"
   zone             = "us-central1-c"
   project          = "fake-project"

--- a/policies/gcp/cloud_tpu/google_tpu_v2_vm/enable_secure_boot/policy.rego
+++ b/policies/gcp/cloud_tpu/google_tpu_v2_vm/enable_secure_boot/policy.rego
@@ -1,0 +1,24 @@
+package terraform.gcp.security.cloud_tpu.google_tpu_v2_vm.enable_secure_boot
+import data.terraform.helpers
+import data.terraform.gcp.security.cloud_tpu.google_tpu_v2_vm.vars
+
+conditions := [
+    [
+        {
+            "situation_description": "Secure Boot is not enabled on the Cloud TPU V2 VM, leaving it vulnerable to boot-level malware and rootkits.",
+            "remedies": [
+                "Set `shielded_instance_config.enable_secure_boot` to true to enable Secure Boot on the TPU VM."
+            ]
+        },
+        {
+            "condition": "Check if Secure Boot is enabled",
+            "attribute_path": ["shielded_instance_config", 0, "enable_secure_boot"],
+            "values": [false],
+            "policy_type": "blacklist"
+        }
+    ]
+]
+
+result := helpers.get_multi_summary(conditions, vars.variables)
+message := result.message
+details := result.details

--- a/policies/gcp/cloud_tpu/google_tpu_v2_vm/no_external_ips/policy.rego
+++ b/policies/gcp/cloud_tpu/google_tpu_v2_vm/no_external_ips/policy.rego
@@ -1,0 +1,24 @@
+package terraform.gcp.security.cloud_tpu.google_tpu_v2_vm.no_external_ips
+import data.terraform.helpers
+import data.terraform.gcp.security.cloud_tpu.google_tpu_v2_vm.vars
+
+conditions := [
+    [
+        {
+            "situation_description": "The Cloud TPU V2 VM has external IP addresses enabled, increasing the attack surface and exposing the TPU worker to the public internet.",
+            "remedies": [
+                "Set `network_config.enable_external_ips` to false and enable Private Google Access on the subnetwork instead."
+            ]
+        },
+        {
+            "condition": "Check if external IPs are disabled",
+            "attribute_path": ["network_config", 0, "enable_external_ips"],
+            "values": [true],
+            "policy_type": "blacklist"
+        }
+    ]
+]
+
+result := helpers.get_multi_summary(conditions, vars.variables)
+message := result.message
+details := result.details

--- a/policies/gcp/cloud_tpu/google_tpu_v2_vm/service_account_configured/policy.rego
+++ b/policies/gcp/cloud_tpu/google_tpu_v2_vm/service_account_configured/policy.rego
@@ -1,0 +1,24 @@
+package terraform.gcp.security.cloud_tpu.google_tpu_v2_vm.service_account_configured
+import data.terraform.helpers
+import data.terraform.gcp.security.cloud_tpu.google_tpu_v2_vm.vars
+
+conditions := [
+    [
+        {
+            "situation_description": "No dedicated service account is configured for the Cloud TPU V2 VM. Using the default compute service account violates the principle of least privilege.",
+            "remedies": [
+                "Set `service_account.email` to a dedicated service account with only the required IAM permissions."
+            ]
+        },
+        {
+            "condition": "Check if a dedicated service account email is configured",
+            "attribute_path": ["service_account", 0, "email"],
+            "values": [""],
+            "policy_type": "blacklist"
+        }
+    ]
+]
+
+result := helpers.get_multi_summary(conditions, vars.variables)
+message := result.message
+details := result.details

--- a/policies/gcp/cloud_tpu/google_tpu_v2_vm/vars.rego
+++ b/policies/gcp/cloud_tpu/google_tpu_v2_vm/vars.rego
@@ -1,0 +1,7 @@
+package terraform.gcp.security.cloud_tpu.google_tpu_v2_vm.vars 
+ 
+variables := { 
+    "friendly_resource_name": "Cloud TPU V2 VM", 
+    "resource_type": "google_tpu_v2_vm", 
+    "resource_value_name": "name" 
+}


### PR DESCRIPTION
Add security policies for Cloud TPU V2 (google_tpu_v2_vm)

Policies implemented:
- enable_secure_boot: Enforces Secure Boot on TPU VM
- no_external_ips: Ensures no external IPs are assigned
- service_account_configured: Enforces dedicated service account usage

Includes compliant (c.tf) and non-compliant (nc.tf) test cases for each policy.
Documentation added at docs/gcp/Cloud_TPU_v2/tpu_v2_vm.md