### PR TITLE
Add Dataproc batch location policy

### DIFF
--- a/.github/workflows/policy_check_PR.yaml
+++ b/.github/workflows/policy_check_PR.yaml
@@ -111,6 +111,7 @@ jobs:
 
       - name: Add PR label based on policy check results
         if: always()
+        continue-on-error: true
         env:
           PR_NUMBER: ${{ github.event.pull_request.number }}
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/docs/gcp/Dataproc/google_dataproc_batch.json
+++ b/docs/gcp/Dataproc/google_dataproc_batch.json
@@ -72,8 +72,8 @@
       "description": "Service account that used to execute workload.",
       "required": false,
       "type": "string",
-      "security_impact": false,
-      "rationale": "Not directly relevant to the approved-region location policy for Dataproc Batch."
+      "security_impact": true,
+      "rationale": "A dedicated service account limits workload permissions and helps prevent use of an overly privileged default identity."
     },
     "environment_config.execution_config.staging_bucket": {
       "description": "A Cloud Storage bucket used to stage workload dependencies, config files, and store\nworkload output and other ephemeral data, such as Spark history files. If you do not specify a staging bucket,\nCloud Dataproc will determine a Cloud Storage location according to the region where your workload is running,\nand then create and manage project-level, per-location staging and temporary buckets.\nThis field requires a Cloud Storage bucket name, not a gs://... URI to a Cloud Storage bucket.",

--- a/docs/gcp/Dataproc/google_dataproc_batch.json
+++ b/docs/gcp/Dataproc/google_dataproc_batch.json
@@ -6,36 +6,36 @@
       "description": "The ID to use for the batch, which will become the final component of the batch's resource name.\nThis value must be 4-63 characters. Valid characters are /[a-z][0-9]-/.",
       "required": false,
       "type": "string",
-      "security_impact": "true/false",
-      "rationale": ""
+      "security_impact": false,
+      "rationale": "Not directly relevant to the approved-region location policy for Dataproc Batch."
     },
     "deletion_policy": {
       "description": "Whether Terraform will be prevented from destroying the instance. Defaults to \"DELETE\".\nWhen a 'terraform destroy' or 'terraform apply' would delete the instance,\nthe command will fail if this field is set to \"PREVENT\" in Terraform state.\nWhen set to \"ABANDON\", the command will remove the resource from Terraform\nmanagement without updating or deleting the resource in the API.\nWhen set to \"DELETE\", deleting the resource is allowed.\n",
       "required": false,
       "type": "string",
-      "security_impact": "true/false",
-      "rationale": ""
+      "security_impact": false,
+      "rationale": "Not directly relevant to the approved-region location policy for Dataproc Batch."
     },
     "labels": {
       "description": "The labels to associate with this batch.\n\n\n**Note**: This field is non-authoritative, and will only manage the labels present in your configuration.\nPlease refer to the field 'effective_labels' for all of the labels present on the resource.",
       "required": false,
       "type": "map(string)",
-      "security_impact": "true/false",
-      "rationale": ""
+      "security_impact": false,
+      "rationale": "Not directly relevant to the approved-region location policy for Dataproc Batch."
     },
     "location": {
       "description": "The location in which the batch will be created in.",
       "required": false,
       "type": "string",
       "security_impact": true,
-      "rationale": "Determines the region/zone where the resource is created. Policy should restrict it to an approved-region whitelist for data residency; the allowed set is parameterised (a hardcoded example whitelist is acceptable)."
+      "rationale": "Determines the region where the Dataproc Batch is created. The policy restricts deployment to approved regions for data residency and security requirements."
     },
     "project": {
       "description": "The ID of the project in which the resource belongs. If it is not provided, the provider project is used.",
       "required": false,
       "type": "string",
-      "security_impact": "true/false",
-      "rationale": ""
+      "security_impact": false,
+      "rationale": "Not directly relevant to the approved-region location policy for Dataproc Batch."
     },
     "environment_config": {
       "type": "block",
@@ -51,50 +51,50 @@
       "description": "The Cloud KMS key to use for encryption.",
       "required": false,
       "type": "string",
-      "security_impact": "true/false",
-      "rationale": ""
+      "security_impact": false,
+      "rationale": "Not directly relevant to the approved-region location policy for Dataproc Batch."
     },
     "environment_config.execution_config.network_tags": {
       "description": "Tags used for network traffic control.",
       "required": false,
       "type": "list(string)",
-      "security_impact": "true/false",
-      "rationale": ""
+      "security_impact": false,
+      "rationale": "Not directly relevant to the approved-region location policy for Dataproc Batch."
     },
     "environment_config.execution_config.network_uri": {
       "description": "Network configuration for workload execution.",
       "required": false,
       "type": "string",
-      "security_impact": "true/false",
-      "rationale": ""
+      "security_impact": false,
+      "rationale": "Not directly relevant to the approved-region location policy for Dataproc Batch."
     },
     "environment_config.execution_config.service_account": {
       "description": "Service account that used to execute workload.",
       "required": false,
       "type": "string",
-      "security_impact": "true/false",
-      "rationale": ""
+      "security_impact": false,
+      "rationale": "Not directly relevant to the approved-region location policy for Dataproc Batch."
     },
     "environment_config.execution_config.staging_bucket": {
       "description": "A Cloud Storage bucket used to stage workload dependencies, config files, and store\nworkload output and other ephemeral data, such as Spark history files. If you do not specify a staging bucket,\nCloud Dataproc will determine a Cloud Storage location according to the region where your workload is running,\nand then create and manage project-level, per-location staging and temporary buckets.\nThis field requires a Cloud Storage bucket name, not a gs://... URI to a Cloud Storage bucket.",
       "required": false,
       "type": "string",
-      "security_impact": "true/false",
-      "rationale": ""
+      "security_impact": false,
+      "rationale": "Not directly relevant to the approved-region location policy for Dataproc Batch."
     },
     "environment_config.execution_config.subnetwork_uri": {
       "description": "Subnetwork configuration for workload execution.",
       "required": false,
       "type": "string",
-      "security_impact": "true/false",
-      "rationale": ""
+      "security_impact": false,
+      "rationale": "Not directly relevant to the approved-region location policy for Dataproc Batch."
     },
     "environment_config.execution_config.ttl": {
       "description": "The duration after which the workload will be terminated.\nWhen the workload exceeds this duration, it will be unconditionally terminated without waiting for ongoing\nwork to finish. If ttl is not specified for a batch workload, the workload will be allowed to run until it\nexits naturally (or run forever without exiting). If ttl is not specified for an interactive session,\nit defaults to 24 hours. If ttl is not specified for a batch that uses 2.1+ runtime version, it defaults to 4 hours.\nMinimum value is 10 minutes; maximum value is 14 days. If both ttl and idleTtl are specified (for an interactive session),\nthe conditions are treated as OR conditions: the workload will be terminated when it has been idle for idleTtl or\nwhen ttl has been exceeded, whichever occurs first.",
       "required": false,
       "type": "string",
-      "security_impact": "true/false",
-      "rationale": ""
+      "security_impact": false,
+      "rationale": "Not directly relevant to the approved-region location policy for Dataproc Batch."
     },
     "environment_config.execution_config.authentication_config": {
       "type": "block",
@@ -105,8 +105,8 @@
       "description": "Authentication type for the user workload running in containers. Possible values: [\"SERVICE_ACCOUNT\", \"END_USER_CREDENTIALS\"]",
       "required": false,
       "type": "string",
-      "security_impact": "true/false",
-      "rationale": ""
+      "security_impact": false,
+      "rationale": "Not directly relevant to the approved-region location policy for Dataproc Batch."
     },
     "environment_config.peripherals_config": {
       "type": "block",
@@ -117,8 +117,8 @@
       "description": "Resource name of an existing Dataproc Metastore service.",
       "required": false,
       "type": "string",
-      "security_impact": "true/false",
-      "rationale": ""
+      "security_impact": false,
+      "rationale": "Not directly relevant to the approved-region location policy for Dataproc Batch."
     },
     "environment_config.peripherals_config.spark_history_server_config": {
       "type": "block",
@@ -129,8 +129,8 @@
       "description": "Resource name of an existing Dataproc Cluster to act as a Spark History Server for the workload.",
       "required": false,
       "type": "string",
-      "security_impact": "true/false",
-      "rationale": ""
+      "security_impact": false,
+      "rationale": "Not directly relevant to the approved-region location policy for Dataproc Batch."
     },
     "pyspark_batch": {
       "type": "block",
@@ -141,43 +141,43 @@
       "description": "HCFS URIs of archives to be extracted into the working directory of each executor.\nSupported file types: .jar, .tar, .tar.gz, .tgz, and .zip.",
       "required": false,
       "type": "list(string)",
-      "security_impact": "true/false",
-      "rationale": ""
+      "security_impact": false,
+      "rationale": "Not directly relevant to the approved-region location policy for Dataproc Batch."
     },
     "pyspark_batch.args": {
       "description": "The arguments to pass to the driver. Do not include arguments that can be set as batch\nproperties, such as --conf, since a collision can occur that causes an incorrect batch submission.",
       "required": false,
       "type": "list(string)",
-      "security_impact": "true/false",
-      "rationale": ""
+      "security_impact": false,
+      "rationale": "Not directly relevant to the approved-region location policy for Dataproc Batch."
     },
     "pyspark_batch.file_uris": {
       "description": "HCFS URIs of files to be placed in the working directory of each executor.",
       "required": false,
       "type": "list(string)",
-      "security_impact": "true/false",
-      "rationale": ""
+      "security_impact": false,
+      "rationale": "Not directly relevant to the approved-region location policy for Dataproc Batch."
     },
     "pyspark_batch.jar_file_uris": {
       "description": "HCFS URIs of jar files to add to the classpath of the Spark driver and tasks.",
       "required": false,
       "type": "list(string)",
-      "security_impact": "true/false",
-      "rationale": ""
+      "security_impact": false,
+      "rationale": "Not directly relevant to the approved-region location policy for Dataproc Batch."
     },
     "pyspark_batch.main_python_file_uri": {
       "description": "The HCFS URI of the main Python file to use as the Spark driver. Must be a .py file.",
       "required": false,
       "type": "string",
-      "security_impact": "true/false",
-      "rationale": ""
+      "security_impact": false,
+      "rationale": "Not directly relevant to the approved-region location policy for Dataproc Batch."
     },
     "pyspark_batch.python_file_uris": {
       "description": "HCFS file URIs of Python files to pass to the PySpark framework.\nSupported file types: .py, .egg, and .zip.",
       "required": false,
       "type": "list(string)",
-      "security_impact": "true/false",
-      "rationale": ""
+      "security_impact": false,
+      "rationale": "Not directly relevant to the approved-region location policy for Dataproc Batch."
     },
     "runtime_config": {
       "type": "block",
@@ -188,29 +188,29 @@
       "description": "Optional. Cohort identifier. Identifies families of the workloads having the same shape, e.g. daily ETL jobs.",
       "required": false,
       "type": "string",
-      "security_impact": "true/false",
-      "rationale": ""
+      "security_impact": false,
+      "rationale": "Not directly relevant to the approved-region location policy for Dataproc Batch."
     },
     "runtime_config.container_image": {
       "description": "Optional custom container image for the job runtime environment. If not specified, a default container image will be used.",
       "required": false,
       "type": "string",
-      "security_impact": "true/false",
-      "rationale": ""
+      "security_impact": false,
+      "rationale": "Not directly relevant to the approved-region location policy for Dataproc Batch."
     },
     "runtime_config.properties": {
       "description": "A mapping of property names to values, which are used to configure workload execution.",
       "required": false,
       "type": "map(string)",
-      "security_impact": "true/false",
-      "rationale": ""
+      "security_impact": false,
+      "rationale": "Not directly relevant to the approved-region location policy for Dataproc Batch."
     },
     "runtime_config.version": {
       "description": "Version of the batch runtime.",
       "required": false,
       "type": "string",
-      "security_impact": "true/false",
-      "rationale": ""
+      "security_impact": false,
+      "rationale": "Not directly relevant to the approved-region location policy for Dataproc Batch."
     },
     "runtime_config.autotuning_config": {
       "type": "block",
@@ -221,8 +221,8 @@
       "description": "Optional. Scenarios for which tunings are applied. Possible values: [\"AUTO\", \"SCALING\", \"BROADCAST_HASH_JOIN\", \"MEMORY\"]",
       "required": false,
       "type": "list(string)",
-      "security_impact": "true/false",
-      "rationale": ""
+      "security_impact": false,
+      "rationale": "Not directly relevant to the approved-region location policy for Dataproc Batch."
     },
     "spark_batch": {
       "type": "block",
@@ -233,43 +233,43 @@
       "description": "HCFS URIs of archives to be extracted into the working directory of each executor.\nSupported file types: .jar, .tar, .tar.gz, .tgz, and .zip.",
       "required": false,
       "type": "list(string)",
-      "security_impact": "true/false",
-      "rationale": ""
+      "security_impact": false,
+      "rationale": "Not directly relevant to the approved-region location policy for Dataproc Batch."
     },
     "spark_batch.args": {
       "description": "The arguments to pass to the driver. Do not include arguments that can be set as batch\nproperties, such as --conf, since a collision can occur that causes an incorrect batch submission.",
       "required": false,
       "type": "list(string)",
-      "security_impact": "true/false",
-      "rationale": ""
+      "security_impact": false,
+      "rationale": "Not directly relevant to the approved-region location policy for Dataproc Batch."
     },
     "spark_batch.file_uris": {
       "description": "HCFS URIs of files to be placed in the working directory of each executor.",
       "required": false,
       "type": "list(string)",
-      "security_impact": "true/false",
-      "rationale": ""
+      "security_impact": false,
+      "rationale": "Not directly relevant to the approved-region location policy for Dataproc Batch."
     },
     "spark_batch.jar_file_uris": {
       "description": "HCFS URIs of jar files to add to the classpath of the Spark driver and tasks.",
       "required": false,
       "type": "list(string)",
-      "security_impact": "true/false",
-      "rationale": ""
+      "security_impact": false,
+      "rationale": "Not directly relevant to the approved-region location policy for Dataproc Batch."
     },
     "spark_batch.main_class": {
       "description": "The name of the driver main class. The jar file that contains the class must be in the\nclasspath or specified in jarFileUris.",
       "required": false,
       "type": "string",
-      "security_impact": "true/false",
-      "rationale": ""
+      "security_impact": false,
+      "rationale": "Not directly relevant to the approved-region location policy for Dataproc Batch."
     },
     "spark_batch.main_jar_file_uri": {
       "description": "The HCFS URI of the jar file that contains the main class.",
       "required": false,
       "type": "string",
-      "security_impact": "true/false",
-      "rationale": ""
+      "security_impact": false,
+      "rationale": "Not directly relevant to the approved-region location policy for Dataproc Batch."
     },
     "spark_r_batch": {
       "type": "block",
@@ -280,29 +280,29 @@
       "description": "HCFS URIs of archives to be extracted into the working directory of each executor.\nSupported file types: .jar, .tar, .tar.gz, .tgz, and .zip.",
       "required": false,
       "type": "list(string)",
-      "security_impact": "true/false",
-      "rationale": ""
+      "security_impact": false,
+      "rationale": "Not directly relevant to the approved-region location policy for Dataproc Batch."
     },
     "spark_r_batch.args": {
       "description": "The arguments to pass to the driver. Do not include arguments that can be set as batch\nproperties, such as --conf, since a collision can occur that causes an incorrect batch submission.",
       "required": false,
       "type": "list(string)",
-      "security_impact": "true/false",
-      "rationale": ""
+      "security_impact": false,
+      "rationale": "Not directly relevant to the approved-region location policy for Dataproc Batch."
     },
     "spark_r_batch.file_uris": {
       "description": "HCFS URIs of files to be placed in the working directory of each executor.",
       "required": false,
       "type": "list(string)",
-      "security_impact": "true/false",
-      "rationale": ""
+      "security_impact": false,
+      "rationale": "Not directly relevant to the approved-region location policy for Dataproc Batch."
     },
     "spark_r_batch.main_r_file_uri": {
       "description": "The HCFS URI of the main R file to use as the driver. Must be a .R or .r file.",
       "required": false,
       "type": "string",
-      "security_impact": "true/false",
-      "rationale": ""
+      "security_impact": false,
+      "rationale": "Not directly relevant to the approved-region location policy for Dataproc Batch."
     },
     "spark_sql_batch": {
       "type": "block",
@@ -313,22 +313,22 @@
       "description": "HCFS URIs of jar files to be added to the Spark CLASSPATH.",
       "required": false,
       "type": "list(string)",
-      "security_impact": "true/false",
-      "rationale": ""
+      "security_impact": false,
+      "rationale": "Not directly relevant to the approved-region location policy for Dataproc Batch."
     },
     "spark_sql_batch.query_file_uri": {
       "description": "The HCFS URI of the script that contains Spark SQL queries to execute.",
       "required": false,
       "type": "string",
-      "security_impact": "true/false",
-      "rationale": ""
+      "security_impact": false,
+      "rationale": "Not directly relevant to the approved-region location policy for Dataproc Batch."
     },
     "spark_sql_batch.query_variables": {
       "description": "Mapping of query variable names to values (equivalent to the Spark SQL command: SET name=\"value\";).",
       "required": false,
       "type": "map(string)",
-      "security_impact": "true/false",
-      "rationale": ""
+      "security_impact": false,
+      "rationale": "Not directly relevant to the approved-region location policy for Dataproc Batch."
     }
   }
 }

