### PR TITLE
Fix folder generator service directory names

### DIFF
--- a/scripts/folder_generator/main.py
+++ b/scripts/folder_generator/main.py
@@ -89,7 +89,7 @@ def copy_files(files, src_dir, dest_dir):
 
 def create_policy_files(cloud, service, resource, policy_name):
     paths = get_cloud_paths(cloud)
-    base_folder = service.replace(" ", "_")
+    base_folder = service
     subfolder = resource
     input_dir = os.path.join(paths["input_dir"], base_folder, subfolder, policy_name)
     policy_dir = os.path.join(paths["policy_dir"], base_folder, subfolder, policy_name)


### PR DESCRIPTION
This PR fixes the folder_generator service directory naming issue.

Previously, service names containing spaces were converted to underscores when creating policy and input folders. For example:

Compute Engine → Compute_Engine

This caused generated folders to not match the existing repository service directory structure.

The fix preserves the original service name when creating folders.

Changes made:

Removed the service.replace(" ", "_") conversion in scripts/folder_generator/main.py
Service directory names now match the names under docs/gcp
Verified the change with Python syntax checking and pre-commit checks

Expected result:

inputs/gcp/Compute Engine/...

policies/gcp/Compute Engine/...

instead of:

inputs/gcp/Compute_Engine/...

policies/gcp/Compute_Engine/...