### PR TITLE
feat: add shared IAM and location policy templates for GCP

### DIFF
--- a/templates/IAM_template/<resource>_iam_binding/no_primitive_or_public/policy.rego
+++ b/templates/IAM_template/<resource>_iam_binding/no_primitive_or_public/policy.rego
@@ -1,0 +1,70 @@
+# TEMPLATE: IAM Binding multiple linked conditions
+# -------------------------------------------------------------------
+# BEFORE USING THIS TEMPLATE:
+# 1. Confirm "role" field name in resource JSON
+# 2. Confirm "members" (array) in resource JSON — _iam_binding always
+#    uses plural "members"
+# 3. Confirm valid roles for this resource — may be service specific
+#    e.g. "roles/apigateway.viewer" not "roles/viewer"
+# 4. Update the 3 fields in vars.rego
+# 5. Change the package line and folder name
+# ---------------------------------------------------------------------
+
+# Make sure to change the folder name to the correct resource name
+package terraform.gcp.security.<service>.<resource_type>.no_primitive_or_public_binding
+import data.terraform.helpers
+import data.terraform.gcp.security.<service>.<resource_type>.vars
+
+conditions := [
+    [
+        {
+            "situation_description": "IAM binding uses a primitive role (owner/editor/viewer)",
+            "remedies": [
+                "Replace roles/owner with a scoped predefined role",
+                "Replace roles/editor with the minimum required predefined role",
+                "Replace roles/viewer with a read-only predefined role — check valid roles for this resource e.g. roles/apigateway.viewer"
+            ]
+        },
+        {
+            "condition": "role must not be a primitive GCP role",
+            "attribute_path": ["role"],  # confirm field name in resource JSON
+            "values": ["roles/owner", "roles/editor", "roles/viewer"], # may be service specific,must match terraform plan e.g. "roles/apigateway.viewer" not "roles/viewer
+            "policy_type": "blacklist"
+        }
+    ],
+    [
+        {
+            "situation_description": "IAM binding grants public access via allUsers or allAuthenticatedUsers",
+            "remedies": [
+                "Remove allUsers — exposes the resource to the entire internet",
+                "Remove allAuthenticatedUsers — grants access to any Google account worldwide"
+            ]
+        },
+        {
+            "condition": "members must not include public identifiers",
+            "attribute_path": ["members"],  # plural array — confirmed for _iam_binding
+            "values": ["allUsers", "allAuthenticatedUsers"],
+            "policy_type": "blacklist"
+        }
+    ],
+    [
+        {
+            "situation_description": "IAM binding grants access to all project owners, editors or viewers",
+            "remedies": [
+                "Replace projectOwner:projectid with a specific user or service account",
+                "Replace projectEditor:projectid with a specific user or service account",
+                "Replace projectViewer:projectid with a specific user or service account"
+            ]
+        },
+        {
+            "condition": "members must not include project-level broad identifiers",
+            "attribute_path": ["members"],  # plural array — confirmed for _iam_binding
+            "values": ["projectOwner:", "projectEditor:", "projectViewer:"],
+            "policy_type": "blacklist"
+        }
+    ]
+]
+
+result  := helpers.get_multi_summary(conditions, vars.variables)
+message := result.message
+details := result.details

