### PR TITLE
Add google_privateca_certificate_template security policies

### DIFF
--- a/docs/gcp/Certificate Authority Service/google_privateca_certificate_template.json
+++ b/docs/gcp/Certificate Authority Service/google_privateca_certificate_template.json
@@ -6,8 +6,8 @@
       "description": "Whether Terraform will be prevented from destroying the instance. Defaults to \"DELETE\".\nWhen a 'terraform destroy' or 'terraform apply' would delete the instance,\nthe command will fail if this field is set to \"PREVENT\" in Terraform state.\nWhen set to \"ABANDON\", the command will remove the resource from Terraform\nmanagement without updating or deleting the resource in the API.\nWhen set to \"DELETE\", deleting the resource is allowed.\n",
       "required": false,
       "type": "string",
-      "security_impact": "true/false",
-      "rationale": ""
+      "security_impact": true,
+      "rationale": "Controls whether Terraform can destroy the certificate template. Enforcing PREVENT protects centrally defined certificate issuance constraints from accidental deletion."
     },
     "description": {
       "description": "Optional. A human-readable description of scenarios this template is intended for.",
@@ -79,8 +79,8 @@
       "description": "Optional. Description of the expression. This is a longer text which describes the expression, e.g. when hovered over it in a UI.",
       "required": false,
       "type": "string",
-      "security_impact": "true/false",
-      "rationale": ""
+      "security_impact": false,
+      "rationale": "Human-readable explanatory text for the CEL expression; it does not change expression evaluation or certificate issuance behaviour."
     },
     "identity_constraints.cel_expression.expression": {
       "description": "Textual representation of an expression in Common Expression Language syntax.",
@@ -93,8 +93,8 @@
       "description": "Optional. String indicating the location of the expression for error reporting, e.g. a file name and a position in the file.",
       "required": false,
       "type": "string",
-      "security_impact": "true/false",
-      "rationale": ""
+      "security_impact": false,
+      "rationale": "Diagnostic source-location metadata used for error reporting; it does not affect CEL expression evaluation or certificate issuance controls."
     },
     "identity_constraints.cel_expression.title": {
       "description": "Optional. Title for the expression, i.e. a short string describing its purpose. This can be used e.g. in UIs which allow to enter the expression.",
@@ -124,8 +124,8 @@
       "description": "Required. The parts of an OID path. The most significant parts of the path come first.",
       "required": true,
       "type": "list(number)",
-      "security_impact": "true/false",
-      "rationale": ""
+      "security_impact": false,
+      "rationale": "Identifies an application-specific extension by OID. The correct OID depends on the certificate profile, so no universal platform policy value can be mandated."
     },
     "predefined_values": {
       "type": "block",
@@ -148,8 +148,8 @@
       "description": "Optional. Indicates whether or not this extension is critical (i.e., if the client does not know how to handle this extension, the client should consider this to be an error).",
       "required": false,
       "type": "bool",
-      "security_impact": "true/false",
-      "rationale": ""
+      "security_impact": false,
+      "rationale": "Whether a custom extension should be marked critical depends on the extension's purpose and client compatibility requirements, so no universal setting is appropriate."
     },
     "predefined_values.additional_extensions.value": {
       "description": "Required. The value of this X.509 extension.",
@@ -167,8 +167,8 @@
       "description": "Required. The parts of an OID path. The most significant parts of the path come first.",
       "required": true,
       "type": "list(number)",
-      "security_impact": "true/false",
-      "rationale": ""
+      "security_impact": false,
+      "rationale": "Identifies an application-specific predefined extension by OID. The correct identifier depends on the certificate profile and cannot be universally mandated."
     },
     "predefined_values.ca_options": {
       "type": "block",
@@ -332,8 +332,8 @@
       "description": "Required. The parts of an OID path. The most significant parts of the path come first.",
       "required": true,
       "type": "list(number)",
-      "security_impact": "true/false",
-      "rationale": ""
+      "security_impact": false,
+      "rationale": "Specifies a custom extended key usage through an OID path. The appropriate OID is application-specific and cannot be universally constrained by platform policy."
     },
     "predefined_values.name_constraints": {
       "type": "block",
@@ -344,8 +344,8 @@
       "description": "Indicates whether or not the name constraints are marked critical.",
       "required": true,
       "type": "bool",
-      "security_impact": "true/false",
-      "rationale": ""
+      "security_impact": true,
+"rationale": "Controls whether clients must reject certificates when they cannot process the template's name constraints. Marking the constraints critical prevents issuance-scope restrictions from being silently ignored."
     },
     "predefined_values.name_constraints.excluded_dns_names": {
       "description": "Contains excluded DNS names. Any DNS name that can be\nconstructed by simply adding zero or more labels to\nthe left-hand side of the name satisfies the name constraint.\nFor example, 'example.com', 'www.example.com', 'www.sub.example.com'\nwould satisfy 'example.com' while 'example1.com' does not.",
@@ -412,8 +412,8 @@
       "description": "Required. The parts of an OID path. The most significant parts of the path come first.",
       "required": true,
       "type": "list(number)",
-      "security_impact": "true/false",
-      "rationale": ""
+      "security_impact": false,
+      "rationale": "Identifies an applicable certificate policy through an OID path. The correct OID depends on the organisation's PKI policy and cannot be universally mandated."
     }
   }
 }

