### PR TITLE
GCP Access Context Manager access level policy fixes

### DIFF
--- a/inputs/gcp/Access Context Manager (VPC Service Controls)/google_access_context_manager_access_level/basic.conditions.device_policy.allowed_device_management_levels/compliant.tf
+++ b/inputs/gcp/Access Context Manager (VPC Service Controls)/google_access_context_manager_access_level/basic.conditions.device_policy.allowed_device_management_levels/compliant.tf
@@ -1,7 +1,8 @@
 resource "google_access_context_manager_access_level" "compliant_example_1" {
   parent = "accessPolicies/123456789"
-  name   = "compliant_example_1"
-  title  = "chromeos_no_lock"
+  name   = "accessPolicies/123456789/accessLevels/compliant_management_level"
+  title  = "compliant-management-level"
+
   basic {
     conditions {
       device_policy {

--- a/inputs/gcp/Access Context Manager (VPC Service Controls)/google_access_context_manager_access_level/basic.conditions.device_policy.allowed_device_management_levels/nonCompliant.tf
+++ b/inputs/gcp/Access Context Manager (VPC Service Controls)/google_access_context_manager_access_level/basic.conditions.device_policy.allowed_device_management_levels/nonCompliant.tf
@@ -1,7 +1,8 @@
 resource "google_access_context_manager_access_level" "non_compliant_example_1" {
   parent = "accessPolicies/123456789"
-  name   = "non_compliant_example_1"
-  title  = "chromeos_no_lock"
+  name   = "accessPolicies/123456789/accessLevels/non_compliant_management_level"
+  title  = "non-compliant-management-level"
+
   basic {
     conditions {
       device_policy {

--- a/inputs/gcp/Access Context Manager (VPC Service Controls)/google_access_context_manager_access_level/basic.conditions.device_policy.allowed_encryption_statuses/compliant.tf
+++ b/inputs/gcp/Access Context Manager (VPC Service Controls)/google_access_context_manager_access_level/basic.conditions.device_policy.allowed_encryption_statuses/compliant.tf
@@ -1,7 +1,8 @@
 resource "google_access_context_manager_access_level" "compliant_example_1" {
   parent = "accessPolicies/123456789"
-  name   = "compliant_example_1"
-  title  = "chromeos_no_lock"
+  name   = "accessPolicies/123456789/accessLevels/compliant_encryption_status"
+  title  = "compliant-encryption-status"
+
   basic {
     conditions {
       device_policy {

--- a/inputs/gcp/Access Context Manager (VPC Service Controls)/google_access_context_manager_access_level/basic.conditions.device_policy.allowed_encryption_statuses/nonCompliant.tf
+++ b/inputs/gcp/Access Context Manager (VPC Service Controls)/google_access_context_manager_access_level/basic.conditions.device_policy.allowed_encryption_statuses/nonCompliant.tf
@@ -1,7 +1,8 @@
 resource "google_access_context_manager_access_level" "non_compliant_example_1" {
   parent = "accessPolicies/123456789"
-  name   = "non_compliant_example_1"
-  title  = "chromeos_no_lock"
+  name   = "accessPolicies/123456789/accessLevels/non_compliant_encryption_status"
+  title  = "non-compliant-encryption-status"
+
   basic {
     conditions {
       device_policy {

--- a/inputs/gcp/Access Context Manager (VPC Service Controls)/google_access_context_manager_access_level/basic.conditions.device_policy.os_constraints.os_type/compliant.tf
+++ b/inputs/gcp/Access Context Manager (VPC Service Controls)/google_access_context_manager_access_level/basic.conditions.device_policy.os_constraints.os_type/compliant.tf
@@ -1,7 +1,8 @@
 resource "google_access_context_manager_access_level" "compliant_example_1" {
   parent = "accessPolicies/123456789"
-  name   = "compliant_example_1"
-  title  = "c-os_type"
+  name   = "accessPolicies/123456789/accessLevels/compliant_os_type"
+  title  = "compliant-os-type"
+
   basic {
     conditions {
       device_policy {

--- a/inputs/gcp/Access Context Manager (VPC Service Controls)/google_access_context_manager_access_level/basic.conditions.device_policy.os_constraints.os_type/nonCompliant.tf
+++ b/inputs/gcp/Access Context Manager (VPC Service Controls)/google_access_context_manager_access_level/basic.conditions.device_policy.os_constraints.os_type/nonCompliant.tf
@@ -1,7 +1,8 @@
 resource "google_access_context_manager_access_level" "non_compliant_example_1" {
   parent = "accessPolicies/123456789"
-  name   = "non_compliant_example_1"
-  title  = "nc-os_type"
+  name   = "accessPolicies/123456789/accessLevels/non_compliant_os_type"
+  title  = "non-compliant-os-type"
+
   basic {
     conditions {
       device_policy {

--- a/inputs/gcp/Access Context Manager (VPC Service Controls)/google_access_context_manager_access_level/basic.conditions.device_policy.require_admin_approval/compliant.tf
+++ b/inputs/gcp/Access Context Manager (VPC Service Controls)/google_access_context_manager_access_level/basic.conditions.device_policy.require_admin_approval/compliant.tf
@@ -1,7 +1,8 @@
 resource "google_access_context_manager_access_level" "compliant_example_1" {
   parent = "accessPolicies/123456789"
-  name   = "compliant_example_1"
-  title  = "chromeos_no_lock"
+  name   = "accessPolicies/123456789/accessLevels/compliant_admin_approval"
+  title  = "compliant-admin-approval"
+
   basic {
     conditions {
       device_policy {

--- a/inputs/gcp/Access Context Manager (VPC Service Controls)/google_access_context_manager_access_level/basic.conditions.device_policy.require_admin_approval/nonCompliant.tf
+++ b/inputs/gcp/Access Context Manager (VPC Service Controls)/google_access_context_manager_access_level/basic.conditions.device_policy.require_admin_approval/nonCompliant.tf
@@ -1,7 +1,8 @@
 resource "google_access_context_manager_access_level" "non_compliant_example_1" {
   parent = "accessPolicies/123456789"
-  name   = "non_compliant_example_1"
-  title  = "chromeos_no_lock"
+  name   = "accessPolicies/123456789/accessLevels/non_compliant_admin_approval"
+  title  = "non-compliant-admin-approval"
+
   basic {
     conditions {
       device_policy {

--- a/inputs/gcp/Access Context Manager (VPC Service Controls)/google_access_context_manager_access_level/basic.conditions.device_policy.require_corp_owned/compliant.tf
+++ b/inputs/gcp/Access Context Manager (VPC Service Controls)/google_access_context_manager_access_level/basic.conditions.device_policy.require_corp_owned/compliant.tf
@@ -1,7 +1,8 @@
 resource "google_access_context_manager_access_level" "compliant_example_1" {
   parent = "accessPolicies/123456789"
-  name   = "compliant_example_1"
-  title  = "chromeos_no_lock"
+  name   = "accessPolicies/123456789/accessLevels/compliant_corp_owned"
+  title  = "compliant-corp-owned"
+
   basic {
     conditions {
       device_policy {

--- a/inputs/gcp/Access Context Manager (VPC Service Controls)/google_access_context_manager_access_level/basic.conditions.device_policy.require_corp_owned/nonCompliant.tf
+++ b/inputs/gcp/Access Context Manager (VPC Service Controls)/google_access_context_manager_access_level/basic.conditions.device_policy.require_corp_owned/nonCompliant.tf
@@ -1,7 +1,8 @@
 resource "google_access_context_manager_access_level" "non_compliant_example_1" {
   parent = "accessPolicies/123456789"
-  name   = "non_compliant_example_1"
-  title  = "chromeos_no_lock"
+  name   = "accessPolicies/123456789/accessLevels/non_compliant_corp_owned"
+  title  = "non-compliant-corp-owned"
+
   basic {
     conditions {
       device_policy {

--- a/inputs/gcp/Access Context Manager (VPC Service Controls)/google_access_context_manager_access_level/basic.conditions.device_policy.require_screen_lock/compliant.tf
+++ b/inputs/gcp/Access Context Manager (VPC Service Controls)/google_access_context_manager_access_level/basic.conditions.device_policy.require_screen_lock/compliant.tf
@@ -1,7 +1,8 @@
 resource "google_access_context_manager_access_level" "compliant_example_1" {
   parent = "accessPolicies/123456789"
-  name   = "compliant_example_1"
-  title  = "c-require-screen-lock"
+  name   = "accessPolicies/123456789/accessLevels/compliant_screen_lock"
+  title  = "compliant-screen-lock"
+
   basic {
     conditions {
       device_policy {

--- a/inputs/gcp/Access Context Manager (VPC Service Controls)/google_access_context_manager_access_level/basic.conditions.device_policy.require_screen_lock/nonCompliant.tf
+++ b/inputs/gcp/Access Context Manager (VPC Service Controls)/google_access_context_manager_access_level/basic.conditions.device_policy.require_screen_lock/nonCompliant.tf
@@ -1,7 +1,8 @@
 resource "google_access_context_manager_access_level" "non_compliant_example_1" {
   parent = "accessPolicies/123456789"
-  name   = "non_compliant_example_1"
-  title  = "chromeos_no_lock"
+  name   = "accessPolicies/123456789/accessLevels/non_compliant_screen_lock"
+  title  = "non-compliant-screen-lock"
+
   basic {
     conditions {
       device_policy {

--- a/inputs/gcp/Access Context Manager (VPC Service Controls)/google_access_context_manager_access_level/basic.conditions.regions/compliant.tf
+++ b/inputs/gcp/Access Context Manager (VPC Service Controls)/google_access_context_manager_access_level/basic.conditions.regions/compliant.tf
@@ -1,12 +1,11 @@
 resource "google_access_context_manager_access_level" "compliant_example_1" {
   parent = "accessPolicies/123456789"
-  name   = "compliant_example_1"
-  title  = "c-region"
+  name   = "accessPolicies/123456789/accessLevels/compliant_region"
+  title  = "compliant-region"
+
   basic {
     conditions {
-      regions = [
-        "australia-southeast1","australia-southeast2",
-      ]
+      regions = ["AU"]
     }
   }
 }

--- a/inputs/gcp/Access Context Manager (VPC Service Controls)/google_access_context_manager_access_level/basic.conditions.regions/nonCompliant.tf
+++ b/inputs/gcp/Access Context Manager (VPC Service Controls)/google_access_context_manager_access_level/basic.conditions.regions/nonCompliant.tf
@@ -1,14 +1,11 @@
 resource "google_access_context_manager_access_level" "non_compliant_example_1" {
   parent = "accessPolicies/123456789"
-  name   = "non_compliant_example_1"
-  title  = "nc-region"
+  name   = "accessPolicies/123456789/accessLevels/non_compliant_region"
+  title  = "non-compliant-region"
+
   basic {
     conditions {
-      regions = [
-        "CH",
-        "IT",
-        "US",
-      ]
+      regions = ["US"]
     }
   }
 }

--- a/policies/gcp/Access Context Manager (VPC Service Controls)/google_access_context_manager_access_level/basic.conditions.device_policy.allowed_device_management_levels.rego
+++ b/policies/gcp/Access Context Manager (VPC Service Controls)/google_access_context_manager_access_level/basic.conditions.device_policy.allowed_device_management_levels.rego
@@ -4,21 +4,24 @@ import data.terraform.helpers
 import data.terraform.gcp.security.access_context_manager_vpc_service_controls.google_access_context_manager_access_level.vars
 
 conditions := [
-  [
-    {
-      "situation_description": "A list of allowed device management levels. An empty list allows all management levels. Each value may be one of: MANAGEMENT_UNSPECIFIED, NONE, BASIC, COMPLETE",
-      "remedies": ["Update allowed_device_management_levels to include only allowed values as per organizational policy."]
-    },
-    {
-      "condition": "os_type is not in blacklist",
-      "attribute_path": ["basic", 0, "conditions", 0, "device_policy", 0, "allowed_device_management_levels"],
-      "values": ["COMPLETE"],
-      "policy_type": "whitelist"
-    }
-  ]
+    [
+        {
+            "situation_description": "Access level device policy allows devices with an unapproved management level.",
+            "remedies": [
+                "Set basic.conditions.device_policy.allowed_device_management_levels to COMPLETE.",
+                "Require completely managed devices to reduce access risk from unmanaged or partially managed endpoints."
+            ]
+        },
+        {
+            "condition": "Access level device policy must only allow completely managed devices.",
+            "attribute_path": ["basic", 0, "conditions", 0, "device_policy", 0, "allowed_device_management_levels"],
+            "values": ["COMPLETE"],
+            "policy_type": "whitelist"
+        }
+    ]
 ]
 
 result := helpers.get_multi_summary(conditions, vars.variables)
-  
+
 message := result.message
 details := result.details

--- a/policies/gcp/Access Context Manager (VPC Service Controls)/google_access_context_manager_access_level/basic.conditions.device_policy.allowed_encryption_statuses.rego
+++ b/policies/gcp/Access Context Manager (VPC Service Controls)/google_access_context_manager_access_level/basic.conditions.device_policy.allowed_encryption_statuses.rego
@@ -4,21 +4,24 @@ import data.terraform.helpers
 import data.terraform.gcp.security.access_context_manager_vpc_service_controls.google_access_context_manager_access_level.vars
 
 conditions := [
-  [
-    {
-      "situation_description": "A list of allowed encryptions statuses. An empty list allows all statuses. Each value may be one of: ENCRYPTION_UNSPECIFIED, ENCRYPTION_UNSUPPORTED, UNENCRYPTED, ENCRYPTED.",
-      "remedies": ["Update allowed_encryption_statuses to include only allowed values as per organizational policy."]
-    },
-    {
-      "condition": "os_type is not in blacklist",
-      "attribute_path": ["basic", 0, "conditions", 0, "device_policy", 0, "allowed_encryption_statuses"],
-      "values": ["ENCRYPTED"],
-      "policy_type": "whitelist"
-    }
-  ]
+    [
+        {
+            "situation_description": "Access level device policy allows devices with unapproved encryption status.",
+            "remedies": [
+                "Set basic.conditions.device_policy.allowed_encryption_statuses to ENCRYPTED.",
+                "Require encrypted devices to reduce the risk of data exposure from lost, stolen, or unmanaged devices."
+            ]
+        },
+        {
+            "condition": "Access level device policy must only allow encrypted devices.",
+            "attribute_path": ["basic", 0, "conditions", 0, "device_policy", 0, "allowed_encryption_statuses"],
+            "values": ["ENCRYPTED"],
+            "policy_type": "whitelist"
+        }
+    ]
 ]
 
 result := helpers.get_multi_summary(conditions, vars.variables)
-  
+
 message := result.message
 details := result.details

--- a/policies/gcp/Access Context Manager (VPC Service Controls)/google_access_context_manager_access_level/basic.conditions.device_policy.os_constraints.os_type.rego
+++ b/policies/gcp/Access Context Manager (VPC Service Controls)/google_access_context_manager_access_level/basic.conditions.device_policy.os_constraints.os_type.rego
@@ -5,20 +5,23 @@ import data.terraform.gcp.security.access_context_manager_vpc_service_controls.g
 
 conditions := [
     [
-    {
-      "situation_description": "Ensure access is not granted to unspecified or unsupported OS types.",
-      "remedies": ["Update os_constraints to explicitly include only supported OS types."]
-    },
-    {
-      "condition": "os_type is in whitelist",
-      "attribute_path": ["basic", 0, "conditions", 0, "device_policy", 0, "os_constraints", 0, "os_type"],
-      "values": ["DESKTOP_WINDOWS","DESKTOP_LINUX","DESKTOP_MAC", "DESKTOP_CHROME_OS"],
-      "policy_type": "whitelist"
-    }
-  ]
+        {
+            "situation_description": "Access level device policy allows an unapproved operating system type.",
+            "remedies": [
+                "Set basic.conditions.device_policy.os_constraints.os_type to an approved OS type.",
+                "Use approved operating systems such as DESKTOP_WINDOWS, DESKTOP_LINUX, DESKTOP_MAC, or DESKTOP_CHROME_OS."
+            ]
+        },
+        {
+            "condition": "Access level device policy must only allow approved operating system types.",
+            "attribute_path": ["basic", 0, "conditions", 0, "device_policy", 0, "os_constraints", 0, "os_type"],
+            "values": ["DESKTOP_WINDOWS", "DESKTOP_LINUX", "DESKTOP_MAC", "DESKTOP_CHROME_OS"],
+            "policy_type": "whitelist"
+        }
+    ]
 ]
 
 result := helpers.get_multi_summary(conditions, vars.variables)
-  
+
 message := result.message
 details := result.details

--- a/policies/gcp/Access Context Manager (VPC Service Controls)/google_access_context_manager_access_level/basic.conditions.device_policy.require_admin_approval.rego
+++ b/policies/gcp/Access Context Manager (VPC Service Controls)/google_access_context_manager_access_level/basic.conditions.device_policy.require_admin_approval.rego
@@ -4,21 +4,24 @@ import data.terraform.helpers
 import data.terraform.gcp.security.access_context_manager_vpc_service_controls.google_access_context_manager_access_level.vars
 
 conditions := [
-  [
-    {
-      "situation_description": "Whether the device needs to be approved by the customer admin.",
-      "remedies": ["Update require_admin_approval to include only allowed values as per organizational policy."]
-    },
-    {
-      "condition": "os_type is not in blacklist",
-      "attribute_path": ["basic", 0, "conditions", 0, "device_policy", 0, "require_admin_approval"],
-      "values": [true],
-      "policy_type": "whitelist"
-    }
-  ]
+    [
+        {
+            "situation_description": "Access level device policy does not require admin approval.",
+            "remedies": [
+                "Set basic.conditions.device_policy.require_admin_approval to true.",
+                "Require admin-approved devices to reduce access risk from unmanaged or unverified devices."
+            ]
+        },
+        {
+            "condition": "Access level device policy must require admin-approved devices.",
+            "attribute_path": ["basic", 0, "conditions", 0, "device_policy", 0, "require_admin_approval"],
+            "values": true,
+            "policy_type": "whitelist"
+        }
+    ]
 ]
 
 result := helpers.get_multi_summary(conditions, vars.variables)
-  
+
 message := result.message
 details := result.details

--- a/policies/gcp/Access Context Manager (VPC Service Controls)/google_access_context_manager_access_level/basic.conditions.device_policy.require_corp_owned.rego
+++ b/policies/gcp/Access Context Manager (VPC Service Controls)/google_access_context_manager_access_level/basic.conditions.device_policy.require_corp_owned.rego
@@ -4,21 +4,24 @@ import data.terraform.helpers
 import data.terraform.gcp.security.access_context_manager_vpc_service_controls.google_access_context_manager_access_level.vars
 
 conditions := [
-  [
-    {
-      "situation_description": "Whether the device needs to be corp owned.",
-      "remedies": ["Update require_corp_owned to include only allowed values as per organizational policy."]
-    },
-    {
-      "condition": "os_type is not in blacklist",
-      "attribute_path": ["basic", 0, "conditions", 0, "device_policy", 0, "require_corp_owned"],
-      "values": [true],
-      "policy_type": "whitelist"
-    }
-  ]
+    [
+        {
+            "situation_description": "Access level device policy does not require a corporate-owned device.",
+            "remedies": [
+                "Set basic.conditions.device_policy.require_corp_owned to true.",
+                "Require corporate-owned devices to reduce access risk from unmanaged or personal devices."
+            ]
+        },
+        {
+            "condition": "Access level device policy must require corporate-owned devices.",
+            "attribute_path": ["basic", 0, "conditions", 0, "device_policy", 0, "require_corp_owned"],
+            "values": true,
+            "policy_type": "whitelist"
+        }
+    ]
 ]
 
 result := helpers.get_multi_summary(conditions, vars.variables)
-  
+
 message := result.message
 details := result.details

--- a/policies/gcp/Access Context Manager (VPC Service Controls)/google_access_context_manager_access_level/basic.conditions.device_policy.require_screen_lock.rego
+++ b/policies/gcp/Access Context Manager (VPC Service Controls)/google_access_context_manager_access_level/basic.conditions.device_policy.require_screen_lock.rego
@@ -5,20 +5,23 @@ import data.terraform.gcp.security.access_context_manager_vpc_service_controls.g
 
 conditions := [
     [
-    {
-      "situation_description": "Whether or not screenlock is required for the DevicePolicy to be true.",
-      "remedies": ["Update screen lock requirement in device policy."]
-    },
-    {
-      "condition": "screen_lock is true",
-      "attribute_path": ["basic", 0, "conditions", 0, "device_policy", 0, "require_screen_lock"],
-      "values": true,
-      "policy_type": "whitelist"
-    }
-  ]
+        {
+            "situation_description": "Access level device policy does not require screen lock.",
+            "remedies": [
+                "Set basic.conditions.device_policy.require_screen_lock to true.",
+                "Require screen lock to reduce the risk of unauthorized access from unattended devices."
+            ]
+        },
+        {
+            "condition": "Access level device policy must require screen lock.",
+            "attribute_path": ["basic", 0, "conditions", 0, "device_policy", 0, "require_screen_lock"],
+            "values": true,
+            "policy_type": "whitelist"
+        }
+    ]
 ]
 
 result := helpers.get_multi_summary(conditions, vars.variables)
-  
+
 message := result.message
 details := result.details

--- a/policies/gcp/Access Context Manager (VPC Service Controls)/google_access_context_manager_access_level/basic.conditions.regions.rego
+++ b/policies/gcp/Access Context Manager (VPC Service Controls)/google_access_context_manager_access_level/basic.conditions.regions.rego
@@ -5,18 +5,23 @@ import data.terraform.gcp.security.access_context_manager_vpc_service_controls.g
 
 conditions := [
     [
-    {"situation_description" : "Must be in Australia Region",
-    "remedies":[ "Change regions to Aus"]},
-    {
-        "condition": "Region is not Aus",
-        "attribute_path" : ["basic", 0, "conditions", 0, "regions"],
-        "values" : ["australia-southeast1","australia-southeast2"],
-        "policy_type" : "whitelist" 
-    }
+        {
+            "situation_description": "Access level request origin region is outside the approved country list.",
+            "remedies": [
+                "Set basic.conditions.regions to an approved ISO 3166-1 alpha-2 country code such as 'AU'.",
+                "Use approved countries to support access governance and regional access control requirements."
+            ]
+        },
+        {
+            "condition": "Access level regions must only include approved country codes.",
+            "attribute_path": ["basic", 0, "conditions", 0, "regions"],
+            "values": ["AU"],
+            "policy_type": "whitelist"
+        }
     ]
 ]
 
 result := helpers.get_multi_summary(conditions, vars.variables)
-  
+
 message := result.message
 details := result.details


### PR DESCRIPTION
## Summary
Updated and tested policies for `google_access_context_manager_access_level` under GCP Access Context Manager (VPC Service Controls).

## Policies updated
- `basic.conditions.regions`
- `basic.conditions.device_policy.require_screen_lock`
- `basic.conditions.device_policy.require_corp_owned`
- `basic.conditions.device_policy.require_admin_approval`
- `basic.conditions.device_policy.allowed_encryption_statuses`
- `basic.conditions.device_policy.allowed_device_management_levels`
- `basic.conditions.device_policy.os_constraints.os_type`

## Changes made
- Fixed Terraform compliant and non-compliant examples.
- Updated Access Level `name` fields to use full Access Context Manager resource format.
- Improved Rego condition descriptions and remediation messages.
- Removed incorrect copy-paste wording such as `os_type is not in blacklist`.
- Tested each policy using Terraform plan and OPA eval.

## Testing
Each policy was tested with:
- `terraform init`
- `terraform plan -out=plan`
- `terraform show -json plan > plan.json`
- `opa eval`

All policies correctly detected their non-compliant resources.