--- a/templates/IAM_template/<resource>_iam_member/no_primitive_or_public/policy.rego
+++ b/templates/IAM_template/<resource>_iam_member/no_primitive_or_public/policy.rego
@@ -1,0 +1,74 @@
+# TEMPLATE: IAM Member multiple linked conditions
+# -----------------------------------------------------------------------
+# BEFORE USING THIS TEMPLATE:
+# 1. Confirm "role" field name in resource JSON
+# 2. Confirm "member" (singular string) in resource JSON — _iam_member
+# 3. Confirm valid roles for this resource — may be service specific
+#    e.g. "roles/apigateway.viewer" not "roles/viewer"
+# 4. Update the 3 fields in vars.rego
+# 5. Change the package line and folder name
+# -----------------------------------------------------------------------
+
+# Make sure to change the folder name to the correct resource name
+package terraform.gcp.security.<service>.<resource_type>.no_primitive_or_public_member
+import data.terraform.helpers
+import data.terraform.gcp.security.<service>.<resource_type>.vars
+
+# NOTE FOR AUTHORS:
+# _iam_member is non-authoritative — adds a single member to a role.
+# member field is a SINGLE STRING not an array.
+# Example: member = "user:jane@example.com"
+
+conditions := [
+    [
+        {
+            "situation_description": "IAM member uses a primitive role (owner/editor/viewer)",
+            "remedies": [
+                "Replace roles/owner with a scoped predefined role",
+                "Replace roles/editor with the minimum required predefined role",
+                "Replace roles/viewer with a read-only predefined role — check valid roles for this resource e.g. roles/apigateway.viewer"
+            ]
+        },
+        {
+            "condition": "role must not be a primitive GCP role",
+            "attribute_path": ["role"],  # confirm field name in resource JSON
+            "values": ["roles/owner", "roles/editor", "roles/viewer"], # may be service specific, must match terraform plan e.g. "roles/apigateway.viewer" not "roles/viewer"
+            "policy_type": "blacklist"
+        }
+    ],
+    [
+        {
+            "situation_description": "IAM member grants public access via allUsers or allAuthenticatedUsers",
+            "remedies": [
+                "Remove allUsers — exposes the resource to the entire internet",
+                "Remove allAuthenticatedUsers — grants access to any Google account worldwide"
+            ]
+        },
+        {
+            "condition": "member must not be a public identifier",
+            "attribute_path": ["member"],  # singular string — _iam_member uses "member" 
+            "values": ["allUsers", "allAuthenticatedUsers"],
+            "policy_type": "blacklist"
+        }
+    ],
+    [
+        {
+            "situation_description": "IAM member grants access to all project owners, editors or viewers",
+            "remedies": [
+                "Replace projectOwner:projectid with a specific user or service account",
+                "Replace projectEditor:projectid with a specific user or service account",
+                "Replace projectViewer:projectid with a specific user or service account"
+            ]
+        },
+        {
+            "condition": "member must not be a project-level broad identifier",
+            "attribute_path": ["member"],  # singular string — confirm in resource JSON
+            "values": ["projectOwner:", "projectEditor:", "projectViewer:"],
+            "policy_type": "blacklist"
+        }
+    ]
+]
+
+result  := helpers.get_multi_summary(conditions, vars.variables)
+message := result.message
+details := result.details

--- a/templates/IAM_template/<resource>_iam_policy/no_primitive_or_public/policy.rego
+++ b/templates/IAM_template/<resource>_iam_policy/no_primitive_or_public/policy.rego
@@ -1,0 +1,88 @@
+# TEMPLATE: IAM Policy multiple linked conditions
+# -----------------------------------------------------------------------
+# BEFORE USING THIS TEMPLATE:
+# 1. Confirm "policy_data" field name in resource JSON
+# 2. Confirm valid roles for this resource — may be service specific
+#    e.g. "roles/apigateway.viewer" not "roles/viewer"
+# 3. Update the 3 fields in vars.rego
+# 4. Change the package line and folder name
+# -----------------------------------------------------------------------
+
+# Make sure to change the folder name to the correct resource name
+package terraform.gcp.security.<service>.<resource_type>.no_primitive_or_public
+import data.terraform.helpers
+import data.terraform.gcp.security.<service>.<resource_type>.vars
+
+# NOTE FOR AUTHORS:
+# _iam_policy wraps all bindings inside a single policy_data JSON string.
+# Structure inside policy_data:
+#   { "bindings": [{ "role": "roles/apigateway.viewer",
+#                    "members": ["user:jane@example.com"] }] }
+# All three conditions check policy_data as the attribute path.
+# values are full JSON string patterns — they must match exactly how
+# the binding appears inside policy_data
+
+conditions := [
+    [
+        {
+            "situation_description": "IAM policy contains a primitive role (owner/editor/viewer)",
+            "remedies": [
+                "Replace roles/owner with a scoped predefined role",
+                "Replace roles/editor with the minimum required predefined role",
+                "Replace roles/viewer with a read-only predefined role "
+            ]
+        },
+        {
+            "condition": "policy_data must not contain a primitive GCP role",
+            "attribute_path": ["policy_data"],
+            "values": [
+                "{\"bindings\":[{\"members\":[\"<member>\"],\"role\":\"roles/owner\"}]}", # check valid roles for this resource e.g. roles/apigateway.viewer
+                "{\"bindings\":[{\"members\":[\"<member>\"],\"role\":\"roles/editor\"}]}",
+                "{\"bindings\":[{\"members\":[\"<member>\"],\"role\":\"roles/viewer\"}]}"
+            ],
+            "policy_type": "blacklist"
+        }
+    ],
+    [
+        {
+            "situation_description": "IAM policy grants public access via allUsers or allAuthenticatedUsers",
+            "remedies": [
+                "Remove allUsers — exposes the resource to the entire internet",
+                "Remove allAuthenticatedUsers — grants access to any Google account worldwide"
+            ]
+        },
+        {
+            "condition": "policy_data must not contain public identifiers",
+            "attribute_path": ["policy_data"],
+            "values": [
+                "{\"bindings\":[{\"members\":[\"allUsers\"],\"role\":\"roles/<replace_with_valid_role>\"}]}", #role must match terraform plan
+                "{\"bindings\":[{\"members\":[\"allAuthenticatedUsers\"],\"role\":\"roles/<replace_with_valid_role>\"}]}"
+            ],
+            "policy_type": "blacklist"
+        }
+    ],
+    [
+        {
+            "situation_description": "IAM policy grants access to all project owners, editors or viewers",
+            "remedies": [
+                "Replace projectOwner:projectid with a specific user or service account",
+                "Replace projectEditor:projectid with a specific user or service account",
+                "Replace projectViewer:projectid with a specific user or service account"
+            ]
+        },
+        {
+            "condition": "policy_data must not contain project-level broad identifiers",
+            "attribute_path": ["policy_data"],
+            "values": [
+                "{\"bindings\":[{\"members\":[\"projectOwner:<project_id>\"],\"role\":\"roles/<replace_with_valid_role>\"}]}", # both the project ID and the role must match what's in the terraform plan
+                "{\"bindings\":[{\"members\":[\"projectEditor:<project_id>\"],\"role\":\"roles/<replace_with_valid_role>\"}]}",
+                "{\"bindings\":[{\"members\":[\"projectViewer:<project_id>\"],\"role\":\"roles/<replace_with_valid_role>\"}]}"
+            ],
+            "policy_type": "blacklist"
+        }
+    ]
+]
+
+result  := helpers.get_multi_summary(conditions, vars.variables)
+message := result.message
+details := result.details

