### PR TITLE
Complete google_privateca_certificate documentation and policies

### DIFF
--- a/docs/gcp/Certificate Authority Service/google_privateca_certificate.json
+++ b/docs/gcp/Certificate Authority Service/google_privateca_certificate.json
@@ -20,8 +20,8 @@
       "description": "Whether Terraform will be prevented from destroying the instance. Defaults to \"DELETE\".\nWhen a 'terraform destroy' or 'terraform apply' would delete the instance,\nthe command will fail if this field is set to \"PREVENT\" in Terraform state.\nWhen set to \"ABANDON\", the command will remove the resource from Terraform\nmanagement without updating or deleting the resource in the API.\nWhen set to \"DELETE\", deleting the resource is allowed.\n",
       "required": false,
       "type": "string",
-      "security_impact": "true/false",
-      "rationale": ""
+      "security_impact": true,
+      "rationale": "This argument controls whether Terraform is permitted to destroy the certificate resource. A generic policy can prevent accidental destruction to preserve certificate records and reduce operational or trust disruption caused by unintended removal."
     },
     "labels": {
       "description": "Labels with user-defined metadata to apply to this resource.\n\n\n**Note**: This field is non-authoritative, and will only manage the labels present in your configuration.\nPlease refer to the field 'effective_labels' for all of the labels present on the resource.",
@@ -228,8 +228,8 @@
       "description": "Indicates whether or not this extension is critical (i.e., if the client does not know how to\nhandle this extension, the client should consider this to be an error).",
       "required": true,
       "type": "bool",
-      "security_impact": "true/false",
-      "rationale": ""
+      "security_impact": false,
+      "rationale": "This argument determines whether clients must reject the certificate when they cannot process the custom X.509 extension. The appropriate setting depends on the meaning and intended enforcement of that specific extension, so a generic policy cannot require all custom extensions to be critical or non-critical."
     },
     "config.x509_config.additional_extensions.value": {
       "description": "The value of this X.509 extension. A base64-encoded string.",
@@ -247,8 +247,8 @@
       "description": "An ObjectId specifies an object identifier (OID). These provide context and describe types in ASN.1 messages.",
       "required": true,
       "type": "list(number)",
-      "security_impact": "true/false",
-      "rationale": ""
+      "security_impact": false,
+      "rationale": "This argument identifies the type and meaning of a custom X.509 extension using an object identifier path. The correct OID depends on the specific extension and its application-defined purpose, so a generic policy cannot prescribe one universally safe value."
     },
     "config.x509_config.ca_options": {
       "type": "block",
@@ -412,8 +412,8 @@
       "description": "An ObjectId specifies an object identifier (OID). These provide context and describe types in ASN.1 messages.",
       "required": true,
       "type": "list(number)",
-      "security_impact": "true/false",
-      "rationale": ""
+      "security_impact": false,
+      "rationale": "This argument specifies a custom extended key usage through an object identifier path. The correct OID depends on the application, protocol and intended certificate purpose, so a generic policy cannot prescribe a universally appropriate value."
     },
     "config.x509_config.name_constraints": {
       "type": "block",
@@ -424,8 +424,8 @@
       "description": "Indicates whether or not the name constraints are marked critical.",
       "required": true,
       "type": "bool",
-      "security_impact": "true/false",
-      "rationale": ""
+      "security_impact": true,
+      "rationale": "This argument determines whether clients must reject a CA certificate when they cannot process its name constraints. A generic policy can require the extension to be critical so namespace restrictions cannot be silently ignored during certificate-path validation, consistent with RFC 5280."
     },
     "config.x509_config.name_constraints.excluded_dns_names": {
       "description": "Contains excluded DNS names. Any DNS name that can be\nconstructed by simply adding zero or more labels to\nthe left-hand side of the name satisfies the name constraint.\nFor example, 'example.com', 'www.example.com', 'www.sub.example.com'\nwould satisfy 'example.com' while 'example1.com' does not.",
@@ -492,8 +492,8 @@
       "description": "An ObjectId specifies an object identifier (OID). These provide context and describe types in ASN.1 messages.",
       "required": true,
       "type": "list(number)",
-      "security_impact": "true/false",
-      "rationale": ""
+      "security_impact": false,
+      "rationale": "This argument identifies an applicable certificate policy using an object identifier path. The correct OID depends on the organisation's certificate policy and assurance framework, so a generic policy cannot prescribe one universally appropriate value."
     }
   }
 }

