### PR TITLE
feat(auto_test): emit machine-readable policy report + publish as CI artifact

### DIFF
--- a/.github/workflows/policy_check_ALL.yaml
+++ b/.github/workflows/policy_check_ALL.yaml
@@ -2,8 +2,14 @@ name: Terraform OPA Policy Check ALL
 
 on:
   workflow_dispatch:
+  # Publish a fresh policy-results artifact on every push to dev so the
+  # AutoCapstone backend can consume the latest verdicts.
+  push:
+    branches:
+      - dev
 
-# Read-only: this is a full-tree verification run; it writes nothing back.
+# Read-only: this is a full-tree verification run; it writes nothing back to the
+# repo. The policy_results.json report is published as a build artifact, not committed.
 permissions:
   contents: read
 
@@ -49,9 +55,29 @@ jobs:
       # discarded. Pruning is a local-maintainer operation:
       #   python3 scripts/auto_test/auto_test.py --inputs inputs/gcp \
       #       --policies policies/gcp --prune-plan-cache   # then commit the result
+      # Only gcp carries fixtures/policies today (inputs/aws and inputs/azure are
+      # empty), so a single gcp run already spans every provider the ALL run scans
+      # and can write policy_results.json directly. When aws/azure gain fixtures,
+      # run auto_test once per provider into provider-specific report files and
+      # merge them here with `jq -s 'add' gcp.json aws.json azure.json > policy_results.json`.
+      # --report is written before the step's non-zero exit, so the artifact upload
+      # below (if: always()) still publishes results when policies fail.
       - name: Run policy checks (Terraform + OPA)
         run: |
           python3 scripts/auto_test/auto_test.py \
             --inputs inputs/gcp \
             --policies policies/gcp \
+            --report policy_results.json \
             --verbose
+
+      # Publish the machine-readable verdicts for the AutoCapstone backend. Runs
+      # even when the policy checks failed (the report is written first), under a
+      # stable name so consumers can always fetch the latest.
+      - name: Upload policy results artifact
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: policy-results
+          path: policy_results.json
+          retention-days: 90
+          if-no-files-found: error

--- a/.gitignore
+++ b/.gitignore
@@ -157,3 +157,7 @@ docs/gcp/_changes/
 
 # folder_generator local user state (per-user UI selection, never committed)
 scripts/folder_generator/cache/
+
+# auto_test --report output: a CI build artifact for the AutoCapstone backend,
+# published via actions/upload-artifact — never committed to the repo.
+policy_results.json

--- a/scripts/auto_test/_tests/test_report.py
+++ b/scripts/auto_test/_tests/test_report.py
@@ -1,0 +1,40 @@
+"""Unit tests for the --report machine-readable output of auto_test."""
+
+import json
+import sys
+from pathlib import Path
+
+project_root = Path(__file__).parent.parent.parent.parent
+sys.path.insert(0, str(project_root))
+
+from scripts.auto_test import auto_test
+
+
+def test_write_report_emits_valid_json_array_with_failures(tmp_path):
+    # A mixed results list, exactly as main() accumulates it from
+    # make_success/make_failure — including a nested dotted leaf-key policy name.
+    results = [
+        auto_test.make_success("storage_class", "Cloud Storage", "google_storage_bucket"),
+        auto_test.make_failure("autoclass.enabled", "Non-compliant resources were not flagged",
+                               "Cloud Storage", "google_storage_bucket"),
+    ]
+    report = tmp_path / "policy_results.json"
+    auto_test.write_report(results, str(report))
+
+    data = json.loads(report.read_text())
+    assert isinstance(data, list)
+    assert len(data) == 2
+
+    # Every entry has the four canonical keys with the right types.
+    for entry in data:
+        assert {"service", "resource", "policy", "passed"} <= set(entry)
+        assert isinstance(entry["passed"], bool)
+
+    # The report must retain at least one failing entry, with names left verbatim.
+    failing = [e for e in data if e["passed"] is False]
+    assert failing, "report must include the passed: false entries"
+    assert failing[0]["service"] == "Cloud Storage"          # display name, unchanged
+    assert failing[0]["resource"] == "google_storage_bucket"  # full google_* type
+    assert failing[0]["policy"] == "autoclass.enabled"        # dotted leaf-key, unchanged
+    # Extra keys already on failure entries are preserved.
+    assert failing[0]["failure"]["reason"] == "Non-compliant resources were not flagged"

