### PR TITLE
Add Cloud Spanner enable_drop_protection policy and documentation

### DIFF
--- a/docs/gcp/Cloud_Spanner/resource_json/spanner_database.json
+++ b/docs/gcp/Cloud_Spanner/resource_json/spanner_database.json
@@ -77,13 +77,14 @@
       "parent": null
     },
     "enable_drop_protection": {
-      "description": "Whether drop protection is enabled for this database. Defaults to false. Drop protection is different from the \"deletion_protection\" attribute in the following ways: (1) \"deletion_protection\" only protects the database from deletions in Terraform. whereas setting \u201cenableDropProtection\u201d to true protects the database from deletions in all interfaces. (2) Setting \"enableDropProtection\" to true also prevents the deletion of the parent instance containing the database. \"deletion_protection\" attribute does not provide protection against the deletion of the parent instance.",
-      "required": false,
-      "security_impact": null,
-      "rationale": null,
-      "compliant": null,
-      "non-compliant": null,
-      "parent": null
+  "description": "Whether drop protection is enabled for the database.",
+  "required": false,
+  "security_impact": true,
+  "rationale": "Prevents accidental dropping of Cloud Spanner databases.",
+  "compliant": true,
+  "non-compliant": false,
+  "parent": null
+}
     },
     "project": {
       "description": "If it is not provided, the provider project is used.",
@@ -94,14 +95,15 @@
       "non-compliant": null,
       "parent": null
     },
-    "deletion_protection": {
-      "description": "When a`terraform destroy` or `terraform apply` would delete the database, the command will fail if this field is not set to false in Terraform state. When the field is set to true or unset in Terraform state, a `terraform apply` or `terraform destroy` that would delete the database will fail. When the field is set to false, deleting the database is allowed.",
-      "required": null,
-      "security_impact": null,
-      "rationale": null,
-      "compliant": null,
-      "non-compliant": null,
-      "parent": null
+  "deletion_protection": {
+  "description": "Whether Terraform prevents deletion of the database.",
+  "required": false,
+  "security_impact": true,
+  "rationale": "Prevents accidental deletion of Cloud Spanner databases through Terraform.",
+  "compliant": true,
+  "non-compliant": false,
+  "parent": null
+}
     },
     "default_time_zone": {
       "description": "from the tz database. Default value is \"America/Los_angeles\".",

--- a/inputs/gcp/cloud_spanner/google_spanner_database/enable_drop_protection/c.tf
+++ b/inputs/gcp/cloud_spanner/google_spanner_database/enable_drop_protection/c.tf
@@ -1,0 +1,5 @@
+resource "google_spanner_database" "good" {
+  instance               = "my-instance"
+  name                   = "my-database"
+  enable_drop_protection = true
+}

--- a/inputs/gcp/cloud_spanner/google_spanner_database/enable_drop_protection/nc.tf
+++ b/inputs/gcp/cloud_spanner/google_spanner_database/enable_drop_protection/nc.tf
@@ -1,0 +1,5 @@
+resource "google_spanner_database" "bad" {
+  instance               = "my-instance"
+  name                   = "my-database"
+  enable_drop_protection = false
+}

--- a/policies/gcp/cloud_spanner/google_spanner_database/enable_drop_protection/policy.rego
+++ b/policies/gcp/cloud_spanner/google_spanner_database/enable_drop_protection/policy.rego
@@ -1,0 +1,8 @@
+package terraform.gcp.security.cloud_spanner.google_spanner_database.enable_drop_protection
+
+deny contains msg if {
+  some r
+  input.resource_changes[r].type == "google_spanner_database"
+  not input.resource_changes[r].change.after.enable_drop_protection
+  msg := "Cloud Spanner database must have enable_drop_protection set to true"
+}


### PR DESCRIPTION
I have raised a new PR from the official repository clone for the Cloud Spanner enable_drop_protection policy. I also updated the Cloud Spanner resource JSON documentation with the security impact and rationale.

I have now corrected the fork workflow issue and started expanding beyond the first deletion_protection policy.