--- a/inputs/gcp/Certificate Authority Service/google_privateca_certificate/config.x509_config.name_constraints.critical/compliant.tf
+++ b/inputs/gcp/Certificate Authority Service/google_privateca_certificate/config.x509_config.name_constraints.critical/compliant.tf
@@ -1,0 +1,41 @@
+resource "google_privateca_certificate" "compliant_example_1" {
+  name            = "compliant-example-1"
+  pool            = "ca-pool"
+  location        = "us-central1"
+  lifetime        = "86400s"
+  deletion_policy = "PREVENT"
+
+  config {
+    public_key {
+      format = "PEM"
+      key    = local.certificate_public_key
+    }
+    subject_config {
+      subject {
+        organization = "ACME"
+        common_name  = "compliant.example.com"
+      }
+    }
+
+    x509_config {
+      ca_options {
+        is_ca = false
+      }
+      name_constraints {
+        critical            = true
+        permitted_dns_names = ["example.com"]
+      }
+
+      key_usage {
+        base_key_usage {
+          digital_signature = true
+          key_encipherment  = true
+        }
+
+        extended_key_usage {
+          server_auth = true
+        }
+      }
+    }
+  }
+}

--- a/inputs/gcp/Certificate Authority Service/google_privateca_certificate/config.x509_config.name_constraints.critical/config.tf
+++ b/inputs/gcp/Certificate Authority Service/google_privateca_certificate/config.x509_config.name_constraints.critical/config.tf
@@ -1,0 +1,14 @@
+##### DO NOT EDIT ######
+
+terraform {
+  required_providers {
+    google = {
+      source = "hashicorp/google"
+    }
+  }
+}
+
+provider "google" {}
+locals {
+  certificate_public_key = "MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAwiRudjheDltMexXmy7iv2XSH0a8W5/y9X+Q02UuZlDkQRbmZjlTTPLwC6WU1C73JKT/kyMcJAmu0C7ZohqOPsnIuNoR/A9mAhCa3NmuOYK42jnzVCl6ALJCB25dHiCv8P2Mm2aUDqShP/Ua8kkAi8/nC8g5vBV5/d44MyUa+IKwNKW8Q30R3AEYGDn6xNsEielVsAAzYqG2bBz+Dn3xXRq9iIqWwujS2N2lgT8ac1k2uRlNQF8ZvqvAu9xOCfvj3J/yJZrmNUJjtdgRW64dreJqjNkWmKQHRDPdIyQBm1DsRvMGuyMbkGNw50VBDi5aCu6/EXmUH69Gyra1Um1bUpQIDAQAB"
+}

--- a/inputs/gcp/Certificate Authority Service/google_privateca_certificate/config.x509_config.name_constraints.critical/nonCompliant.tf
+++ b/inputs/gcp/Certificate Authority Service/google_privateca_certificate/config.x509_config.name_constraints.critical/nonCompliant.tf
@@ -1,0 +1,41 @@
+resource "google_privateca_certificate" "non_compliant_example_1" {
+  name            = "non-compliant-example-1"
+  pool            = "ca-pool"
+  location        = "us-central1"
+  lifetime        = "86400s"
+  deletion_policy = "PREVENT"
+
+  config {
+    public_key {
+      format = "PEM"
+      key    = local.certificate_public_key
+    }
+    subject_config {
+      subject {
+        organization = "ACME"
+        common_name  = "non-compliant.example.com"
+      }
+    }
+
+    x509_config {
+      ca_options {
+        is_ca = false
+      }
+      name_constraints {
+        critical            = false
+        permitted_dns_names = ["example.com"]
+      }
+
+      key_usage {
+        base_key_usage {
+          digital_signature = true
+          key_encipherment  = true
+        }
+
+        extended_key_usage {
+          server_auth = true
+        }
+      }
+    }
+  }
+}

