### PR TITLE
Add certificate location policy

### DIFF
--- a/inputs/gcp/Certificate Authority Service/google_privateca_certificate/location/compliant.tf
+++ b/inputs/gcp/Certificate Authority Service/google_privateca_certificate/location/compliant.tf
@@ -1,0 +1,22 @@
+resource "tls_private_key" "compliant_key" {
+  algorithm = "RSA"
+  rsa_bits  = 2048
+}
+
+resource "tls_cert_request" "compliant_request" {
+  private_key_pem = tls_private_key.compliant_key.private_key_pem
+
+  subject {
+    common_name  = "example.com"
+    organization = "Example"
+  }
+}
+
+resource "google_privateca_certificate" "compliant_example_1" {
+  name                  = "compliant-certificate"
+  location              = "australia-southeast1"
+  pool                  = "example-pool"
+  certificate_authority = "example-ca"
+  lifetime              = "86000s"
+  pem_csr               = tls_cert_request.compliant_request.cert_request_pem
+}

--- a/inputs/gcp/Certificate Authority Service/google_privateca_certificate/location/config.tf
+++ b/inputs/gcp/Certificate Authority Service/google_privateca_certificate/location/config.tf
@@ -1,0 +1,14 @@
+##### DO NOT EDIT #####
+
+terraform {
+  required_providers {
+    google = {
+      source = "hashicorp/google"
+    }
+    tls = {
+      source = "hashicorp/tls"
+    }
+  }
+}
+
+provider "google" {}

--- a/inputs/gcp/Certificate Authority Service/google_privateca_certificate/location/nonCompliant.tf
+++ b/inputs/gcp/Certificate Authority Service/google_privateca_certificate/location/nonCompliant.tf
@@ -1,0 +1,22 @@
+resource "tls_private_key" "non_compliant_key" {
+  algorithm = "RSA"
+  rsa_bits  = 2048
+}
+
+resource "tls_cert_request" "non_compliant_request" {
+  private_key_pem = tls_private_key.non_compliant_key.private_key_pem
+
+  subject {
+    common_name  = "example.com"
+    organization = "Example"
+  }
+}
+
+resource "google_privateca_certificate" "non_compliant_example_1" {
+  name                  = "non-compliant-certificate"
+  location              = "us-central1"
+  pool                  = "example-pool"
+  certificate_authority = "example-ca"
+  lifetime              = "86000s"
+  pem_csr               = tls_cert_request.non_compliant_request.cert_request_pem
+}

--- a/policies/gcp/Certificate Authority Service/google_privateca_certificate/_vars.rego
+++ b/policies/gcp/Certificate Authority Service/google_privateca_certificate/_vars.rego
@@ -1,0 +1,7 @@
+package terraform.gcp.security.certificate_authority_service.google_privateca_certificate.vars
+
+variables := {
+	"friendly_resource_name": "Certificate",
+	"resource_type": "google_privateca_certificate",
+	"resource_value_name": "name",
+}

--- a/policies/gcp/Certificate Authority Service/google_privateca_certificate/location.rego
+++ b/policies/gcp/Certificate Authority Service/google_privateca_certificate/location.rego
@@ -1,0 +1,27 @@
+package terraform.gcp.security.certificate_authority_service.google_privateca_certificate.location
+
+import data.terraform.helpers
+import data.terraform.gcp.security.certificate_authority_service.google_privateca_certificate.vars
+
+conditions := [
+	[
+		{
+			"situation_description": "Certificate must be deployed in an approved geographic region.",
+			"remedies": [
+				"Set the location field to an approved region such as 'australia-southeast1' or 'australia-southeast2'.",
+				"Run 'gcloud privateca locations list' to see all available regions.",
+			],
+		},
+		{
+			"condition": "Location is in approved region whitelist",
+			"attribute_path": ["location"],
+			"values": ["australia-southeast1", "australia-southeast2"],
+			"policy_type": "whitelist",
+		},
+	],
+]
+
+result := helpers.get_multi_summary(conditions, vars.variables)
+
+message := result.message
+details := result.details


### PR DESCRIPTION
# Summary

-I added a location policy for the GCP `google_privateca_certificate` resource.

# Changes

- Restricts certificates to approved Australian regions.
- Adds compliant and non-compliant Terraform test fixtures.
- Passes all automated policy tests successfully.

# The approved regions

1) australia-southeast1
2)australia-southeast2