### PR TITLE
feat(ci): add dispatchable policy-scan workflow for per-branch results

### DIFF
--- a/.github/workflows/policy-scan.yml
+++ b/.github/workflows/policy-scan.yml
@@ -1,0 +1,105 @@
+name: Policy Scan (dispatch)
+
+# On-demand, policy-only scan of arbitrary branches, requested by an external
+# system via the GitHub API:
+#
+#   POST /repos/{owner}/{repo}/dispatches
+#   { "event_type": "policy-scan",
+#     "client_payload": { "branches": ["Service/gcp/cloud_storage/google_storage_bucket", ...] } }
+#
+# Each branch is scanned in its own matrix job and its verdicts are published as a
+# per-branch artifact (policy-results-<branch-slug>) for the consumer to collect.
+# This is additive — it does not touch the dev-push ALL workflow.
+on:
+  repository_dispatch:
+    types: [policy-scan]
+
+# Read-only: we only check out branches and publish build artifacts; nothing is
+# written back to the repo. No secrets are used.
+permissions:
+  contents: read
+
+env:
+  # Pin the engines so CI matches local runs (the provider is pinned via
+  # scripts/auto_test/provider_version.txt). Bump alongside the local tools.
+  TERRAFORM_VERSION: "1.15.7"
+  OPA_VERSION: "v1.17.1"
+
+jobs:
+  scan:
+    runs-on: ubuntu-latest
+    strategy:
+      # Resilient matrix: one branch failing (policy failures, a bad ref, …) must
+      # not cancel the scans of the other branches.
+      fail-fast: false
+      matrix:
+        # The branch list arrives as a JSON array in the dispatch payload;
+        # toJson -> fromJson normalizes it into a proper matrix list.
+        branch: ${{ fromJson(toJson(github.event.client_payload.branches)) }}
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          ref: ${{ matrix.branch }}
+
+      # Slug is computed up front (right after checkout) so it is available to the
+      # if: always() upload even when the policy-check step exits non-zero. Every
+      # `/` becomes `-`, matching the artifact name the consumer looks up exactly
+      # (Service/gcp/cloud_storage/google_storage_bucket
+      #   -> policy-results-Service-gcp-cloud_storage-google_storage_bucket).
+      - name: Compute branch slug
+        id: slug
+        env:
+          BRANCH: ${{ matrix.branch }}
+        run: echo "slug=${BRANCH//\//-}" >> "$GITHUB_OUTPUT"
+
+      - name: Setup Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: '3.x'
+
+      - name: Setup Terraform
+        uses: hashicorp/setup-terraform@v4
+        with:
+          terraform_version: ${{ env.TERRAFORM_VERSION }}
+          terraform_wrapper: false   # auto_test redirects `terraform show -json` to a file
+
+      - name: Install OPA
+        env:
+          OPA_VERSION: ${{ env.OPA_VERSION }}
+        run: |
+          curl -L -o opa "https://openpolicyagent.org/downloads/${OPA_VERSION}/opa_linux_amd64_static"
+          chmod +x opa
+          sudo mv opa /usr/local/bin/opa
+
+      # Best-effort provider mirror — same rationale as the ALL workflow: when every
+      # plan is cached auto_test skips terraform entirely, and it lazily builds the
+      # cache itself (ensure_cache_ready) on a miss. A registry hiccup must not fail
+      # the job, so swallow the error with `|| echo`.
+      - name: Set up provider cache (best-effort; plan cache is the offline source)
+        run: |
+          bash scripts/auto_test/cache_setup.sh \
+            || echo "⚠️  provider mirror unavailable — relying on the committed plan cache"
+
+      # Reuse the EXACT policy-only invocation the dev-push ALL workflow uses, so the
+      # two stay in lockstep. Writes policy_results.json (a list of
+      # {service, resource, policy, passed} objects) before any non-zero exit, so the
+      # if: always() upload below still publishes results when policies fail.
+      - name: Run policy checks (Terraform + OPA)
+        run: |
+          python3 scripts/auto_test/auto_test.py \
+            --inputs inputs/gcp \
+            --policies policies/gcp \
+            --report policy_results.json \
+            --verbose
+
+      # Per-branch artifact. Name = policy-results-<slug> (the consumer's exact
+      # lookup key); the file member stays policy_results.json. Runs even when the
+      # policy checks failed (the report is written first).
+      - name: Upload policy results artifact
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: policy-results-${{ steps.slug.outputs.slug }}
+          path: policy_results.json
+          retention-days: 90
+          if-no-files-found: warn


### PR DESCRIPTION
## What
New `.github/workflows/policy-scan.yml` that lets an external system request policy-only checks on specific branches and collect per-branch results. **Additive** — the dev-push ALL workflow is untouched. No new secrets.

## Trigger
```jsonc
// POST /repos/Hardhat-Enterprises/Policy-Deployment-Engine/dispatches
{ "event_type": "policy-scan",
  "client_payload": { "branches": ["Service/gcp/cloud_storage/google_storage_bucket", "..."] } }
```
```yaml
on:
  repository_dispatch:
    types: [policy-scan]
```
Branch list is read from `github.event.client_payload.branches`.

## Per branch (parallel matrix, `fail-fast: false`)
1. `actions/checkout` with `ref: <branch>`.
2. Compute the slug **up front** (`/` → `-`) so it's available to the `if: always()` upload even on a non-zero exit.
3. Run the **exact** policy-only invocation the dev-push ALL workflow uses — `auto_test.py --inputs inputs/gcp --policies policies/gcp --report policy_results.json --verbose` — reused verbatim, not forked. Emits the standard `policy_results.json` (`[{service, resource, policy, passed}, …]`) before any non-zero exit.
4. `actions/upload-artifact` (`if: always()`, `retention-days: 90`) → **`policy-results-<branch-slug>`**, file member stays **`policy_results.json`**.

## Slug rule (verified)
`Service/gcp/cloud_storage/google_storage_bucket` → artifact **`policy-results-Service-gcp-cloud_storage-google_storage_bucket`**, matching the consumer's exact-name lookup.

## Notes
- `repository_dispatch` runs from the **default branch** (`dev`, confirmed), so it activates once merged.
- Consumer auth (GitHub App, Contents: write + Actions: read) is unchanged; this workflow itself needs only `contents: read`.
- Opening this PR doesn't exercise the workflow (dispatch-only). After merge, verify with a `POST /dispatches` and confirm each `policy-results-<slug>` artifact appears — I can trigger a smoke test then.

🤖 Generated with [Claude Code](https://claude.com/claude-code)