--- a/templates/location_template/by_location/policy.rego
+++ b/templates/location_template/by_location/policy.rego
@@ -1,0 +1,25 @@
+package terraform.gcp.security.<service>.<resource_type>.<policy_name> # Edit here 
+import data.terraform.helpers
+import data.terraform.gcp.security.<service>.<resource_type>.vars # to be edited
+
+conditions := [
+    [
+        {
+            "situation_description": "Resource location is outside approved Australian regions",
+            "remedies": [
+                "Set location to australia-southeast1 (Sydney)",
+                "Set location to australia-southeast2 (Melbourne)"
+            ]
+        },
+        {
+            "condition": "location must be an approved Australian region",
+            "attribute_path": ["location"], # make sure this matches the plan.json path for your resource e.g eg. ["location",0] or [location]
+            "values": [ "australia-southeast1",  "australia-southeast2"],
+            "policy_type": "whitelist"
+        }
+    ]
+]
+
+result  := helpers.get_multi_summary(conditions, vars.variables)
+message := result.message
+details := result.details

--- a/templates/location_template/by_region/policy.rego
+++ b/templates/location_template/by_region/policy.rego
@@ -1,0 +1,25 @@
+package terraform.gcp.security.<service>.<resource_type>.<policy_name> # Edit here 
+import data.terraform.helpers
+import data.terraform.gcp.security.<service>.<resource_type>.vars
+
+conditions := [
+    [
+        {
+            "situation_description": "Resource region is outside approved Australian regions",
+            "remedies": [
+                "Set region to australia-southeast1 (Sydney)",
+                "Set region to australia-southeast2 (Melbourne)"
+            ]
+        },
+        {
+            "condition": "region must be an approved Australian region",
+            "attribute_path": ["region"],
+            "values": [ "australia-southeast1",  "australia-southeast2"],
+            "policy_type": "whitelist"
+        }
+    ]
+]
+
+result  := helpers.get_multi_summary(conditions, vars.variables)
+message := result.message
+details := result.details

--- a/templates/location_template/by_zone/policy.rego
+++ b/templates/location_template/by_zone/policy.rego
@@ -1,0 +1,27 @@
+package terraform.gcp.security.<service>.<resource_type>.<policy_name> # Edit here 
+import data.terraform.helpers
+import data.terraform.gcp.security.<service>.<resource_type>.vars
+
+conditions := [
+    [
+        {
+            "situation_description": "Resource zone is outside approved Australian zones",
+            "remedies": [
+                "Set zone to australia-southeast1-a, australia-southeast1-b, or australia-southeast1-c (Sydney)",
+                "Set zone to australia-southeast2-a, australia-southeast2-b, or australia-southeast2-c (Melbourne)"
+            ]
+        },
+        {
+            "condition": "zone must be an approved Australian zone",
+            "attribute_path": ["zone"],
+            "values": [ "australia-southeast1-a","australia-southeast1-b",
+            "australia-southeast1-c","australia-southeast2-a",
+            "australia-southeast2-b","australia-southeast2-c"],
+            "policy_type": "whitelist"
+        }
+    ]
+]
+
+result  := helpers.get_multi_summary(conditions, vars.variables)
+message := result.message
+details := result.details


### PR DESCRIPTION
- Add _iam_binding template covering primitive roles, public members and project-level broad identifiers
- Add _iam_member template with singular member field handling
- Add _iam_policy template with full JSON string pattern values
- Add location templates by_location, by_region, by_zone
- All templates follow existing get_multi_summary pattern