--- a/docs/gcp/Certificate Authority Service/google_privateca_certificate_template.json
+++ b/docs/gcp/Certificate Authority Service/google_privateca_certificate_template.json
@@ -148,8 +148,8 @@
       "description": "Optional. Indicates whether or not this extension is critical (i.e., if the client does not know how to handle this extension, the client should consider this to be an error).",
       "required": false,
       "type": "bool",
-      "security_impact": false,
-      "rationale": "Whether a custom extension should be marked critical depends on the extension's purpose and client compatibility requirements, so no universal setting is appropriate."
+      "security_impact": true,
+      "rationale": "Controls whether clients must reject certificates containing an extension they cannot process. Enforcing appropriate critical-extension handling prevents security-relevant extension semantics from being silently ignored."
     },
     "predefined_values.additional_extensions.value": {
       "description": "Required. The value of this X.509 extension.",
@@ -167,8 +167,8 @@
       "description": "Required. The parts of an OID path. The most significant parts of the path come first.",
       "required": true,
       "type": "list(number)",
-      "security_impact": false,
-      "rationale": "Identifies an application-specific predefined extension by OID. The correct identifier depends on the certificate profile and cannot be universally mandated."
+     "security_impact": true,
+    "rationale": "Defines the OID of an additional certificate extension. Restricting permitted OIDs prevents unauthorized or security-sensitive extensions from being embedded in certificates issued from the template."
     },
     "predefined_values.ca_options": {
       "type": "block",

--- a/inputs/gcp/Certificate Authority Service/google_privateca_certificate_template/deletion_policy/compliant.tf
+++ b/inputs/gcp/Certificate Authority Service/google_privateca_certificate_template/deletion_policy/compliant.tf
@@ -1,0 +1,10 @@
+resource "google_privateca_certificate_template" "compliant_example_1" {
+  name            = "compliant-example-1"
+  location        = "australia-southeast1"
+  deletion_policy = "PREVENT"
+
+  identity_constraints {
+    allow_subject_passthrough           = false
+    allow_subject_alt_names_passthrough = false
+  }
+}

--- a/inputs/gcp/Certificate Authority Service/google_privateca_certificate_template/deletion_policy/config.tf
+++ b/inputs/gcp/Certificate Authority Service/google_privateca_certificate_template/deletion_policy/config.tf
@@ -1,0 +1,11 @@
+##### DO NOT EDIT ######
+
+terraform {
+  required_providers {
+    google = {
+      source = "hashicorp/google"
+    }
+  }
+}
+
+provider "google" {}

--- a/inputs/gcp/Certificate Authority Service/google_privateca_certificate_template/deletion_policy/nonCompliant.tf
+++ b/inputs/gcp/Certificate Authority Service/google_privateca_certificate_template/deletion_policy/nonCompliant.tf
@@ -1,0 +1,10 @@
+resource "google_privateca_certificate_template" "non_compliant_example_1" {
+  name            = "non-compliant-example-1"
+  location        = "australia-southeast1"
+  deletion_policy = "DELETE"
+
+  identity_constraints {
+    allow_subject_passthrough           = false
+    allow_subject_alt_names_passthrough = false
+  }
+}

--- a/inputs/gcp/Certificate Authority Service/google_privateca_certificate_template/location/compliant.tf
+++ b/inputs/gcp/Certificate Authority Service/google_privateca_certificate_template/location/compliant.tf
@@ -1,0 +1,10 @@
+resource "google_privateca_certificate_template" "compliant_example_1" {
+  name            = "compliant-example-1"
+  location        = "australia-southeast1"
+  deletion_policy = "PREVENT"
+
+  identity_constraints {
+    allow_subject_passthrough           = false
+    allow_subject_alt_names_passthrough = false
+  }
+}

--- a/inputs/gcp/Certificate Authority Service/google_privateca_certificate_template/location/config.tf
+++ b/inputs/gcp/Certificate Authority Service/google_privateca_certificate_template/location/config.tf
@@ -1,0 +1,11 @@
+##### DO NOT EDIT ######
+
+terraform {
+  required_providers {
+    google = {
+      source = "hashicorp/google"
+    }
+  }
+}
+
+provider "google" {}

--- a/inputs/gcp/Certificate Authority Service/google_privateca_certificate_template/location/nonCompliant.tf
+++ b/inputs/gcp/Certificate Authority Service/google_privateca_certificate_template/location/nonCompliant.tf
@@ -1,0 +1,10 @@
+resource "google_privateca_certificate_template" "non_compliant_example_1" {
+  name            = "non-compliant-example-1"
+  location        = "us-central1"
+  deletion_policy = "PREVENT"
+
+  identity_constraints {
+    allow_subject_passthrough           = false
+    allow_subject_alt_names_passthrough = false
+  }
+}

--- a/inputs/gcp/Certificate Authority Service/google_privateca_certificate_template/predefined_values.additional_extensions.critical/compliant.tf
+++ b/inputs/gcp/Certificate Authority Service/google_privateca_certificate_template/predefined_values.additional_extensions.critical/compliant.tf
@@ -1,0 +1,21 @@
+resource "google_privateca_certificate_template" "compliant_example_1" {
+  name            = "compliant-example-1"
+  location        = "australia-southeast1"
+  deletion_policy = "PREVENT"
+
+  identity_constraints {
+    allow_subject_passthrough           = false
+    allow_subject_alt_names_passthrough = false
+  }
+
+  predefined_values {
+    additional_extensions {
+      object_id {
+        object_id_path = [1, 3, 6, 1, 4, 1, 11129, 2, 5, 1]
+      }
+
+      critical = true
+      value    = "AQ=="
+    }
+  }
+}

--- a/inputs/gcp/Certificate Authority Service/google_privateca_certificate_template/predefined_values.additional_extensions.critical/config.tf
+++ b/inputs/gcp/Certificate Authority Service/google_privateca_certificate_template/predefined_values.additional_extensions.critical/config.tf
@@ -1,0 +1,11 @@
+##### DO NOT EDIT ######
+
+terraform {
+  required_providers {
+    google = {
+      source = "hashicorp/google"
+    }
+  }
+}
+
+provider "google" {}

--- a/inputs/gcp/Certificate Authority Service/google_privateca_certificate_template/predefined_values.additional_extensions.critical/nonCompliant.tf
+++ b/inputs/gcp/Certificate Authority Service/google_privateca_certificate_template/predefined_values.additional_extensions.critical/nonCompliant.tf
@@ -1,0 +1,21 @@
+resource "google_privateca_certificate_template" "non_compliant_example_1" {
+  name            = "non-compliant-example-1"
+  location        = "australia-southeast1"
+  deletion_policy = "PREVENT"
+
+  identity_constraints {
+    allow_subject_passthrough           = false
+    allow_subject_alt_names_passthrough = false
+  }
+
+  predefined_values {
+    additional_extensions {
+      object_id {
+        object_id_path = [1, 3, 6, 1, 4, 1, 11129, 2, 5, 1]
+      }
+
+      critical = false
+      value    = "AQ=="
+    }
+  }
+}

--- a/inputs/gcp/Certificate Authority Service/google_privateca_certificate_template/predefined_values.additional_extensions.object_id.object_id_path/compliant.tf
+++ b/inputs/gcp/Certificate Authority Service/google_privateca_certificate_template/predefined_values.additional_extensions.object_id.object_id_path/compliant.tf
@@ -1,0 +1,21 @@
+resource "google_privateca_certificate_template" "compliant_example_1" {
+  name            = "compliant-example-1"
+  location        = "australia-southeast1"
+  deletion_policy = "PREVENT"
+
+  identity_constraints {
+    allow_subject_passthrough           = false
+    allow_subject_alt_names_passthrough = false
+  }
+
+  predefined_values {
+    additional_extensions {
+      object_id {
+        object_id_path = [1, 3, 6, 1, 4, 1, 11129, 2, 5, 1]
+      }
+
+      critical = true
+      value    = "AQ=="
+    }
+  }
+}

--- a/inputs/gcp/Certificate Authority Service/google_privateca_certificate_template/predefined_values.additional_extensions.object_id.object_id_path/config.tf
+++ b/inputs/gcp/Certificate Authority Service/google_privateca_certificate_template/predefined_values.additional_extensions.object_id.object_id_path/config.tf
@@ -1,0 +1,11 @@
+##### DO NOT EDIT ######
+
+terraform {
+  required_providers {
+    google = {
+      source = "hashicorp/google"
+    }
+  }
+}
+
+provider "google" {}

--- a/inputs/gcp/Certificate Authority Service/google_privateca_certificate_template/predefined_values.additional_extensions.object_id.object_id_path/nonCompliant.tf
+++ b/inputs/gcp/Certificate Authority Service/google_privateca_certificate_template/predefined_values.additional_extensions.object_id.object_id_path/nonCompliant.tf
@@ -1,0 +1,21 @@
+resource "google_privateca_certificate_template" "non_compliant_example_1" {
+  name            = "non-compliant-example-1"
+  location        = "australia-southeast1"
+  deletion_policy = "PREVENT"
+
+  identity_constraints {
+    allow_subject_passthrough           = false
+    allow_subject_alt_names_passthrough = false
+  }
+
+  predefined_values {
+    additional_extensions {
+      object_id {
+        object_id_path = [1, 3, 6, 1, 4, 1, 11129, 2, 5, 99999]
+      }
+
+      critical = true
+      value    = "AQ=="
+    }
+  }
+}

--- a/inputs/gcp/Certificate Authority Service/google_privateca_certificate_template/predefined_values.name_constraints.critical/compliant.tf
+++ b/inputs/gcp/Certificate Authority Service/google_privateca_certificate_template/predefined_values.name_constraints.critical/compliant.tf
@@ -1,0 +1,16 @@
+resource "google_privateca_certificate_template" "compliant_example_1" {
+  name            = "compliant-example-1"
+  location        = "australia-southeast1"
+  deletion_policy = "PREVENT"
+
+  identity_constraints {
+    allow_subject_passthrough           = false
+    allow_subject_alt_names_passthrough = false
+  }
+
+  predefined_values {
+    name_constraints {
+      critical = true
+    }
+  }
+}

--- a/inputs/gcp/Certificate Authority Service/google_privateca_certificate_template/predefined_values.name_constraints.critical/config.tf
+++ b/inputs/gcp/Certificate Authority Service/google_privateca_certificate_template/predefined_values.name_constraints.critical/config.tf
@@ -1,0 +1,11 @@
+##### DO NOT EDIT ######
+
+terraform {
+  required_providers {
+    google = {
+      source = "hashicorp/google"
+    }
+  }
+}
+
+provider "google" {}

--- a/inputs/gcp/Certificate Authority Service/google_privateca_certificate_template/predefined_values.name_constraints.critical/nonCompliant.tf
+++ b/inputs/gcp/Certificate Authority Service/google_privateca_certificate_template/predefined_values.name_constraints.critical/nonCompliant.tf
@@ -1,0 +1,16 @@
+resource "google_privateca_certificate_template" "non_compliant_example_1" {
+  name            = "non-compliant-example-1"
+  location        = "australia-southeast1"
+  deletion_policy = "PREVENT"
+
+  identity_constraints {
+    allow_subject_passthrough           = false
+    allow_subject_alt_names_passthrough = false
+  }
+
+  predefined_values {
+    name_constraints {
+      critical = false
+    }
+  }
+}

--- a/policies/gcp/Certificate Authority Service/google_privateca_certificate_template/_vars.rego
+++ b/policies/gcp/Certificate Authority Service/google_privateca_certificate_template/_vars.rego
@@ -1,0 +1,7 @@
+package terraform.gcp.security.certificate_authority_service.google_privateca_certificate_template.vars
+
+variables := {
+    "friendly_resource_name": "Certificate Template",
+    "resource_type": "google_privateca_certificate_template",
+    "resource_value_name": "name"
+}

--- a/policies/gcp/Certificate Authority Service/google_privateca_certificate_template/deletion_policy.rego
+++ b/policies/gcp/Certificate Authority Service/google_privateca_certificate_template/deletion_policy.rego
@@ -1,0 +1,27 @@
+package terraform.gcp.security.certificate_authority_service.google_privateca_certificate_template.deletion_policy
+
+import data.terraform.helpers
+import data.terraform.gcp.security.certificate_authority_service.google_privateca_certificate_template.vars
+
+conditions := [
+    [
+        {
+            "situation_description": "Certificate template deletion policy must prevent Terraform from destroying the template.",
+            "remedies": [
+                "Set deletion_policy to PREVENT.",
+                "Using PREVENT protects certificate issuance requirements from accidental Terraform destruction."
+            ]
+        },
+        {
+            "condition": "deletion_policy is in approved whitelist",
+            "attribute_path": ["deletion_policy"],
+            "values": ["PREVENT"],
+            "policy_type": "whitelist"
+        }
+    ]
+]
+
+result := helpers.get_multi_summary(conditions, vars.variables)
+
+message := result.message
+details := result.details

--- a/policies/gcp/Certificate Authority Service/google_privateca_certificate_template/location.rego
+++ b/policies/gcp/Certificate Authority Service/google_privateca_certificate_template/location.rego
@@ -1,0 +1,27 @@
+package terraform.gcp.security.certificate_authority_service.google_privateca_certificate_template.location
+
+import data.terraform.helpers
+import data.terraform.gcp.security.certificate_authority_service.google_privateca_certificate_template.vars
+
+conditions := [
+    [
+        {
+            "situation_description": "Certificate template must be created in an approved geographic region.",
+            "remedies": [
+                "Set location to an approved region such as australia-southeast1 or australia-southeast2.",
+                "Use an approved region to meet organisational data-residency requirements."
+            ]
+        },
+        {
+            "condition": "location is in approved region whitelist",
+            "attribute_path": ["location"],
+            "values": ["australia-southeast1", "australia-southeast2"],
+            "policy_type": "whitelist"
+        }
+    ]
+]
+
+result := helpers.get_multi_summary(conditions, vars.variables)
+
+message := result.message
+details := result.details

--- a/policies/gcp/Certificate Authority Service/google_privateca_certificate_template/predefined_values.additional_extensions.critical.rego
+++ b/policies/gcp/Certificate Authority Service/google_privateca_certificate_template/predefined_values.additional_extensions.critical.rego
@@ -1,0 +1,27 @@
+package terraform.gcp.security.certificate_authority_service.google_privateca_certificate_template.predefined_values_additional_extensions_critical
+
+import data.terraform.helpers
+import data.terraform.gcp.security.certificate_authority_service.google_privateca_certificate_template.vars
+
+conditions := [
+    [
+        {
+            "situation_description": "Additional certificate extensions must be marked critical so unsupported security semantics are not silently ignored.",
+            "remedies": [
+                "Set predefined_values.additional_extensions.critical to true.",
+                "Critical extensions require clients to reject certificates when they cannot process the extension."
+            ]
+        },
+        {
+            "condition": "additional extension critical flag is in approved whitelist",
+            "attribute_path": ["predefined_values", 0, "additional_extensions", 0, "critical"],
+            "values": [true],
+            "policy_type": "whitelist"
+        }
+    ]
+]
+
+result := helpers.get_multi_summary(conditions, vars.variables)
+
+message := result.message
+details := result.details

--- a/policies/gcp/Certificate Authority Service/google_privateca_certificate_template/predefined_values.additional_extensions.object_id.object_id_path.rego
+++ b/policies/gcp/Certificate Authority Service/google_privateca_certificate_template/predefined_values.additional_extensions.object_id.object_id_path.rego
@@ -1,0 +1,27 @@
+package terraform.gcp.security.certificate_authority_service.google_privateca_certificate_template.predefined_values_additional_extensions_object_id_object_id_path
+
+import data.terraform.helpers
+import data.terraform.gcp.security.certificate_authority_service.google_privateca_certificate_template.vars
+
+conditions := [
+    [
+        {
+            "situation_description": "Additional certificate extensions must use an approved object identifier.",
+            "remedies": [
+                "Set the additional extension object_id_path to an approved OID.",
+                "Restricting OIDs prevents unauthorized or security-sensitive extensions from being included in issued certificates."
+            ]
+        },
+        {
+            "condition": "additional extension OID is in approved whitelist",
+            "attribute_path": ["predefined_values", 0, "additional_extensions", 0, "object_id", 0, "object_id_path"],
+            "values": [1, 3, 6, 4, 11129, 2, 5],
+            "policy_type": "whitelist"
+        }
+    ]
+]
+
+result := helpers.get_multi_summary(conditions, vars.variables)
+
+message := result.message
+details := result.details

--- a/policies/gcp/Certificate Authority Service/google_privateca_certificate_template/predefined_values.name_constraints.critical.rego
+++ b/policies/gcp/Certificate Authority Service/google_privateca_certificate_template/predefined_values.name_constraints.critical.rego
@@ -1,0 +1,27 @@
+package terraform.gcp.security.certificate_authority_service.google_privateca_certificate_template.predefined_values_name_constraints_critical
+
+import data.terraform.helpers
+import data.terraform.gcp.security.certificate_authority_service.google_privateca_certificate_template.vars
+
+conditions := [
+    [
+        {
+            "situation_description": "Template name constraints must be marked critical so certificate scope restrictions cannot be silently ignored.",
+            "remedies": [
+                "Set predefined_values.name_constraints.critical to true.",
+                "Critical name constraints require clients to reject certificates when they cannot process the restrictions."
+            ]
+        },
+        {
+            "condition": "name constraints critical flag is in approved whitelist",
+            "attribute_path": ["predefined_values", 0, "name_constraints", 0, "critical"],
+            "values": [true],
+            "policy_type": "whitelist"
+        }
+    ]
+]
+
+result := helpers.get_multi_summary(conditions, vars.variables)
+
+message := result.message
+details := result.details


### PR DESCRIPTION
Completed security-impact documentation for all 49 leaf arguments.

Added policies and Terraform fixtures for five security-impacting arguments:

- deletion_policy
- location
- predefined_values.additional_extensions.critical
- predefined_values.additional_extensions.object_id.object_id_path
- predefined_values.name_constraints.critical

Validation:
- All five automated policy tests passed
- Pre-commit checks passed
- Documentation and fixture linter passed