--- a/inputs/gcp/Dataproc/google_dataproc_batch/environment_config.execution_config.service_account/compliant.tf
+++ b/inputs/gcp/Dataproc/google_dataproc_batch/environment_config.execution_config.service_account/compliant.tf
@@ -1,0 +1,14 @@
+resource "google_dataproc_batch" "compliant_example_1" {
+  project  = "test-project"
+  location = "australia-southeast1"
+
+  pyspark_batch {
+    main_python_file_uri = "gs://test-bucket/main.py"
+  }
+
+  environment_config {
+    execution_config {
+      service_account = "dataproc-sa@my-project.iam.gserviceaccount.com"
+    }
+  }
+}

--- a/inputs/gcp/Dataproc/google_dataproc_batch/environment_config.execution_config.service_account/config.tf
+++ b/inputs/gcp/Dataproc/google_dataproc_batch/environment_config.execution_config.service_account/config.tf
@@ -1,0 +1,11 @@
+##### DO NOT EDIT ######
+
+terraform {
+  required_providers {
+    google = {
+      source = "hashicorp/google"
+    }
+  }
+}
+
+provider "google" {}

--- a/inputs/gcp/Dataproc/google_dataproc_batch/environment_config.execution_config.service_account/nonCompliant.tf
+++ b/inputs/gcp/Dataproc/google_dataproc_batch/environment_config.execution_config.service_account/nonCompliant.tf
@@ -1,0 +1,13 @@
+resource "google_dataproc_batch" "non_compliant_example_1" {
+  project  = "test-project"
+  location = "australia-southeast1"
+
+  pyspark_batch {
+    main_python_file_uri = "gs://test-bucket/main.py"
+  }
+
+  environment_config {
+    execution_config {
+    }
+  }
+}