--- a/inputs/gcp/Certificate Authority Service/google_privateca_certificate/deletion_policy/compliant.tf
+++ b/inputs/gcp/Certificate Authority Service/google_privateca_certificate/deletion_policy/compliant.tf
@@ -1,0 +1,37 @@
+resource "google_privateca_certificate" "compliant_example_1" {
+  name            = "compliant-example-1"
+  pool            = "ca-pool"
+  location        = "us-central1"
+  lifetime        = "86400s"
+  deletion_policy = "PREVENT"
+
+  config {
+    public_key {
+      format = "PEM"
+      key    = local.certificate_public_key
+    }
+    subject_config {
+      subject {
+        organization = "ACME"
+        common_name  = "compliant.example.com"
+      }
+    }
+
+    x509_config {
+      ca_options {
+        is_ca = false
+      }
+
+      key_usage {
+        base_key_usage {
+          digital_signature = true
+          key_encipherment  = true
+        }
+
+        extended_key_usage {
+          server_auth = true
+        }
+      }
+    }
+  }
+}

--- a/inputs/gcp/Certificate Authority Service/google_privateca_certificate/deletion_policy/config.tf
+++ b/inputs/gcp/Certificate Authority Service/google_privateca_certificate/deletion_policy/config.tf
@@ -1,0 +1,14 @@
+##### DO NOT EDIT ######
+
+terraform {
+  required_providers {
+    google = {
+      source = "hashicorp/google"
+    }
+  }
+}
+
+provider "google" {}
+locals {
+  certificate_public_key = "MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAwiRudjheDltMexXmy7iv2XSH0a8W5/y9X+Q02UuZlDkQRbmZjlTTPLwC6WU1C73JKT/kyMcJAmu0C7ZohqOPsnIuNoR/A9mAhCa3NmuOYK42jnzVCl6ALJCB25dHiCv8P2Mm2aUDqShP/Ua8kkAi8/nC8g5vBV5/d44MyUa+IKwNKW8Q30R3AEYGDn6xNsEielVsAAzYqG2bBz+Dn3xXRq9iIqWwujS2N2lgT8ac1k2uRlNQF8ZvqvAu9xOCfvj3J/yJZrmNUJjtdgRW64dreJqjNkWmKQHRDPdIyQBm1DsRvMGuyMbkGNw50VBDi5aCu6/EXmUH69Gyra1Um1bUpQIDAQAB"
+}

--- a/inputs/gcp/Certificate Authority Service/google_privateca_certificate/deletion_policy/nonCompliant.tf
+++ b/inputs/gcp/Certificate Authority Service/google_privateca_certificate/deletion_policy/nonCompliant.tf
@@ -1,0 +1,37 @@
+resource "google_privateca_certificate" "non_compliant_example_1" {
+  name            = "non-compliant-example-1"
+  pool            = "ca-pool"
+  location        = "us-central1"
+  lifetime        = "86400s"
+  deletion_policy = "DELETE"
+
+  config {
+    public_key {
+      format = "PEM"
+      key    = local.certificate_public_key
+    }
+    subject_config {
+      subject {
+        organization = "ACME"
+        common_name  = "non-compliant.example.com"
+      }
+    }
+
+    x509_config {
+      ca_options {
+        is_ca = false
+      }
+
+      key_usage {
+        base_key_usage {
+          digital_signature = true
+          key_encipherment  = true
+        }
+
+        extended_key_usage {
+          server_auth = true
+        }
+      }
+    }
+  }
+}

