### PR TITLE
docs: rewrite ASSESSMENT_GUIDANCE.md as a reasoning guide

### DIFF
--- a/docs/ASSESSMENT_GUIDANCE.md
+++ b/docs/ASSESSMENT_GUIDANCE.md
@@ -1,220 +1,109 @@
-# Security Assessment Guidance
+# Assessment Guidance: How to Think About `security_impact`
 
-How to decide an argument's `security_impact` (`true`/`false`) and write its `rationale`
-in the `docs/` resource files — and how to review student PRs that do the same.
-
-> `security_impact: true` means **"this argument is worth a platform-level security
-> policy"** — a generic rule that constrains its value to make the resource more secure.
-> `false` means it is not a useful policy target. The goal is to build a large library of
-> *optional* policies an enterprise client may choose to adopt — so we add a policy
-> wherever enforcing it would make the resource more secure, and skip it otherwise.
+Your task, for every argument of a Terraform resource type, is to decide
+`security_impact` (`true`/`false`) and write a `rationale`. This document teaches you how
+to reason your way to a defensible answer. It deliberately does **not** contain the
+answers — the reasoning is the skill being assessed, and it is yours to do.
 
 ---
 
-## 1. The core mental model: platform-level, multi-tenant
+## 1. The mission
 
-These policies run for an **imaginary enterprise org** with many teams and hundreds of
-projects. **We do not know — and must never assume — specific names, keys, projects,
-emails, or regions belonging to a particular team.** This is the single most common
-mistake.
+We are building a library of **generic, platform-level security policies** for an
+imaginary multi-tenant enterprise: many teams, hundreds of projects, and — crucially —
+**we know nothing about any particular team**. No project names, no key IDs, no email
+addresses, no bucket names.
 
-A policy is only valid if it is **generic and structural** — true for any team, any
-project, without naming anything specific:
+For each argument, the question you are answering is:
 
-- ✅ *"encryption key must not be blank/null"* — structural, applies everywhere.
-- ❌ *"encryption key must equal `projects/acme/keys/foo`"* — assumes a specific key we
-  cannot know. **Overreaching — invalid.**
-- ✅ *"region must be in an approved set (whitelist)"* — **region / data residency is a
-  sanctioned exception**: enforcing it is explicitly wanted. Ideally the allowed set is
-  parameterised, but a **hardcoded** example whitelist (e.g. `australia-southeast1/2`) is
-  acceptable — the policy shape is fully repurposable by swapping the list.
-- ❌ *"bucket name must be `prod-data`"* — naming a specific resource. Invalid.
+> **Would a generic policy constraining this argument make the resource more secure?**
 
-Region is the one place a concrete value (even hardcoded) is fine; keys, projects,
-emails, and resource names are not.
+*Generic* means the policy could be written once and applied to every team without
+knowing anything team-specific. If the only way to enforce something is to hardcode a
+value that belongs to one team, that is not a platform policy — it's overreach.
 
-We are ensuring **this resource is cleanly/securely configured** — we are **not** policing
-the names of *other* resources it references (other buckets, projects, datasets). Pointing
-at another resource is the team's business; constraining that reference is not our job.
+`true` means "this argument is a worthwhile target for such a policy."
+`false` means it is not. Both verdicts require a reason you can defend.
 
 ---
 
-## 2. When is `security_impact = true`?
+## 2. Do the research
 
-Mark `true` when a **generic** policy on the argument would improve security — i.e. it
-matches one of the **policy archetypes** below. These archetypes are platform-agnostic;
-they were distilled from real Azure platform policies and apply equally to GCP:
+The single biggest differentiator between strong and weak assessments is whether the
+author actually found out what the argument does.
 