--- a/inputs/gcp/Dataproc/google_dataproc_batch/location/compliant.tf
+++ b/inputs/gcp/Dataproc/google_dataproc_batch/location/compliant.tf
@@ -1,0 +1,8 @@
+resource "google_dataproc_batch" "compliant_example_1" {
+  project  = "test-project"
+  location = "australia-southeast1"
+
+  pyspark_batch {
+    main_python_file_uri = "gs://test-bucket/main.py"
+  }
+}

--- a/inputs/gcp/Dataproc/google_dataproc_batch/location/config.tf
+++ b/inputs/gcp/Dataproc/google_dataproc_batch/location/config.tf
@@ -1,0 +1,11 @@
+##### DO NOT EDIT ######
+
+terraform {
+  required_providers {
+    google = {
+      source = "hashicorp/google"
+    }
+  }
+}
+
+provider "google" {}

--- a/inputs/gcp/Dataproc/google_dataproc_batch/location/nonCompliant.tf
+++ b/inputs/gcp/Dataproc/google_dataproc_batch/location/nonCompliant.tf
@@ -1,0 +1,8 @@
+resource "google_dataproc_batch" "non_compliant_example_1" {
+  project  = "test-project"
+  location = "europe-west1"
+
+  pyspark_batch {
+    main_python_file_uri = "gs://test-bucket/main.py"
+  }
+}