--- a/scripts/auto_test/auto_test.py
+++ b/scripts/auto_test/auto_test.py
@@ -638,6 +638,20 @@ def find_matching_pairs(inputs_root: Path, policies_search_root: Path):
     return pairs, unmatched_inputs, orphan_policies
 
 
+def write_report(results: list, path: str) -> None:
+    """Write the full results list to PATH as a JSON array.
+
+    Each entry keeps the shape produced by make_success/make_failure —
+    {"service", "resource", "policy", "passed"} — with failure entries retaining
+    their extra keys (e.g. "failure"). Called before any failure exit so a run
+    with failing policies still emits the complete report (including the
+    passed: false entries) for CI to publish as an artifact.
+    """
+    with open(path, "w", encoding="utf-8") as fh:
+        json.dump(results, fh, indent=2)
+        fh.write("\n")
+
+
 def main():
     parser = argparse.ArgumentParser(
         description="Run Terraform + OPA policy checks for matched input/policy pairs.",
@@ -664,6 +678,11 @@ def main():
     parser.add_argument("--prune-plan-cache", action="store_true",
                         help="After a whole-platform/-repo run, delete cached plans no fixture "
                              "references (orphans from changed/removed fixtures). Ignored for scoped runs.")
+    parser.add_argument("--report", default=None, metavar="PATH",
+                        help="Write the full results list to PATH as a JSON array of "
+                             "{service, resource, policy, passed} objects (failure entries keep "
+                             "their extra keys). Written even when policies fail, before the "
+                             "non-zero exit, so CI can publish it as an artifact.")
     args = parser.parse_args()
     start_time = time.monotonic()
 
@@ -753,6 +772,13 @@ def main():
                   "(cannot safely identify orphans).")
         else:
             prune_plan_cache(inputs_root, set(pair_cache.values()))
+
+    # Emit the machine-readable report BEFORE the failure exit below, so a run with
+    # failing policies still writes the full report (including passed: false entries).
+    # The exit code is unchanged — CI still fails the check on policy failures.
+    if args.report:
+        write_report(results, args.report)
+        print(f"[*] wrote policy report ({len(results)} entries) to {args.report}")
 
     # Quiet output: successes are silent — print only failures, then a one-line
     # summary of coverage (services / resource types / policies) and total time.


### PR DESCRIPTION
## Summary
Emit machine-readable policy verdicts and publish them as a downloadable GitHub Actions artifact from `dev`, for the AutoCapstone backend to consume. Nothing is committed back to the repo.

## Part 1 — `scripts/auto_test/auto_test.py`
- New `--report PATH` flag (default `None`). When set, writes the full results list to `PATH` as a JSON array via `json.dump`.
- The report is written **before** the failure `sys.exit(1)`, so a run with failing policies still emits the complete report — including the `passed: false` entries. Exit-code behaviour is unchanged (CI still fails the check on policy failures).
- Each entry keeps the existing shape `{"service", "resource", "policy", "passed"}` verbatim — `service` stays the display name (e.g. `Cloud Storage`), `resource` the full `google_*` type, `policy` the attribute leaf-key (e.g. `autoclass.enabled`); extra keys on failure entries (`failure`) are preserved.
- Added a focused unit test (`scripts/auto_test/_tests/test_report.py`) asserting the report is valid JSON with the expected object shape, including a failing entry.

## Part 2 — `.github/workflows/policy_check_ALL.yaml`
- Runs on push to `dev` (keeps `workflow_dispatch`).
- Writes `policy_results.json` (`--report`). Only `gcp` carries fixtures/policies today (`inputs/aws`, `inputs/azure` are empty), so a single gcp run spans every provider the ALL run scans; a comment documents the per-provider `jq -s 'add'` merge for when aws/azure gain fixtures.
- Uploads `policy_results.json` via `actions/upload-artifact@v4` under the stable name `policy-results`, `retention-days: 90`, with `if: always()` so the artifact publishes even when policy checks fail.
- `policy_results.json` is gitignored — build artifact only, never committed.

## Verification
- `pytest` — all 76 tests pass (incl. the new report test).
- Local run on a passing scope: report written, exit 0, correct `{service, resource, policy, passed}` shape.
- Local run forced to fail: report written **with the `passed: false` entry**, real exit code **1**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)