### PR TITLE
fix(ci): don't fail ALL run when provider registry is unreachable

### DIFF
--- a/.github/workflows/policy_check_ALL.yaml
+++ b/.github/workflows/policy_check_ALL.yaml
@@ -47,8 +47,16 @@ jobs:
           chmod +x opa
           sudo mv opa /usr/local/bin/opa
 
-      - name: Set up plugin cache config
-        run: bash scripts/auto_test/cache_setup.sh
+      # Best-effort provider mirror. The ALL run is designed to execute OFFLINE from
+      # the committed plan cache (inputs/plan_cache): when every plan is cached,
+      # auto_test skips terraform entirely and this mirror is never touched. So a
+      # registry hiccup here must NOT fail the job — auto_test still lazily builds the
+      # cache itself (ensure_cache_ready) if a fixture ever misses. Don't add `set -e`
+      # semantics: the `|| echo` keeps the step green when the registry is unreachable.
+      - name: Set up provider cache (best-effort; plan cache is the offline source)
+        run: |
+          bash scripts/auto_test/cache_setup.sh \
+            || echo "⚠️  provider mirror unavailable — relying on the committed plan cache"
 
       # NOTE: plan-cache pruning is intentionally NOT done here. The runner is
       # ephemeral and this workflow has no commit/push step, so any prune would be
@@ -80,4 +88,8 @@ jobs:
           name: policy-results
           path: policy_results.json
           retention-days: 90
-          if-no-files-found: error
+          # `warn`, not `error`: this is a safety-net upload (if: always()). The report
+          # is written on every path that runs auto_test to completion (pass or policy
+          # failure), so a missing file means an upstream step already failed the job —
+          # don't let this step manufacture a second, misleading failure.
+          if-no-files-found: warn


### PR DESCRIPTION
## Problem
The first push-to-dev run of **Terraform OPA Policy Check ALL** failed ([run 28589472333](https://github.com/Hardhat-Enterprises/Policy-Deployment-Engine/actions/runs/28589472333)). Root cause: the `Set up plugin cache config` step (`cache_setup.sh`) hit **"registry unreachable; ❌ could not populate mirror for google 7.37.0"** and exited 1, aborting the job. `Run policy checks` was skipped, so no `policy_results.json` was written, and the `if: always()` upload then hard-failed on `if-no-files-found: error`.

## Why it's safe to not fail there
The ALL run executes **offline from the committed plan cache** — all **1021** gcp fixture plans are cached, so `auto_test.py` reports `all 1021 plan(s) cached — skipping terraform entirely` and never touches the provider mirror. `auto_test` also lazily builds the cache itself (`ensure_cache_ready`) if a fixture ever misses, so the explicit mirror step is best-effort, not load-bearing.

## Fix
- **Provider-cache step** → best-effort: `bash cache_setup.sh || echo "…relying on the committed plan cache"`. A registry hiccup can no longer fail the job.
- **Upload step** → `if-no-files-found: warn` (was `error`). The report is written on every path that runs `auto_test` to completion (pass *or* policy failure); a missing file now means an upstream step already failed, so this safety-net upload won't manufacture a second, misleading failure.

## Verification
Full local ALL-equivalent run (cached plans + OPA v1.17.1):
```
✅ all passed — 94 services, 370 resource types, 1021 policies  in 12s
[*] wrote policy report (1021 entries) to /tmp/full.json
```
Report is a 1021-entry JSON array, every entry `{service, resource, policy, passed}`. The merge to dev will re-trigger the workflow and exercise this end-to-end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)