--- a/policies/gcp/Dataproc/google_dataproc_batch/_vars.rego
+++ b/policies/gcp/Dataproc/google_dataproc_batch/_vars.rego
@@ -3,5 +3,5 @@ package terraform.gcp.security.dataproc.google_dataproc_batch.vars
 variables := {
     "friendly_resource_name": "Dataproc Batch",
     "resource_type": "google_dataproc_batch",
-    "resource_value_name": "location",
+    "resource_value_name": "name",
 }

--- a/policies/gcp/Dataproc/google_dataproc_batch/_vars.rego
+++ b/policies/gcp/Dataproc/google_dataproc_batch/_vars.rego
@@ -1,0 +1,7 @@
+package terraform.gcp.security.dataproc.google_dataproc_batch.vars
+
+variables := {
+    "friendly_resource_name": "Dataproc Batch",
+    "resource_type": "google_dataproc_batch",
+    "resource_value_name": "location",
+}

--- a/policies/gcp/Dataproc/google_dataproc_batch/environment_config.execution_config.service_account.rego
+++ b/policies/gcp/Dataproc/google_dataproc_batch/environment_config.execution_config.service_account.rego
@@ -1,0 +1,25 @@
+package terraform.gcp.security.dataproc.google_dataproc_batch.environment_config_execution_config_service_account
+
+import data.terraform.helpers
+import data.terraform.gcp.security.dataproc.google_dataproc_batch.vars
+
+conditions := [
+    [
+        {
+            "situation_description": "Dataproc Batch does not specify a dedicated service account, which may result in use of a default identity with overly broad permissions.",
+            "remedies": [
+                "Configure a dedicated service account with least-privilege permissions."
+            ]
+        },
+        {
+            "condition": "A dedicated service account must be configured.",
+            "attribute_path": ["environment_config", 0, "execution_config", 0, "service_account"],
+            "values": [null, ""],
+            "policy_type": "blacklist"
+        }
+    ]
+]
+
+result := helpers.get_multi_summary(conditions, vars.variables)
+message := result.message
+details := result.details

