### PR TITLE
linters: drop chore/ branch prefix (allow only feature/ and Service/)

### DIFF
--- a/Guide/Policy_writing_tutorial/prerequisite.md
+++ b/Guide/Policy_writing_tutorial/prerequisite.md
@@ -52,8 +52,7 @@ Branch names must follow the repo convention (enforced by the branch-name check
 and the per-resource CI gate). Use one of:
 
 - `Service/<platform>/<service_slug>/<resource_type>` — when working on a specific resource
-- `feature/<name>` — for a general feature
-- `chore/<name>` — for maintenance/cleanup
+- `feature/<name>` — for a general feature or any non-resource maintenance/cleanup work
 
 The `<service_slug>` is the underscore slug of a `docs/<platform>` service folder
 (folder names contain spaces/parens, which are illegal in git branch names) — e.g.

--- a/README.md
+++ b/README.md
@@ -47,8 +47,7 @@ All branches must follow one of these patterns:
     names contain spaces/parens (illegal in git branches), so the slug is used — e.g.
     `Cloud Run (v2 API)` → `cloud_run_v2_api`. It maps back to exactly one folder.
   - `<resource_type>`: a documented resource (a `docs/<platform>/<folder>/<resource>.json`)
-- `feature/<feature_name>` - For general features (e.g., `feature/add-logging`)
-- `chore/<chore_name>` - For maintenance/cleanup work (e.g., `chore/tidy-fixtures`)
+- `feature/<feature_name>` - For general features and any non-resource maintenance/cleanup work (e.g., `feature/add-logging`)
 
 This `Service/...` branch is what scopes the per-resource CI gate to the resource you're
 working on (doc completeness, policy/input coverage, and the OPA test).
@@ -58,11 +57,8 @@ working on (doc completeness, policy/input coverage, and the OPA test).
 # Working on a specific resource
 git checkout -b Service/gcp/cloud_run_v2_api/google_cloud_run_v2_service
 
-# Adding a new feature
+# Adding a feature, or any non-resource maintenance/cleanup work
 git checkout -b feature/add-validator
-
-# Maintenance / cleanup
-git checkout -b chore/tidy-fixtures
 ```
 
 ### 3. **Install Pre-Commit Hooks**
@@ -101,7 +97,6 @@ When you commit, the pre-commit hooks will run automatically:
 
 Allowed branch names:
   - feature/<name>
-  - chore/<name>
   - Service/<platform>/<service_slug>/<resource_type>
       e.g. Service/gcp/cloud_run_v2_api/google_cloud_run_v2_service
   - (protected: dev)

--- a/scripts/linters/check_branch_name.py
+++ b/scripts/linters/check_branch_name.py
@@ -3,7 +3,6 @@
 Validate branch naming convention. Allowed branches:
 
 - feature/<name>
-- chore/<name>
 - Service/<platform>/<service_slug>/<resource_type>
     * <platform>: gcp | aws | azure (only gcp is populated today)
     * <service_slug>: the underscore slug of a docs/<platform> service folder
@@ -16,11 +15,10 @@ Validate branch naming convention. Allowed branches:
 
 Examples:
 - feature/add-validator
-- chore/docgen-consolidation
 - Service/gcp/cloud_run_v2_api/google_cloud_run_v2_service
 - dev (protected)
 
-Invalid: gcp/service/x, fix/x, docs/x, my-branch, main
+Invalid: chore/x, gcp/service/x, fix/x, docs/x, my-branch, main
 """
 import argparse
 import os
@@ -33,9 +31,9 @@ from _service_slug import slug_to_folder, resource_doc_path  # noqa: E402
 
 ALLOWED_PLATFORMS = {"gcp", "aws", "azure"}
 PROTECTED_BRANCHES = {"dev"}
-# feature/<name> | chore/<name>: <name> is free-form (letters incl. uppercase,
-# digits, '.', '_', '-', and '/' for sub-scopes), min 2 chars.
-SIMPLE_BRANCH = re.compile(r"^(feature|chore)/[A-Za-z0-9._/-]{2,}$")
+# feature/<name>: <name> is free-form (letters incl. uppercase, digits, '.',
+# '_', '-', and '/' for sub-scopes), min 2 chars.
+SIMPLE_BRANCH = re.compile(r"^feature/[A-Za-z0-9._/-]{2,}$")
 RESOURCE_TYPE = re.compile(r"^[a-z0-9_]+$")
 
 
@@ -57,7 +55,6 @@ def _allowed_formats():
     return (
         "Allowed branch names:\n"
         "  - feature/<name>\n"
-        "  - chore/<name>\n"
         "  - Service/<platform>/<service_slug>/<resource_type>\n"
         "      platform in gcp|aws|azure; service_slug is the underscore slug of a\n"
         "      docs/<platform> service folder; resource_type is a documented resource.\n"


### PR DESCRIPTION
## Summary

Removes `chore/` as an allowed branch prefix. The convention is now just two forms:

- `feature/<name>` — general features **and** any non-resource maintenance/cleanup work
- `Service/<platform>/<service_slug>/<resource_type>` — resource work (scopes the per-resource CI gate)

(`dev` remains the protected base branch.)

## Changes

- **`scripts/linters/check_branch_name.py`** — regex `^(feature|chore)/…` → `^feature/…`; removed `chore/` from the docstring, `_allowed_formats()` help text, and examples; added `chore/x` to the "Invalid" example list.
- **`README.md`** — branch-convention section, example commands, and the sample error message no longer mention `chore/`; `feature/` now documented as covering maintenance/cleanup.
- **`Guide/Policy_writing_tutorial/prerequisite.md`** — same, in the contributor guide.

## Verification

- `chore/x`, `chore/docgen` → now **REJECT**.
- `feature/<name>` and `Service/gcp/<slug>/<resource>` → **ALLOW**.
- No tests referenced branch validation; nothing else in the repo presents `chore/` as a valid name (the one remaining mention is a historical TODO comment in `check_resource_pr.py` about a past migration branch, not a naming rule).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