--- a/inputs/gcp/Certificate Authority Service/google_privateca_certificate/location/compliant.tf
+++ b/inputs/gcp/Certificate Authority Service/google_privateca_certificate/location/compliant.tf
@@ -1,0 +1,41 @@
+resource "google_privateca_certificate" "compliant_example_1" {
+  name            = "compliant-example-1"
+  pool            = "ca-pool"
+  location        = "australia-southeast1"
+  lifetime        = "86400s"
+  deletion_policy = "PREVENT"
+
+  config {
+    public_key {
+      format = "PEM"
+      key    = local.certificate_public_key
+    }
+    subject_config {
+      subject {
+        organization = "ACME"
+        common_name  = "compliant.example.com"
+      }
+    }
+
+    x509_config {
+      ca_options {
+        is_ca = false
+      }
+      name_constraints {
+        critical            = true
+        permitted_dns_names = ["example.com"]
+      }
+
+      key_usage {
+        base_key_usage {
+          digital_signature = true
+          key_encipherment  = true
+        }
+
+        extended_key_usage {
+          server_auth = true
+        }
+      }
+    }
+  }
+}

--- a/inputs/gcp/Certificate Authority Service/google_privateca_certificate/location/config.tf
+++ b/inputs/gcp/Certificate Authority Service/google_privateca_certificate/location/config.tf
@@ -1,0 +1,14 @@
+##### DO NOT EDIT ######
+
+terraform {
+  required_providers {
+    google = {
+      source = "hashicorp/google"
+    }
+  }
+}
+
+provider "google" {}
+locals {
+  certificate_public_key = "MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAwiRudjheDltMexXmy7iv2XSH0a8W5/y9X+Q02UuZlDkQRbmZjlTTPLwC6WU1C73JKT/kyMcJAmu0C7ZohqOPsnIuNoR/A9mAhCa3NmuOYK42jnzVCl6ALJCB25dHiCv8P2Mm2aUDqShP/Ua8kkAi8/nC8g5vBV5/d44MyUa+IKwNKW8Q30R3AEYGDn6xNsEielVsAAzYqG2bBz+Dn3xXRq9iIqWwujS2N2lgT8ac1k2uRlNQF8ZvqvAu9xOCfvj3J/yJZrmNUJjtdgRW64dreJqjNkWmKQHRDPdIyQBm1DsRvMGuyMbkGNw50VBDi5aCu6/EXmUH69Gyra1Um1bUpQIDAQAB"
+}

--- a/inputs/gcp/Certificate Authority Service/google_privateca_certificate/location/nonCompliant.tf
+++ b/inputs/gcp/Certificate Authority Service/google_privateca_certificate/location/nonCompliant.tf
@@ -1,0 +1,41 @@
+resource "google_privateca_certificate" "non_compliant_example_1" {
+  name            = "non-compliant-example-1"
+  pool            = "ca-pool"
+  location        = "us-central1"
+  lifetime        = "86400s"
+  deletion_policy = "PREVENT"
+
+  config {
+    public_key {
+      format = "PEM"
+      key    = local.certificate_public_key
+    }
+    subject_config {
+      subject {
+        organization = "ACME"
+        common_name  = "non-compliant.example.com"
+      }
+    }
+
+    x509_config {
+      ca_options {
+        is_ca = false
+      }
+      name_constraints {
+        critical            = true
+        permitted_dns_names = ["example.com"]
+      }
+
+      key_usage {
+        base_key_usage {
+          digital_signature = true
+          key_encipherment  = true
+        }
+
+        extended_key_usage {
+          server_auth = true
+        }
+      }
+    }
+  }
+}

--- a/policies/gcp/Certificate Authority Service/google_privateca_certificate/_vars.rego
+++ b/policies/gcp/Certificate Authority Service/google_privateca_certificate/_vars.rego
@@ -1,0 +1,7 @@
+package terraform.gcp.security.certificate_authority_service.google_privateca_certificate.vars
+
+variables := {
+    "friendly_resource_name": "Certificate",
+    "resource_type": "google_privateca_certificate",
+    "resource_value_name": "name"
+}