--- a/policies/gcp/Dataproc/google_dataproc_batch/location.rego
+++ b/policies/gcp/Dataproc/google_dataproc_batch/location.rego
@@ -1,0 +1,31 @@
+package terraform.gcp.security.dataproc.google_dataproc_batch.location
+
+import data.terraform.gcp.security.dataproc.google_dataproc_batch.vars
+import data.terraform.helpers
+
+conditions := [
+	[
+		{
+			"situation_description": "Dataproc Batch is deployed outside an approved region.",
+			"remedies": [
+				"Deploy the Dataproc Batch in an approved region.",
+			],
+		},
+		{
+			"condition": "Location must be one of the approved regions.",
+			"attribute_path": ["location"],
+			"values": [
+				"australia-southeast1",
+				"us-central1",
+				"us-east1",
+			],
+			"policy_type": "whitelist",
+		},
+	],
+]
+
+summary := helpers.get_multi_summary(conditions, vars.variables)
+
+message := summary.message
+
+details := summary.details


### PR DESCRIPTION
## Summary

Added the Dataproc Batch location policy.

## Changes

- Added compliant and non-compliant Terraform fixtures for Dataproc Batch location.
- Added Dataproc Batch policy variables.
- Added a location whitelist policy for approved regions:
  - australia-southeast1
  - us-central1
  - us-east1
- Added Terraform configuration for the Google provider.

## Validation

OPA policy check passed.
Automated policy test passed with the non-compliant europe-west1 fixture correctly flagged.