### PR TITLE
ci: bump GitHub Actions off deprecated Node 20 runtime

### DIFF
--- a/.github/workflows/policy_check_ALL.yaml
+++ b/.github/workflows/policy_check_ALL.yaml
@@ -23,10 +23,10 @@ jobs:
   policy_check:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
       - name: Setup Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: '3.x'
 
@@ -34,7 +34,7 @@ jobs:
         run: python3 scripts/linters/linter.py --tree all --platform gcp
 
       - name: Setup Terraform
-        uses: hashicorp/setup-terraform@v3
+        uses: hashicorp/setup-terraform@v4
         with:
           terraform_version: ${{ env.TERRAFORM_VERSION }}
           terraform_wrapper: false   # auto_test redirects `terraform show -json` to a file
@@ -83,7 +83,7 @@ jobs:
       # stable name so consumers can always fetch the latest.
       - name: Upload policy results artifact
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: policy-results
           path: policy_results.json

--- a/.github/workflows/policy_check_PR.yaml
+++ b/.github/workflows/policy_check_PR.yaml
@@ -32,12 +32,12 @@ jobs:
     permissions:
       contents: read
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
         with:
           fetch-depth: 0          # need history for merge-base with the base branch
 
       - name: Setup Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: '3.x'
 
@@ -77,15 +77,15 @@ jobs:
       contents: read
       pull-requests: write    # gh pr edit --add-label / --remove-label
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
       - name: Setup Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: '3.x'
 
       - name: Setup Terraform
-        uses: hashicorp/setup-terraform@v3
+        uses: hashicorp/setup-terraform@v4
         with:
           terraform_version: ${{ env.TERRAFORM_VERSION }}
           terraform_wrapper: false   # auto_test redirects `terraform show -json` to a file


### PR DESCRIPTION
## Why
GitHub Actions runners now emit: *"Node.js 20 is deprecated… actions/checkout@v4, actions/setup-python@v5, actions/upload-artifact@v4, hashicorp/setup-terraform@v3 are being forced to run on Node.js 24."* This clears that on both policy-check workflows.

## Change
Bump to the current majors (all run on Node 24 natively):

| Action | Before | After |
|---|---|---|
| actions/checkout | v4 | **v7** |
| actions/setup-python | v5 | **v6** |
| actions/upload-artifact | v4 | **v7** |
| hashicorp/setup-terraform | v3 | **v4** |

Applied to `policy_check_ALL.yaml` and `policy_check_PR.yaml`. Usage is unchanged (vanilla `checkout` with `ref`/`fetch-depth`, single-file `upload-artifact`), so no other edits are needed. CI on this PR exercises the PR workflow with the new versions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)