--- a/policies/gcp/Certificate Authority Service/google_privateca_certificate/config.x509_config.name_constraints.critical.rego
+++ b/policies/gcp/Certificate Authority Service/google_privateca_certificate/config.x509_config.name_constraints.critical.rego
@@ -1,0 +1,27 @@
+package terraform.gcp.security.certificate_authority_service.google_privateca_certificate.config_x509_config_name_constraints_critical
+
+import data.terraform.helpers
+import data.terraform.gcp.security.certificate_authority_service.google_privateca_certificate.vars
+
+conditions := [
+    [
+        {
+            "situation_description": "X.509 name constraints must be marked as critical so clients reject certificates when they cannot process the constraints.",
+            "remedies": [
+                "Set config.x509_config.name_constraints.critical to true.",
+                "Marking name constraints as critical ensures that certificate scope restrictions cannot be silently ignored by clients."
+            ]
+        },
+        {
+            "condition": "name_constraints.critical is in approved whitelist",
+            "attribute_path": ["config", 0, "x509_config", 0, "name_constraints", 0, "critical"],
+            "values": [true],
+            "policy_type": "whitelist"
+        }
+    ]
+]
+
+result := helpers.get_multi_summary(conditions, vars.variables)
+
+message := result.message
+details := result.details

--- a/policies/gcp/Certificate Authority Service/google_privateca_certificate/deletion_policy.rego
+++ b/policies/gcp/Certificate Authority Service/google_privateca_certificate/deletion_policy.rego
@@ -1,0 +1,27 @@
+package terraform.gcp.security.certificate_authority_service.google_privateca_certificate.deletion_policy
+
+import data.terraform.helpers
+import data.terraform.gcp.security.certificate_authority_service.google_privateca_certificate.vars
+
+conditions := [
+    [
+        {
+            "situation_description": "Certificate deletion policy must prevent Terraform from destroying the certificate resource.",
+            "remedies": [
+                "Set deletion_policy to PREVENT.",
+                "Using PREVENT blocks accidental Terraform destruction of the managed certificate resource."
+            ]
+        },
+        {
+            "condition": "deletion_policy is in approved whitelist",
+            "attribute_path": ["deletion_policy"],
+            "values": ["PREVENT"],
+            "policy_type": "whitelist"
+        }
+    ]
+]
+
+result := helpers.get_multi_summary(conditions, vars.variables)
+
+message := result.message
+details := result.details

--- a/policies/gcp/Certificate Authority Service/google_privateca_certificate/location.rego
+++ b/policies/gcp/Certificate Authority Service/google_privateca_certificate/location.rego
@@ -1,0 +1,27 @@
+package terraform.gcp.security.certificate_authority_service.google_privateca_certificate.location
+
+import data.terraform.helpers
+import data.terraform.gcp.security.certificate_authority_service.google_privateca_certificate.vars
+
+conditions := [
+    [
+        {
+            "situation_description": "Certificate must be created in an approved geographic region.",
+            "remedies": [
+                "Set location to an approved region such as australia-southeast1 or australia-southeast2.",
+                "Use an approved region to meet organisational data-residency requirements."
+            ]
+        },
+        {
+            "condition": "location is in approved region whitelist",
+            "attribute_path": ["location"],
+            "values": ["australia-southeast1", "australia-southeast2"],
+            "policy_type": "whitelist"
+        }
+    ]
+]
+
+result := helpers.get_multi_summary(conditions, vars.variables)
+
+message := result.message
+details := result.details


### PR DESCRIPTION
## Summary

I completed the remaining 6 leaf argument assessments for `google_privateca_certificate`, including security impact decisions and also the rationales.

 Then added policies and Terraform fixtures for the three security-impacting arguments:

- `deletion_policy`
- `config.x509_config.name_constraints.critical`
- `location`

## Validation

- Confirmed all 59 leaf arguments are documented.
- Three policy tests passed using the targeted auto-test.
- Pre-commit policy/input linter passed.
- Branch naming convention check passed.
- `git diff --cached --check` completed successfully.