-| Archetype | Pattern | Example args |
-|---|---|---|
-| **Disable public exposure** | force private/no-public-access | `public_access_prevention`, "disable public network access" |
-| **Require encryption / CMEK** | key must be **set** (not blank); enable infra/double encryption | `kms_key_name`, `encryption.default_kms_key_name` |
-| **Enforce secure protocol minimums** | min TLS ≥ 1.2, etc. | TLS/version fields |
-| **Whitelist secure tiers/SKUs** | require tiers that *have* the security features (evidence-based, not arbitrary) | `sku`/`tier` fields |
-| **Disable weak/static auth** | prefer managed identity / IAM over local/basic auth, SAS, shared keys | local-auth toggles, SAS/HMAC keys |
-| **Require logging / audit** | logging/diagnostics enabled and routed | `logging.log_bucket`, diagnostic settings |
-| **Data residency** | region/location must be in an approved **whitelist** | `location`, `zone`, `region` |
-| **Prevent destructive loss** | block hard-destroy; require retention lock, soft-delete, purge protection | `force_destroy` (→false), `retention_policy.is_locked`, `soft_delete_policy` |
-| **Require managed identity** | identity assigned to the resource | identity blocks |
-| **Credential hygiene** | enforce rotation / max age; disable static keys | key rotation, SAS expiry |
-| **Enable any security feature / disable anything that weakens security** | the catch-all | various |
-
-Rule of thumb: **enable security features; disable or constrain things that weaken
-security.** If an argument toggles or sizes one of those, it is almost always `true`.
+- **Read the Terraform description critically.** It is often one vague sentence written
+  for people who already know the service. Treat it as a starting point, not an answer.
+- **When it's thin, go to the source.** Look up the argument in the underlying cloud
+  service's own documentation. What does this setting actually change in the running
+  service? What happens when it's unset? What is the default, and is the default safe?
+- **Check what values the platform accepts before claiming a risk.** It is easy to
+  imagine an insecure configuration that the platform doesn't actually allow. If every
+  accepted value is equally safe, a policy constraining the choice buys nothing.
+- **Know whose job it is.** Our policies secure *this* resource's configuration. An
+  argument that merely points at some other resource, or encodes a choice that belongs to
+  the team operating it, may be real and important — and still not ours to police.
+  Learning to see that boundary is part of the exercise.
 
 ---
 
-## 3. When is `security_impact = false`?
+## 3. Questions to ask of any argument
 
-- **Identifiers & references** — names, IDs, and pointers to *other* resources
-  (`bucket`, `project`, `*_id`, "references existing X", policy `data` sources). We don't
-  constrain what something is named or what it points at.
-- **Cosmetic / descriptive** — `display_name`, `description`, `labels`, annotations.
-- **Team data-management choices** that aren't security controls — e.g. `versioning`,
-  cache `ttl`, autoclass. We don't dictate how teams manage their data *unless* the field
-  clearly prevents destructive loss or exposure.
-- **Free-form policy documents** — e.g. IAM `policy_data` (a whole JSON policy). Writing a
-  generic platform policy that meaningfully constrains an arbitrary embedded document is
-  impractical → out of scope.
-- **Anything that would require knowing a specific name/key/project/region/email** — if
-  the only way to "enforce" it is to hardcode a specific value, it's overreaching → `false`.
+Work through these honestly for every argument — they are the analysis:
 
----
+1. **What does this argument actually control?** Not what its name suggests — what does
+   it *do*, in this resource, on this platform?
+2. **Who would a policy on it constrain?** Would the constraint hold for every team in
+   the org, or does it only make sense for some teams, some workloads, some values?
+3. **Does enforcing it change the security posture?** Or does it only affect operations,
+   cost, performance, or naming? "Important" and "security-relevant" are not synonyms.
+4. **Could the policy be written without knowing any team-specific value?** If you can't
+   state the rule without inventing a name, key, or address, reconsider.
+5. **Is this resource's security what's at stake?** Or are you reaching into
+   configuration that another resource, or another team, is responsible for?
 
-## 4. IAM: freedom vs. overreaching
+If you can answer all five with evidence, the verdict usually falls out on its own.
 
-IAM needs a careful, consistent line. Teams must stay free to assign access; we only block
-the clearly dangerous.
+### An example of the *process* (not a verdict)
 
