### PR TITLE
fix(auto_test): make provider cache setup cross-platform (Windows/mac…

### DIFF
--- a/scripts/auto_test/auto_test.py
+++ b/scripts/auto_test/auto_test.py
@@ -110,7 +110,24 @@ def ensure_cache_ready() -> None:
     if CLI_CONFIG_FILE.exists() and any(MIRROR_DIR.rglob("terraform-provider-*")):
         return
     print("⏳ Provider cache not found — running cache_setup.sh (one-time setup)…")
-    result = subprocess.run(["bash", str(CACHE_SETUP_SCRIPT)], cwd=str(REPO_ROOT))
+    # Pass the script as a RELATIVE forward-slash path: absolute Windows paths
+    # (C:\...) get their backslashes eaten by bash, and MSYS/WSL bash resolve
+    # a relative path correctly from cwd on every platform. On Windows, prefer
+    # Git Bash over the WSL shim so the cache is built for the same platform
+    # as the terraform.exe that will consume it.
+    bash = None
+    if os.name == "nt":
+        for candidate in (r"C:\Program Files\Git\bin\bash.exe",
+                          r"C:\Program Files (x86)\Git\bin\bash.exe"):
+            if Path(candidate).exists():
+                bash = candidate
+                break
+    if bash is None:
+        bash = shutil.which("bash")
+    if bash is None:
+        sys.exit("❌ bash not found. Install Git Bash (Windows) or run inside WSL.")
+    script_rel = CACHE_SETUP_SCRIPT.relative_to(REPO_ROOT).as_posix()
+    result = subprocess.run([bash, script_rel], cwd=str(REPO_ROOT))
     if result.returncode != 0 or not CLI_CONFIG_FILE.exists() \
             or not any(MIRROR_DIR.rglob("terraform-provider-*")):
         sys.exit("❌ Could not set up the Terraform provider cache. "

--- a/scripts/auto_test/cache_setup.sh
+++ b/scripts/auto_test/cache_setup.sh
@@ -26,7 +26,35 @@ CACHE_ROOT="$REPO_ROOT/.terraform-cache"
 MIRROR="$CACHE_ROOT/mirror"
 CLI_TFRC="$CACHE_ROOT/cli.tfrc"
 CANON_LOCK="$CACHE_ROOT/canonical.lock.hcl"
-MIRROR_LEAF="$MIRROR/$PROVIDER/$TARGET_VERSION/linux_amd64"
+
+# Detect the host platform so the mirror matches the terraform binary that
+# will consume it (linux/darwin/windows, amd64/arm64) instead of assuming
+# linux_amd64 (which breaks native Windows and Apple Silicon hosts).
+case "$(uname -s)" in
+  Linux*)               TF_OS=linux ;;
+  Darwin*)              TF_OS=darwin ;;
+  MINGW*|MSYS*|CYGWIN*) TF_OS=windows ;;
+  *) echo "❌ unsupported OS: $(uname -s)"; exit 1 ;;
+esac
+case "$(uname -m)" in
+  x86_64|amd64)  TF_ARCH=amd64 ;;
+  arm64|aarch64) TF_ARCH=arm64 ;;
+  *) echo "❌ unsupported arch: $(uname -m)"; exit 1 ;;
+esac
+PLATFORM="${TF_OS}_${TF_ARCH}"
+MIRROR_LEAF="$MIRROR/$PROVIDER/$TARGET_VERSION/$PLATFORM"
+
+# On Git Bash/MSYS the mirror path is /c/... which the native Windows
+# terraform.exe cannot read from a config file — convert to C:/... form.
+if [ "$TF_OS" = windows ] && command -v cygpath >/dev/null 2>&1; then
+  MIRROR_CFG="$(cygpath -m "$MIRROR")"
+else
+  MIRROR_CFG="$MIRROR"
+fi
+
+# The provider binary keeps its versioned name in plugin caches and mirrors
+# (e.g. terraform-provider-google_v7.37.0_x5[.exe]) — always match by glob.
+have_provider() { compgen -G "$1/terraform-provider-google*" >/dev/null; }
 
 mkdir -p "$MIRROR"
 
