### PR TITLE
Added a certificate template location policy

### DIFF
--- a/inputs/gcp/Certificate Authority Service/google_privateca_certificate_template/location/compliant.tf
+++ b/inputs/gcp/Certificate Authority Service/google_privateca_certificate_template/location/compliant.tf
@@ -1,0 +1,4 @@
+resource "google_privateca_certificate_template" "compliant_example_1" {
+  name     = "compliant-certificate-template"
+  location = "australia-southeast1"
+}

--- a/inputs/gcp/Certificate Authority Service/google_privateca_certificate_template/location/config.tf
+++ b/inputs/gcp/Certificate Authority Service/google_privateca_certificate_template/location/config.tf
@@ -1,0 +1,11 @@
+##### DO NOT EDIT ######
+
+terraform {
+  required_providers {
+    google = {
+      source  = "hashicorp/google"
+    }
+  }
+}
+
+provider "google" {}

--- a/inputs/gcp/Certificate Authority Service/google_privateca_certificate_template/location/nonCompliant.tf
+++ b/inputs/gcp/Certificate Authority Service/google_privateca_certificate_template/location/nonCompliant.tf
@@ -1,0 +1,4 @@
+resource "google_privateca_certificate_template" "non_compliant_example_1" {
+  name     = "non-compliant-certificate-template"
+  location = "us-central1"
+}

--- a/policies/gcp/Certificate Authority Service/google_privateca_certificate_template/_vars.rego
+++ b/policies/gcp/Certificate Authority Service/google_privateca_certificate_template/_vars.rego
@@ -1,0 +1,7 @@
+package terraform.gcp.security.certificate_authority_service.google_privateca_certificate_template.vars
+
+variables := {
+	"friendly_resource_name": "Certificate Template",
+	"resource_type": "google_privateca_certificate_template",
+	"resource_value_name": "name",
+}

--- a/policies/gcp/Certificate Authority Service/google_privateca_certificate_template/location.rego
+++ b/policies/gcp/Certificate Authority Service/google_privateca_certificate_template/location.rego
@@ -1,0 +1,27 @@
+package terraform.gcp.security.certificate_authority_service.google_privateca_certificate_template.location
+
+import data.terraform.gcp.security.certificate_authority_service.google_privateca_certificate_template.vars
+import data.terraform.helpers
+
+conditions := [
+	[
+		{
+			"situation_description": "Certificate Template must be deployed in an approved geographic region.",
+			"remedies": [
+				"Set the location field to an approved region such as 'australia-southeast1' or 'australia-southeast2'.",
+				"Run 'gcloud privateca locations list' to see all available regions.",
+			],
+		},
+		{
+			"condition": "location is in approved region whitelist",
+			"attribute_path": ["location"],
+			"values": ["australia-southeast1", "australia-southeast2"],
+			"policy_type": "whitelist",
+		},
+	],
+]
+
+result := helpers.get_multi_summary(conditions, vars.variables)
+
+message := result.message
+details := result.details


### PR DESCRIPTION
-Summary
I Added a location policy for the GCP **google_privateca_certificate_template** resource.

-Changes that were made
>Restricts certificate templates to approved Australian regions.
> Adds compliant and non-compliant Terraform test fixtures.
> Automated policy test passes successfully.

- The Approved regions
1)australia-southeast1
2)australia-southeast2