-**Good IAM policy (`true`, worth enforcing):**
-- Block **public** principals: `allUsers`, `allAuthenticatedUsers`.
-- Block **wildcards** and obviously over-broad principal patterns.
-- Block dangerous mixtures / overly-sensitive grants (e.g. public + privileged).
-- → applies to `members` / `member`.
-
-**Overreaching (don't enforce):**
-- Dictating **which roles** a team may assign (teams need freedom to grant roles). → `role`
-  is generally **not** a policy target.
-- Controlling the embedded **`policy_data`** document. → out of scope.
-
-*(Open for refinement: whether to block specific primitive roles like `roles/owner` on
-public-facing resources. Default stance: leave role assignment to teams; police the
-principals, not the role catalog.)*
+Suppose you meet a boolean whose entire Terraform description is "Enables tiered request
+handling." That tells you nothing. A strong assessment would: search the cloud provider's
+docs for the feature; establish what actually changes when it's on versus off; check the
+default; then run the questions above — does the off state expose anything, or is this
+purely a capacity/cost lever? Whatever you find *is* your rationale. A weak assessment
+guesses from the name, and it shows immediately.
 
 ---
 
-## 5. Rationale standard
+## 4. What a good rationale looks like
 
-A rationale must **demonstrate understanding of what the argument controls** and give a
-**reasonable justification** for why a policy is (or isn't) warranted.
+The rationale is where you prove the work happened. It must:
 
-- For a **`true`** arg: name the *risk if mis-set* and the *secure direction/shape* of the
-  policy (without hardcoding specifics).
-- For a **`false`** arg: briefly say what it controls and why constraining it doesn't
-  improve security (or would be overreaching).
-- Simple fields (`display_name`, `description`) → one short sentence is fine.
-- Vague or complex fields → explain what they actually control before judging.
-- Be specific and correct (no typos, no hand-wave like *"not security related"* without
-  saying what it is).
+- **Show you understand what the argument does in this resource's context** —
+  especially where the Terraform docs are vague. If the docs were unclear and your
+  rationale is just as unclear, you haven't added anything.
+- **For security-relevant arguments, say what a policy would actually enforce** — the
+  shape of the rule, the direction it pushes, without hardcoding specifics. "This is
+  security related" is not a rationale; it's the absence of one.
+- **Give a real why (or why-not).** A `false` verdict still needs to say what the
+  argument controls and why constraining it wouldn't improve security.
 
-**Model rationales**
-
-- `public_access_prevention` (true): *"Controls whether the bucket can be exposed
-  publicly. Enforcing it 'enforced' prevents accidental public data exposure — a core
-  platform guarantee."*
-- `encryption.default_kms_key_name` (true): *"Sets the CMEK used to encrypt objects. A
-  policy should require it to be non-empty so data is always customer-managed-key
-  encrypted; it must **not** pin a specific key, since keys are team/project-specific."*
-- `role` (false): *"Specifies the IAM role granted. Platform policy should not dictate
-  which roles teams may assign; we constrain the principals (`members`) against public/
-  wildcard grants instead."*
-- `bucket` (false): *"Identifier referencing the target bucket. We don't constrain
-  resource names or references to other resources."*
+Be proportionate: a genuinely trivial field deserves one precise sentence, not padding.
+But note well — **a poor rationale costs marks even when the `true`/`false` call is
+right.** A correct verdict with a hollow justification tells us you may have guessed, or
+copied. Either way, the assessed skill wasn't demonstrated.
 
 ---
 
-## 6. PR-review checklist
+## 5. On doing your own analysis
 
-When reviewing a student's assessment of an argument, **reject** if any of these fail:
+To be plain about it: the analysis is what is being assessed, not the final booleans.
+Verdicts are checked, rationales are read, and reviewers are experienced at spotting
+prose that describes an argument without understanding it — including the fluent,
+confident, generically-worded kind. A rationale that doesn't demonstrate genuine
+engagement with what the argument does *in this resource* will not pass, whatever the
+verdict says.
 
-1. **Generic, not specific** — does the implied policy avoid hardcoding any specific name,
-   key, project, region, or email? (whitelists/structural shapes are fine)
-2. **Scoped to this resource** — it secures *this* resource, not the names/config of
-   resources it merely references.
-3. **Real security gain** — enforcing it would genuinely make the resource more secure
-   (maps to an archetype in §2). If not, it should be `false`.
-4. **Not overreaching** — it doesn't dictate team choices that aren't security
-   (role catalogs, data-management prefs, free-form policy docs).
-5. **Rationale quality** — shows understanding of what the arg controls and gives a
-   reasonable why/why-not; correct and specific (§5).
-
-If you simply disagree that enforcing a policy here improves security, that's a valid
-rejection — the bar is *"does a platform-level policy here make the resource more
-secure?"*
-
----
-
-## 7. Service notes
-
-### Cloud Storage
-
-Applying the principles to the real args:
-
-- **Access / exposure (true):** `public_access_prevention`, `uniform_bucket_level_access`,
-  IAM `members`/`member` (block public/wildcards), ACL `entity`/`role_entity`/
-  `predefined_acl`/`default_acl`.
-- **Encryption (true):** `encryption.default_kms_key_name` (bucket) and
-  `storage_bucket_object.kms_key_name` — require **non-blank** CMEK; never pin a key.
-  *(The bucket-level one is currently unassessed — a coverage gap to fill later.)*
-- **Destructive loss (true):** `force_destroy` (disable), `retention_policy.is_locked` /
-  `retention_period`, `soft_delete_policy` (enable).
-- **Data residency (true):** `location` / `zone` — region **whitelist**.
-- **Logging (true):** `logging.log_bucket` (enable). **Notifications** — team-dependent,
-  generally not a policy target.
-- **Not policy targets (false):** `bucket`/`project` and other identifiers/references;
-  IAM `role` (team freedom); `policy_data` (free-form doc, overreaching);
-  `versioning` and cache `ttl`/autoclass (team data-management, not security).
-
-These match the existing `true`/`false` calls in the Cloud Storage files — the main
-remaining work is **rationale quality** (several are vague or have typos) and **coverage**
-(security-relevant args still on the `"true/false"` placeholder, e.g. bucket-level
-encryption/logging/soft-delete).
-
-## 8. Refinements from the service-wide review
-
-Rulings established while reviewing every service — apply these consistently:
-
-- **Run-as service accounts → `true`.** The account a *workload* executes as (e.g.
-  Dataflow/Workflows/Application Integration `service_account`) is a least-privilege
-  control: require an explicit, **non-default** account (the default Compute Engine SA is
-  over-privileged). Enforce "set and not the default" — never pin a specific account. (A
-  service-account value used only as an inert reference, with no execution semantics,
-  stays `false`.)
-- **Delivery endpoint URLs → require `https://` (`true`).** Where a field is an endpoint
-  that receives/sends data (e.g. Pub/Sub `push_endpoint`), requiring the TLS scheme is the
-  secure-protocol archetype. Constrain the scheme only; never pin the host. (A URL that is
-  purely a reference to a team-specific system — e.g. an SCM `host_uri` — stays `false`.)
-- **Monitoring / observability → `true`.** Treat enable-monitoring like logging: require
-  it on so activity is visible. For log-*level* fields, require logging enabled (not OFF)
-  for auditability — favour capturing security events over silencing logs.
-- **Exposure allowlists → `true`.** A list that gates who can reach a private resource
-  (e.g. `allowed_projects` on a private cluster) is a network-exposure control: constrain
-  the allowlist *shape* (non-empty, not overly broad); don't pin specific entries.
-
-Confirmed **`false`** (not policy targets):
-- Network **address ranges / CIDR blocks** — team addressing; segmentation is enforced by
-  firewall/network-policy resources, not range sizing.
-- **Functional / architectural enums** with no insecure value (serving scope, hosting
-  type, HTTP method, store type, streaming-engine toggle, provisioning force-override).
-- **References to other resources** (buckets/paths, networks, name servers, endpoints,
-  driver names, store IDs) — we secure the referenced resource itself, not the pointer.
-- **Backup retention length and deletion/cleanup policies** — data-management /
-  operational hygiene, distinct from blocking destructive data loss.
-- **Un-constrainable secret values and free-form documents** (auth tokens, OpenAPI/gRPC
-  config blobs) — like IAM `policy_data`, a generic rule can't meaningfully constrain
-  them. (Free-form **env-var maps** stay `true` on credential-hygiene grounds — a policy
-  discourages plaintext secrets, pointing teams to Secret Manager.)
-
----
-
-*Add a new `### <Service>` subsection here as each service is reviewed.*
+The good news: the process above is not long. Read the docs, chase the vague bits, ask
+the five questions, write down what you found. Do that, and both the verdict and the
+rationale take care of themselves.


### PR DESCRIPTION
## Why

`docs/ASSESSMENT_GUIDANCE.md` had grown into a long internal working document — dense reference tables, service-by-service notes, and accumulated review decisions. As onboarding material for contributors doing argument assessments, it was hard to digest and had drifted from its actual audience.

## What changed

Full rewrite (~76 lines, down from ~187), refocused on the reader who has to do the analysis:

- States the mission in general terms: generic, platform-level policies for an imaginary multi-tenant enterprise; each assessment asks whether a generic policy on the argument would make the resource more secure.
- Teaches the research process: read Terraform descriptions critically, chase vague arguments into the cloud provider's own docs, check what values the platform actually accepts, and respect the boundary between securing this resource and configuration owned elsewhere.
- Gives a set of questions to work through for any argument, plus a short walk-through of the investigation process.
- Sets expectations for rationale quality and makes clear the reasoning itself is what's assessed.

The detailed reference material from the old version was removed rather than trimmed — this file now sticks to method and expectations.

Merging left to @JBarazani.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