@@ -35,7 +63,7 @@ mkdir -p "$MIRROR"
 cat > "$CLI_TFRC" <<EOF
 provider_installation {
   filesystem_mirror {
-    path    = "$MIRROR"
+    path    = "$MIRROR_CFG"
     include = ["$PROVIDER"]
   }
   direct {
@@ -49,10 +77,10 @@ echo "✅ wrote $CLI_TFRC"
 #    from a provider binary already present in a local plugin cache (handy on hosts
 #    where the registry is unreachable, e.g. IPv6-only egress is broken).
 # We build an UNPACKED mirror (the bare provider binary under
-# .../<version>/linux_amd64/) rather than the default packed (.zip) layout, because
+# .../<version>/<platform>/) rather than the default packed (.zip) layout, because
 # Terraform can then SYMLINK the binary into each fixture's .terraform instead of
 # extracting a ~120MB copy per directory — far less disk churn across 1000+ runs.
-if [ -f "$MIRROR_LEAF/terraform-provider-google" ]; then
+if have_provider "$MIRROR_LEAF"; then
   echo "✅ mirror already populated for google $TARGET_VERSION"
 else
   mkdir -p "$MIRROR_LEAF"
@@ -68,19 +96,23 @@ terraform {
 }
 EOF
   # `terraform init` with a plugin cache unpacks the provider; copy that out.
-  unpacked="$tmpcache/$PROVIDER/$TARGET_VERSION/linux_amd64/terraform-provider-google"
+  # TF_PLUGIN_CACHE_MAY_BREAK_DEPENDENCY_LOCK_FILE=1 is required on
+  # Terraform >= 1.4, which otherwise refuses to populate a plugin cache
+  # for providers not already in a lock file (fresh init has none).
+  unpacked_dir="$tmpcache/$PROVIDER/$TARGET_VERSION/$PLATFORM"
   if (cd "$tmp" && TF_PLUGIN_CACHE_DIR="$tmpcache" TF_DATA_DIR="$tmp/.tf" \
+        TF_PLUGIN_CACHE_MAY_BREAK_DEPENDENCY_LOCK_FILE=1 \
         terraform init -no-color >/dev/null 2>&1) \
-     && [ -f "$unpacked" ]; then
-    cp "$unpacked" "$MIRROR_LEAF/"
+     && have_provider "$unpacked_dir"; then
+    cp "$unpacked_dir"/terraform-provider-google* "$MIRROR_LEAF/"
     echo "✅ mirrored (unpacked) google $TARGET_VERSION from the registry"
   else
     echo "⚠️  registry unreachable; trying to seed from a local plugin cache…"
     seeded=""
     for host in registry.terraform.io registry.opentofu.org; do
-      src="$HOME/.terraform.d/plugin-cache/$host/hashicorp/google/$TARGET_VERSION/linux_amd64"
-      if [ -f "$src/terraform-provider-google" ]; then
-        cp "$src/terraform-provider-google" "$MIRROR_LEAF/"
+      src="$HOME/.terraform.d/plugin-cache/$host/hashicorp/google/$TARGET_VERSION/$PLATFORM"
+      if have_provider "$src"; then
+        cp "$src"/terraform-provider-google* "$MIRROR_LEAF/"
         seeded="$src"; break
       fi
     done
@@ -93,7 +125,7 @@ EOF
 fi
 
 # 3) Canonical lock (no constraint) pinning TARGET_VERSION with the mirror's
-#    linux_amd64 h1 hash. Per-fixture `terraform init` regenerates each fixture's
+#    host-platform h1 hash. Per-fixture `terraform init` regenerates each fixture's
 #    .terraform.lock.hcl from the mirror (locks are gitignored, not committed).
 tmp="$(mktemp -d)"
 cat > "$tmp/main.tf" <<'EOF'
@@ -108,7 +140,7 @@ EOF
 lock_log="$tmp/lock.log"
 if ! ( cd "$tmp" \
        && TF_CLI_CONFIG_FILE="$CLI_TFRC" TF_DATA_DIR="$tmp/.tf" \
-          terraform providers lock -fs-mirror="$MIRROR" -platform=linux_amd64 -no-color ) \
+          terraform providers lock -fs-mirror="$MIRROR_CFG" -platform="$PLATFORM" -no-color ) \
        >"$lock_log" 2>&1 \
    || [ ! -f "$tmp/.terraform.lock.hcl" ]; then
   echo "❌ 'terraform providers lock' failed; cannot write $CANON_LOCK:"


### PR DESCRIPTION
## Problem

The local test harness only worked on Linux. On any other host, `python scripts/auto_test/auto_test.py` failed to bootstrap the Terraform provider cache, and running `bash scripts/auto_test/cache_setup.sh` manually failed with "registry unreachable" — even with terraform installed and the registry reachable (HTTP 200).

## Root causes

1. **`auto_test.py` passed an absolute Windows path to bash.** Bash strips the backslashes (`C:UserstauhiDesktop...`), so the bootstrap script was never found from PowerShell.
2. **`cache_setup.sh` hardcoded `linux_amd64`** in the mirror path, the plugin-cache seed path, and `terraform providers lock` — non-Linux hosts could never populate or use the mirror.
3. **The success check looked for the exact filename `terraform-provider-google`**, but plugin caches keep the versioned name (`terraform-provider-google_v7.37.0_x5[.exe]`), so the check always failed.
4. **Terraform ≥ 1.4 refuses to populate a plugin cache for providers not in a lock file** — the throwaway `terraform init` succeeded but left the temp cache empty. This (not the network) was the real source of the misleading "registry unreachable" message.
5. **On Git Bash, the mirror path written into `cli.tfrc` was MSYS-style (`/c/...`)**, which the native Windows `terraform.exe` cannot read.

## Changes

**`scripts/auto_test/cache_setup.sh`**
- Detect the host platform via `uname` (`linux`/`darwin`/`windows` × `amd64`/`arm64`) instead of assuming `linux_amd64`
- Match the provider binary by glob (`have_provider`) instead of an exact filename
- Set `TF_PLUGIN_CACHE_MAY_BREAK_DEPENDENCY_LOCK_FILE=1` on the bootstrap init so TF ≥ 1.4 populates the temp cache
- Convert config paths with `cygpath -m` on Windows so `terraform.exe` can read `cli.tfrc`
- Lock hashes for the detected host platform

**`scripts/auto_test/auto_test.py`**
- Invoke `cache_setup.sh` via a relative forward-slash path (survives Git Bash, WSL, macOS, Linux)
- On Windows, prefer Git Bash over the WSL shim so the cache is built for the same platform as the `terraform.exe` that consumes it
- Exit with a clear message when no bash is available

## Testing

- **Windows 11 (Git Bash):** `cache_setup.sh` builds the mirror and canonical lock successfully
- **Windows 11 (PowerShell):** `auto_test.py "gcp/Artifact Registry/google_artifact_registry_repository"` — passing end to end
- **WSL Ubuntu:** platform detected as `linux_amd64`; script passes `bash -n`
- **macOS:** not tested directly, but uses the same detection path (`darwin_amd64`/`darwin_arm64`); constructs are bash 3.2-compatible

## CI impact

None expected: runners detect `linux_amd64`, identical to the previous hardcoded value, and plan-cache keys (fixture SHA + provider version) are unchanged. CI already treats this step as best-effort (`|| echo`), so behavior is strictly improved.

## Scope

Harness only — no changes to policies, docs, or fixtures.