### PR TITLE
Policy-kit linter (policy_lint.py): deterministic rules with ids, changed-files CI gate, rules page

### DIFF
--- a/.github/workflows/policy_check_ALL.yaml
+++ b/.github/workflows/policy_check_ALL.yaml
@@ -47,6 +47,36 @@ jobs:
           chmod +x opa
           sudo mv opa /usr/local/bin/opa
 
+      # Content-quality rules (scripts/linters/policy_lint.py) over every documented
+      # gcp resource — a repo-wide companion to the structural lint above, not a gate:
+      # continue-on-error so a repo-wide content regression never reddens this job.
+      # `--json gcp` is the whole-platform sweep (~11s; needs only OPA, no terraform
+      # plan), so it must run after "Install OPA" above and needs nothing else set up.
+      - name: Policy lint (whole tree, report only)
+        continue-on-error: true
+        run: |
+          python3 scripts/linters/policy_lint.py --json gcp > policy-lint-report.json || true
+          python3 - <<'EOF'
+          import json
+          from collections import Counter
+
+          findings = json.load(open("policy-lint-report.json"))
+          errors = sum(1 for f in findings if f["severity"] == "error")
+          warns = len(findings) - errors
+          print(f"policy_lint (whole tree): {errors} error(s), {warns} warning(s)")
+          for rule, count in sorted(Counter(f["rule"] for f in findings).items()):
+              print(f"  {rule}: {count}")
+          EOF
+
+      - name: Upload policy-lint report artifact
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: policy-lint-report
+          path: policy-lint-report.json
+          retention-days: 90
+          if-no-files-found: warn
+
       # Best-effort provider mirror. The ALL run is designed to execute OFFLINE from
       # the committed plan cache (inputs/plan_cache): when every plan is cached,
       # auto_test skips terraform entirely and this mirror is never touched. So a

--- a/.github/workflows/policy_check_ALL.yaml
+++ b/.github/workflows/policy_check_ALL.yaml
@@ -3,7 +3,7 @@ name: Terraform OPA Policy Check ALL
 on:
   workflow_dispatch:
   # Publish a fresh policy-results artifact on every push to dev so the
-  # AutoCapstone backend can consume the latest verdicts.
+  # PDE Portal backend can consume the latest verdicts.
   push:
     branches:
       - dev
@@ -108,7 +108,7 @@ jobs:
             --report policy_results.json \
             --verbose
 
-      # Publish the machine-readable verdicts for the AutoCapstone backend. Runs
+      # Publish the machine-readable verdicts for the PDE Portal backend. Runs
       # even when the policy checks failed (the report is written first), under a
       # stable name so consumers can always fetch the latest.
       - name: Upload policy results artifact

--- a/.github/workflows/policy_check_PR.yaml
+++ b/.github/workflows/policy_check_PR.yaml
@@ -56,6 +56,17 @@ jobs:
       - name: Structural lint (whole tree)
         run: python3 scripts/linters/linter.py --tree all --platform gcp --no-content-checks
 
+      # run_precommit_linter.py also runs policy_lint.py (content-quality rules,
+      # e.g. hard-coded values, fixture drift) over the resource types this PR
+      # touches, which needs `opa eval` on PATH.
+      - name: Install OPA
+        env:
+          OPA_VERSION: ${{ env.OPA_VERSION }}
+        run: |
+          curl -L -o opa "https://openpolicyagent.org/downloads/${OPA_VERSION}/opa_linux_amd64_static"
+          chmod +x opa
+          sudo mv opa /usr/local/bin/opa
+
       # PR gate: structural + content checks (content is on by default), but only
       # fail on files this PR changed vs its base branch — never the repo-wide tree.
       - name: Lint changed files (structural + content)

--- a/.gitignore
+++ b/.gitignore
@@ -158,6 +158,6 @@ docs/gcp/_changes/
 # folder_generator local user state (per-user UI selection, never committed)
 scripts/folder_generator/cache/
 
-# auto_test --report output: a CI build artifact for the AutoCapstone backend,
+# auto_test --report output: a CI build artifact for the PDE Portal backend,
 # published via actions/upload-artifact — never committed to the repo.
 policy_results.json

--- a/Guide/Policy_writing_tutorial/policy-lint.md
+++ b/Guide/Policy_writing_tutorial/policy-lint.md
@@ -100,9 +100,17 @@ looks at the **last** segment.
 ## presence-only
 
 `values` is only `null`/`""` under a `blacklist`/`whitelist` `policy_type`: the check tests
-nothing but whether the attribute is set at all. That's sometimes genuinely the intent (e.g. "an
-override must not be configured") — pair it with a real pattern where you can, or say why
-presence alone is the right check in the argument's `rationale` in `docs/`.
+nothing but whether the attribute is set at all.
+
+**This is a warning, and it does not fail your build.** Sometimes presence really is the control
+(e.g. "an override must not be configured at all"), and sometimes it is a check that gave up
+halfway. Which one it is depends on what the argument's `rationale` in `docs/` says the risk is —
+a judgement the reviewer makes when reading your policy, not something the linter can settle. So
+write the rationale honestly and expect to be asked about it: the finding is surfaced to whoever
+reviews the resource, and a clear rationale is what turns it from a question into a decision.
+
+Where the attribute has a *shape* — a prefix, a project path, an approved value — pair the
+presence check with a pattern instead. That is a stronger policy in every case.
 
 Bad:
 
@@ -148,11 +156,61 @@ Good:
 ## fixture-drift
 
 `compliant.tf` and `nonCompliant.tf` differ on an attribute **other than** the one under test.
-The whole point of the pair is to isolate a single variable; drift on anything else means the
-test isn't proving what you think it's proving (or the pipeline computed a plan diff that means
-something else entirely). Fix it by making every other attribute identical between the two
-files — only the tested argument (and expected provider-computed mirrors like `labels`) should
-differ.
+The whole point of the pair is to isolate a single variable: if two things differ and the policy
+flags the non-compliant resource, you cannot tell which of the two the policy actually caught.
+Fix it by making every other attribute identical between the two files.
+
+Bad — `public_access_prevention.rego`, but `storage_class` moved too:
+
+    # compliant.tf
+    resource "google_storage_bucket" "compliant_example_1" {
+      name                     = "compliant_example_1"
+      location                 = "AU"
+      storage_class            = "STANDARD"
+      public_access_prevention = "enforced"
+    }
+
+    # nonCompliant.tf
+    resource "google_storage_bucket" "non_compliant_example_1" {
+      name                     = "non_compliant_example_1"
+      location                 = "AU"
+      storage_class            = "NEARLINE"     # <- unrelated to the policy
+      public_access_prevention = "inherited"
+    }
+
+Good — only the tested argument differs:
+
+    # nonCompliant.tf
+    resource "google_storage_bucket" "non_compliant_example_1" {
+      name                     = "non_compliant_example_1"
+      location                 = "AU"
+      storage_class            = "STANDARD"
+      public_access_prevention = "inherited"
+    }
+
+These keys are expected to differ and are never reported:
+
+- `name` — the example's own label.
+- `labels`, and the provider-computed mirrors `effective_labels` and `terraform_labels`, which
+  always move with it.
+- the argument under test (for a nested argument, its top-level block).
+- the attribute named by `resource_value_name` in `_vars.rego` — **but only when it holds the
+  example label itself** (`bucket = "compliant_example_1"`). Two genuinely different values there
+  (`bucket = "prod-data-bucket"` vs `"dev-scratch-bucket"`) are drift like any other.
+
+## fixture-unpaired
+
+An example has no counterpart with the same number: a `non_compliant_example_2` with no
+`compliant_example_2`, or the other way round. The harness compares the two halves of each
+numbered pair, so a lone example is never compared to anything — it looks like extra coverage but
+tests nothing.
+
+Either add the missing half with the same number, or renumber so every example is one half of a
+pair:
+
+    # compliant.tf                        # nonCompliant.tf
+    ..."compliant_example_1" { ... }      ..."non_compliant_example_1" { ... }
+    ..."compliant_example_2" { ... }      ..."non_compliant_example_2" { ... }
 
 ## fixture-missing-plan
 

--- a/Guide/Policy_writing_tutorial/policy-lint.md
+++ b/Guide/Policy_writing_tutorial/policy-lint.md
@@ -1,0 +1,273 @@
+<a id="top"></a>
+<h1 align="center">policy_lint — content-quality rules</h1>
+
+> `linter.py` (the previous page) checks that `docs/`, `inputs/` and `policies/` **reconcile** —
+> every documented argument has a policy, a fixture pair, and the right file names. It says
+> nothing about whether the policy you wrote is any good. **`policy_lint.py`** reads the
+> `conditions` you declared in your `<argument>.rego` and the `variables` in your `_vars.rego`,
+> and reports the smells a reviewer would otherwise have to find by hand — a hard-coded project
+> id, a check that only tests presence, a fixture pair that drifted, and so on.
+
+Every rule below has a stable id, so a finding can be quoted, fixed, and the id searched for in
+this page.
+
+---
+
+## How to run it
+
+    # One resource
+    python3 scripts/linters/policy_lint.py "gcp/<Service>/<resource type>"
+
+    # The whole service
+    python3 scripts/linters/policy_lint.py "gcp/<Service>"
+
+    # The whole platform
+    python3 scripts/linters/policy_lint.py gcp
+
+    # Machine-readable output
+    python3 scripts/linters/policy_lint.py --json "gcp/<Service>/<resource type>"
+
+    # Every rule id and its one-liner
+    python3 scripts/linters/policy_lint.py --list-rules
+
+Exit code is `1` when any **error**-severity finding is reported, `0` otherwise — warnings never
+fail a run on their own.
+
+You do not need to run it separately as part of your normal workflow: `pre-commit` and the PR
+lint job (`run_precommit_linter.py`) both run it automatically, scoped to the resource type(s)
+your changed files belong to. See [Testing your policies](testing-policies.md#top) for the rest
+of the local test loop.
+
+---
+
+## The rules
+
+Each rule below is its own anchored section (`policy-lint.md#<rule-id>`) — the portal links a
+finding straight to it.
+
+## hard-coded-value
+
+A value in `values` is a team-specific literal (project id, email address, bucket/key/folder
+URI, org/folder id). These belong to whoever deploys the policy, not to the policy itself —
+hard-coding one means the policy only ever passes for your project. Use a `projects/*` pattern
+(or a structural check) instead. Location values (`location`, `region`, `zone`, ...) are exempt —
+naming a specific location is usually the point of that argument.
+
+Bad:
+
+    {
+      "attribute_path": ["labels", "owner"],
+      "values": ["projects/my-real-project/locations/us"],
+      "policy_type": "whitelist"
+    }
+
+Good:
+
+    {
+      "attribute_path": ["labels", "owner"],
+      "values": ["projects/*/locations/*"],
+      "policy_type": "pattern whitelist"
+    }
+
+## index-path
+
+`attribute_path` ends in a bare list index (e.g. `["allowed_ips", 0]`). That checks only the
+first element of an array and silently ignores the rest — use `element blacklist` (or
+`element whitelist`) to check the whole list instead.
+
+Bad:
+
+    {
+      "attribute_path": ["allowed_ips", 0],
+      "values": ["0.0.0.0/0"],
+      "policy_type": "blacklist"
+    }
+
+Good:
+
+    {
+      "attribute_path": ["allowed_ips"],
+      "values": ["0.0.0.0/0"],
+      "policy_type": "element blacklist"
+    }
+
+A path that only passes *through* an index (e.g. `["rsa", 0, "key"]`) is fine — this rule only
+looks at the **last** segment.
+
+## presence-only
+
+`values` is only `null`/`""` under a `blacklist`/`whitelist` `policy_type`: the check tests
+nothing but whether the attribute is set at all. That's sometimes genuinely the intent (e.g. "an
+override must not be configured") — pair it with a real pattern where you can, or say why
+presence alone is the right check in the argument's `rationale` in `docs/`.
+
+Bad:
+
+    {
+      "condition": "override is set",
+      "attribute_path": ["override"],
+      "values": [null],
+      "policy_type": "blacklist"
+    }
+
+Good — paired with a pattern:
+
+    {
+      "condition": "override is set to something other than the approved value",
+      "attribute_path": ["override"],
+      "values": ["approved-*", [["approved-", "*"]]],
+      "policy_type": "pattern blacklist"
+    }
+
+## wrong-argument
+
+No condition in `<argument>.rego` reads the argument the file is named after — usually a
+copy-paste from another resource's policy where the `attribute_path` never got updated.
+`policy_lint` checks each condition group's `attribute_path` against the filename stem, so
+`location.rego` must contain at least one condition whose path starts with `location`.
+
+Bad — file is `location.rego`, but the condition reads `region`:
+
+    {
+      "attribute_path": ["region"],
+      "values": ["australia-southeast1"],
+      "policy_type": "whitelist"
+    }
+
+Good:
+
+    {
+      "attribute_path": ["location"],
+      "values": ["australia-southeast1"],
+      "policy_type": "whitelist"
+    }
+
+## fixture-drift
+
+`compliant.tf` and `nonCompliant.tf` differ on an attribute **other than** the one under test.
+The whole point of the pair is to isolate a single variable; drift on anything else means the
+test isn't proving what you think it's proving (or the pipeline computed a plan diff that means
+something else entirely). Fix it by making every other attribute identical between the two
+files — only the tested argument (and expected provider-computed mirrors like `labels`) should
+differ.
+
+## fixture-missing-plan
+
+There's no committed plan cache for this fixture pair at `inputs/plan_cache/gcp/<sha>.json`. Run
+the test harness locally and commit what it produces:
+
+    python3 scripts/auto_test/auto_test.py "gcp/<Service>/<resource type>"
+    git add inputs/plan_cache/
+
+See [Testing your policies](testing-policies.md#top) for the full local test loop.
+
+## vars-resource-type
+
+`_vars.rego`'s `resource_type` doesn't match the directory it lives in. The pipeline matches a
+planned Terraform resource to a policy set by exact `resource_type` string — get this wrong and
+your policy never runs against anything, and every fixture test passes for the wrong reason (no
+resource ever matched).
+
+Bad — directory is `google_bigquery_dataset/`, but:
+
+    variables := {
+        "friendly_resource_name": "BigQuery Dataset",
+        "resource_type": "google_bigquery_table",
+        "resource_value_name": "dataset_id"
+    }
+
+Good:
+
+    variables := {
+        "friendly_resource_name": "BigQuery Dataset",
+        "resource_type": "google_bigquery_dataset",
+        "resource_value_name": "dataset_id"
+    }
+
+## vars-friendly-name
+
+`friendly_resource_name` is empty, is literally the raw Terraform type (not the name a human
+would say), or is already used by a different resource type elsewhere in the platform (violation
+messages would then be ambiguous about which resource they're about).
+
+Bad:
+
+    "friendly_resource_name": "google_bigquery_dataset"   # same as resource_type
+
+Good:
+
+    "friendly_resource_name": "BigQuery Dataset"
+
+## trivial-message
+
+`situation_description` is under 20 characters, or `remedies` is empty. Both are shown to the
+person whose Terraform failed the policy — a description like `"Bad config"` or an empty
+`remedies` list tells them nothing about what to fix.
+
+Bad:
+
+    {"situation_description": "Bad config", "remedies": []}
+
+Good:
+
+    {
+      "situation_description": "Dataset location is not the approved region",
+      "remedies": ["Set location to australia-southeast1"]
+    }
+
+## legacy-assign
+
+`message`, `details` or `summary` assigned with `=` instead of `:=`. Both work in Rego, but `:=`
+is the convention this codebase uses everywhere else — a warning only, it never fails a build.
+
+Bad: `message = helpers.get_multi_summary(conditions, vars.variables).message`
+
+Good: `message := helpers.get_multi_summary(conditions, vars.variables).message`
+
+## package-case
+
+The package's service segment isn't lowercase `snake_case`. This is advisory only — plenty of
+existing packages use the service folder name verbatim (e.g. `BigQuery`), which this rule flags
+but never blocks on.
+
+    package terraform.gcp.security.BigQuery.google_bigquery_dataset.location   # flagged (warn)
+    package terraform.gcp.security.big_query.google_bigquery_dataset.location  # preferred
+
+---
+
+## Your branch must not modify the shared harness or linter
+
+`scripts/**` and `policies/_helpers/**` are the shared test harness, linter and Rego helper
+library every resource's policy runs against. When the portal scans your branch, it pulls
+**those two paths from `dev`**, not from your branch — so editing them locally does nothing to
+what the portal actually checks you against, and can make your local run diverge from what CI
+sees.
+
+If the portal reports `linter-out-of-date` or `harness-out-of-date`, your branch is behind `dev`
+on one of those paths. Fix it by merging `dev` in, not by hand-editing the harness:
+
+    git fetch origin dev
+    git merge origin/dev
+
+If you believe the harness or linter itself needs to change (a missing rule, a bug in
+`policy_lint.py`), raise it with a senior team member rather than editing it on a resource
+branch.
+
+---
+
+## The whole-tree report is for maintainers, not for you
+
+CI also runs `policy_lint.py` over **every** documented `gcp` resource on every push to `dev`
+(`Policy lint (whole tree, report only)` in the `ALL` workflow) and publishes the JSON as a build
+artifact. That run is `continue-on-error` and exists so maintainers can track the repo-wide
+backlog over time — it is not a gate. Pre-existing findings elsewhere on `dev` are never held
+against you: your PR only fails on findings inside the `.rego` file (or fixture pair) **you**
+changed, exactly like the structural linter on the previous page.
+
+<div align="center">
+
+[⬅️ Previous: Testing your policies](testing-policies.md#top) &nbsp;&nbsp;&nbsp; | &nbsp;&nbsp;&nbsp;
+[📘 Back to Contents](policy-writing-tutorial.md#top) &nbsp;&nbsp;&nbsp; | &nbsp;&nbsp;&nbsp;
+[Next: Raising a pull request ➡️](raising-pull-request.md#top)
+
+</div>

--- a/Guide/Policy_writing_tutorial/policy-lint.md
+++ b/Guide/Policy_writing_tutorial/policy-lint.md
@@ -30,8 +30,11 @@ this page.
     # Every rule id and its one-liner
     python3 scripts/linters/policy_lint.py --list-rules
 
-Exit code is `1` when any **error**-severity finding is reported, `0` otherwise — warnings never
-fail a run on their own.
+Exit code is `1` when any **error**-severity finding is reported and `0` otherwise — warnings
+never fail a run on their own. Exit code `2` means the *target* was wrong: a platform, service
+folder or resource type spelled in a way that doesn't exist in the tree. That is a typo in your
+command, not a finding about your policy — check the spelling (service folders have spaces and
+capitals, e.g. `"gcp/Cloud Storage/google_storage_bucket"`) and run it again.
 
 You do not need to run it separately as part of your normal workflow: `pre-commit` and the PR
 lint job (`run_precommit_linter.py`) both run it automatically, scoped to the resource type(s)
@@ -232,6 +235,21 @@ but never blocks on.
 
     package terraform.gcp.security.BigQuery.google_bigquery_dataset.location   # flagged (warn)
     package terraform.gcp.security.big_query.google_bigquery_dataset.location  # preferred
+
+## lint-error
+
+The linter could not evaluate this policy at all — the file failed to parse, or it declares no
+`conditions` list for the linter to read. Every other rule needs those conditions, so this
+finding means the policy was **not checked**, not that it passed.
+
+The message carries the reason OPA gave. Run `opa check` on the file to see it in full:
+
+    opa check policies/_helpers "policies/gcp/<Service>/<resource type>/<argument>.rego"
+
+Fix the parse error (or add the missing `conditions := [...]`) and re-run the linter. If the file
+looks fine to you and the error persists, ask in the unit channel before changing anything else —
+this one is usually a stray bracket or a missing `:=`, and it is much easier to spot with a
+second pair of eyes than to guess at.
 
 ---
 

--- a/Guide/Policy_writing_tutorial/policy-writing-tutorial.md
+++ b/Guide/Policy_writing_tutorial/policy-writing-tutorial.md
@@ -21,6 +21,7 @@
 <a href="vars-rego.md">_vars.rego</a><br>
 <a href="policy-rego.md">policy.rego</a><br>
 <a href="testing-policies.md">Testing your policies</a><br>
+<a href="policy-lint.md">policy_lint — content-quality rules</a><br>
 <a href="raising-pull-request.md">Raising a Pull Request</a><br>
 <a href="general-workflow.md">General work flow</a>
 

--- a/Guide/Policy_writing_tutorial/raising-pull-request.md
+++ b/Guide/Policy_writing_tutorial/raising-pull-request.md
@@ -64,6 +64,7 @@ Example:
 
 <div align="center">
 
+[⬅️ Previous: policy_lint — content-quality rules](policy-lint.md#top) &nbsp;&nbsp;&nbsp; | &nbsp;&nbsp;&nbsp;
 [📘 Back to Contents](policy-writing-tutorial.md#top) &nbsp;&nbsp;&nbsp;  &nbsp;&nbsp;&nbsp;
 
 </div>

--- a/Guide/Policy_writing_tutorial/testing-policies.md
+++ b/Guide/Policy_writing_tutorial/testing-policies.md
@@ -42,6 +42,6 @@ if you are having trouble with this section please return to [Common Errors](com
 
 [⬅️ Previous: policy.rego](policy-rego.md#top) &nbsp;&nbsp;&nbsp; | &nbsp;&nbsp;&nbsp;
 [📘 Back to Contents](policy-writing-tutorial.md#top) &nbsp;&nbsp;&nbsp; | &nbsp;&nbsp;&nbsp;
-[Next: Raising a pull request ➡️](raising-pull-request.md#top) 
+[Next: policy_lint — content-quality rules ➡️](policy-lint.md#top) 
 
 </div>

--- a/scripts/linters/_tests/fixtures/broken/docs/gcp/Cloud Platform/google_broken_thing.json
+++ b/scripts/linters/_tests/fixtures/broken/docs/gcp/Cloud Platform/google_broken_thing.json
@@ -1,0 +1,5 @@
+{
+  "last_updated": "2026-08-30T00:00:00Z",
+  "provider_version": "7.37.0",
+  "arguments": {}
+}

--- a/scripts/linters/_tests/fixtures/broken/inputs/gcp/Cloud Platform/google_broken_thing/good/compliant.tf
+++ b/scripts/linters/_tests/fixtures/broken/inputs/gcp/Cloud Platform/google_broken_thing/good/compliant.tf
@@ -1,0 +1,4 @@
+resource "google_broken_thing" "compliant_example_1" {
+  name = "compliant_example_1"
+  good = "approved"
+}

--- a/scripts/linters/_tests/fixtures/broken/inputs/gcp/Cloud Platform/google_broken_thing/good/config.tf
+++ b/scripts/linters/_tests/fixtures/broken/inputs/gcp/Cloud Platform/google_broken_thing/good/config.tf
@@ -1,0 +1,11 @@
+##### DO NOT EDIT ######
+
+terraform {
+  required_providers {
+    google = {
+      source  = "hashicorp/google"
+    }
+  }
+}
+
+provider "google" {}

--- a/scripts/linters/_tests/fixtures/broken/inputs/gcp/Cloud Platform/google_broken_thing/good/nonCompliant.tf
+++ b/scripts/linters/_tests/fixtures/broken/inputs/gcp/Cloud Platform/google_broken_thing/good/nonCompliant.tf
@@ -1,0 +1,4 @@
+resource "google_broken_thing" "non_compliant_example_1" {
+  name = "non_compliant_example_1"
+  good = "whatever"
+}

--- a/scripts/linters/_tests/fixtures/broken/inputs/gcp/Cloud Platform/google_broken_thing/noconditions/compliant.tf
+++ b/scripts/linters/_tests/fixtures/broken/inputs/gcp/Cloud Platform/google_broken_thing/noconditions/compliant.tf
@@ -1,0 +1,4 @@
+resource "google_broken_thing" "compliant_example_1" {
+  name         = "compliant_example_1"
+  noconditions = "approved"
+}

--- a/scripts/linters/_tests/fixtures/broken/inputs/gcp/Cloud Platform/google_broken_thing/noconditions/config.tf
+++ b/scripts/linters/_tests/fixtures/broken/inputs/gcp/Cloud Platform/google_broken_thing/noconditions/config.tf
@@ -1,0 +1,11 @@
+##### DO NOT EDIT ######
+
+terraform {
+  required_providers {
+    google = {
+      source  = "hashicorp/google"
+    }
+  }
+}
+
+provider "google" {}

--- a/scripts/linters/_tests/fixtures/broken/inputs/gcp/Cloud Platform/google_broken_thing/noconditions/nonCompliant.tf
+++ b/scripts/linters/_tests/fixtures/broken/inputs/gcp/Cloud Platform/google_broken_thing/noconditions/nonCompliant.tf
@@ -1,0 +1,4 @@
+resource "google_broken_thing" "non_compliant_example_1" {
+  name         = "non_compliant_example_1"
+  noconditions = "whatever"
+}

--- a/scripts/linters/_tests/fixtures/broken/policies/gcp/Cloud Platform/google_broken_thing/broken.rego
+++ b/scripts/linters/_tests/fixtures/broken/policies/gcp/Cloud Platform/google_broken_thing/broken.rego
@@ -1,0 +1,3 @@
+package terraform.gcp.security.cloud_platform_service.google_broken_thing.broken
+
+conditions := [[[[

--- a/scripts/linters/_tests/fixtures/broken/policies/gcp/Cloud Platform/google_broken_thing/good.rego
+++ b/scripts/linters/_tests/fixtures/broken/policies/gcp/Cloud Platform/google_broken_thing/good.rego
@@ -1,0 +1,14 @@
+package terraform.gcp.security.cloud_platform_service.google_broken_thing.good
+
+import data.terraform.helpers
+
+conditions := [
+  [
+    {"situation_description": "Good argument is set to an unapproved value.",
+     "remedies": ["Set good to 'approved'."]},
+    {"condition": "Good must be approved",
+     "attribute_path": ["good"],
+     "values": ["approved"],
+     "policy_type": "whitelist"}
+  ]
+]

--- a/scripts/linters/_tests/fixtures/broken/policies/gcp/Cloud Platform/google_broken_thing/noconditions.rego
+++ b/scripts/linters/_tests/fixtures/broken/policies/gcp/Cloud Platform/google_broken_thing/noconditions.rego
@@ -1,0 +1,4 @@
+package terraform.gcp.security.cloud_platform_service.google_broken_thing.noconditions
+
+# Declares no `conditions` at all — the kit is incomplete, not merely clean.
+placeholder := true

--- a/scripts/linters/_tests/fixtures/clean/docs/gcp/Cloud Storage/google_storage_bucket.json
+++ b/scripts/linters/_tests/fixtures/clean/docs/gcp/Cloud Storage/google_storage_bucket.json
@@ -1,0 +1,13 @@
+{
+  "last_updated": "2026-08-30T00:00:00Z",
+  "provider_version": "7.37.0",
+  "arguments": {
+    "public_access_prevention": {
+      "description": "Fixture argument.",
+      "required": false,
+      "type": "string",
+      "security_impact": true,
+      "rationale": "Fixture."
+    }
+  }
+}

--- a/scripts/linters/_tests/fixtures/clean/inputs/gcp/Cloud Storage/google_storage_bucket/public_access_prevention/compliant.tf
+++ b/scripts/linters/_tests/fixtures/clean/inputs/gcp/Cloud Storage/google_storage_bucket/public_access_prevention/compliant.tf
@@ -1,0 +1,5 @@
+resource "google_storage_bucket" "compliant_example_1" {
+  name                     = "compliant_example_1"
+  location                 = "AU"
+  public_access_prevention = "enforced"
+}

--- a/scripts/linters/_tests/fixtures/clean/inputs/gcp/Cloud Storage/google_storage_bucket/public_access_prevention/config.tf
+++ b/scripts/linters/_tests/fixtures/clean/inputs/gcp/Cloud Storage/google_storage_bucket/public_access_prevention/config.tf
@@ -1,0 +1,11 @@
+##### DO NOT EDIT ######
+
+terraform {
+  required_providers {
+    google = {
+      source  = "hashicorp/google"
+    }
+  }
+}
+
+provider "google" {}

--- a/scripts/linters/_tests/fixtures/clean/inputs/gcp/Cloud Storage/google_storage_bucket/public_access_prevention/expected_plan.json
+++ b/scripts/linters/_tests/fixtures/clean/inputs/gcp/Cloud Storage/google_storage_bucket/public_access_prevention/expected_plan.json
@@ -1,0 +1,355 @@
+{
+  "format_version": "1.2",
+  "terraform_version": "1.15.7",
+  "planned_values": {
+    "root_module": {
+      "resources": [
+        {
+          "address": "google_storage_bucket.compliant_example_1",
+          "mode": "managed",
+          "type": "google_storage_bucket",
+          "name": "compliant_example_1",
+          "provider_name": "registry.terraform.io/hashicorp/google",
+          "schema_version": 4,
+          "values": {
+            "autoclass": [],
+            "cors": [],
+            "custom_placement_config": [],
+            "default_event_based_hold": null,
+            "deletion_policy": "DELETE",
+            "effective_labels": {
+              "goog-terraform-provisioned": "true"
+            },
+            "enable_object_retention": null,
+            "encryption": [],
+            "force_destroy": false,
+            "hierarchical_namespace": [],
+            "ip_filter": [],
+            "labels": null,
+            "lifecycle_rule": [],
+            "location": "AU",
+            "logging": [],
+            "name": "compliant_example_1",
+            "public_access_prevention": "enforced",
+            "requester_pays": null,
+            "retention_policy": [],
+            "storage_class": "STANDARD",
+            "terraform_labels": {
+              "goog-terraform-provisioned": "true"
+            },
+            "timeouts": null
+          },
+          "sensitive_values": {
+            "autoclass": [],
+            "cors": [],
+            "custom_placement_config": [],
+            "effective_labels": {},
+            "encryption": [],
+            "hierarchical_namespace": [],
+            "ip_filter": [],
+            "lifecycle_rule": [],
+            "logging": [],
+            "retention_policy": [],
+            "soft_delete_policy": [],
+            "terraform_labels": {},
+            "versioning": [],
+            "website": []
+          },
+          "identity_schema_version": 1,
+          "identity": {
+            "name": null,
+            "project": null
+          }
+        },
+        {
+          "address": "google_storage_bucket.non_compliant_example_1",
+          "mode": "managed",
+          "type": "google_storage_bucket",
+          "name": "non_compliant_example_1",
+          "provider_name": "registry.terraform.io/hashicorp/google",
+          "schema_version": 4,
+          "values": {
+            "autoclass": [],
+            "cors": [],
+            "custom_placement_config": [],
+            "default_event_based_hold": null,
+            "deletion_policy": "DELETE",
+            "effective_labels": {
+              "goog-terraform-provisioned": "true"
+            },
+            "enable_object_retention": null,
+            "encryption": [],
+            "force_destroy": false,
+            "hierarchical_namespace": [],
+            "ip_filter": [],
+            "labels": null,
+            "lifecycle_rule": [],
+            "location": "AU",
+            "logging": [],
+            "name": "non_compliant_example_1",
+            "public_access_prevention": "inherited",
+            "requester_pays": null,
+            "retention_policy": [],
+            "storage_class": "STANDARD",
+            "terraform_labels": {
+              "goog-terraform-provisioned": "true"
+            },
+            "timeouts": null
+          },
+          "sensitive_values": {
+            "autoclass": [],
+            "cors": [],
+            "custom_placement_config": [],
+            "effective_labels": {},
+            "encryption": [],
+            "hierarchical_namespace": [],
+            "ip_filter": [],
+            "lifecycle_rule": [],
+            "logging": [],
+            "retention_policy": [],
+            "soft_delete_policy": [],
+            "terraform_labels": {},
+            "versioning": [],
+            "website": []
+          },
+          "identity_schema_version": 1,
+          "identity": {
+            "name": null,
+            "project": null
+          }
+        }
+      ]
+    }
+  },
+  "resource_changes": [
+    {
+      "address": "google_storage_bucket.compliant_example_1",
+      "mode": "managed",
+      "type": "google_storage_bucket",
+      "name": "compliant_example_1",
+      "provider_name": "registry.terraform.io/hashicorp/google",
+      "change": {
+        "actions": [
+          "create"
+        ],
+        "before": null,
+        "after": {
+          "autoclass": [],
+          "cors": [],
+          "custom_placement_config": [],
+          "default_event_based_hold": null,
+          "deletion_policy": "DELETE",
+          "effective_labels": {
+            "goog-terraform-provisioned": "true"
+          },
+          "enable_object_retention": null,
+          "encryption": [],
+          "force_destroy": false,
+          "hierarchical_namespace": [],
+          "ip_filter": [],
+          "labels": null,
+          "lifecycle_rule": [],
+          "location": "AU",
+          "logging": [],
+          "name": "compliant_example_1",
+          "public_access_prevention": "enforced",
+          "requester_pays": null,
+          "retention_policy": [],
+          "storage_class": "STANDARD",
+          "terraform_labels": {
+            "goog-terraform-provisioned": "true"
+          },
+          "timeouts": null
+        },
+        "after_unknown": {
+          "autoclass": [],
+          "cors": [],
+          "custom_placement_config": [],
+          "effective_labels": {},
+          "encryption": [],
+          "hierarchical_namespace": [],
+          "id": true,
+          "ip_filter": [],
+          "lifecycle_rule": [],
+          "logging": [],
+          "project": true,
+          "project_number": true,
+          "retention_policy": [],
+          "rpo": true,
+          "self_link": true,
+          "soft_delete_policy": true,
+          "terraform_labels": {},
+          "time_created": true,
+          "uniform_bucket_level_access": true,
+          "updated": true,
+          "url": true,
+          "versioning": true,
+          "website": true
+        },
+        "before_sensitive": false,
+        "after_sensitive": {
+          "autoclass": [],
+          "cors": [],
+          "custom_placement_config": [],
+          "effective_labels": {},
+          "encryption": [],
+          "hierarchical_namespace": [],
+          "ip_filter": [],
+          "lifecycle_rule": [],
+          "logging": [],
+          "retention_policy": [],
+          "soft_delete_policy": [],
+          "terraform_labels": {},
+          "versioning": [],
+          "website": []
+        },
+        "after_identity": {
+          "name": null,
+          "project": null
+        }
+      }
+    },
+    {
+      "address": "google_storage_bucket.non_compliant_example_1",
+      "mode": "managed",
+      "type": "google_storage_bucket",
+      "name": "non_compliant_example_1",
+      "provider_name": "registry.terraform.io/hashicorp/google",
+      "change": {
+        "actions": [
+          "create"
+        ],
+        "before": null,
+        "after": {
+          "autoclass": [],
+          "cors": [],
+          "custom_placement_config": [],
+          "default_event_based_hold": null,
+          "deletion_policy": "DELETE",
+          "effective_labels": {
+            "goog-terraform-provisioned": "true"
+          },
+          "enable_object_retention": null,
+          "encryption": [],
+          "force_destroy": false,
+          "hierarchical_namespace": [],
+          "ip_filter": [],
+          "labels": null,
+          "lifecycle_rule": [],
+          "location": "AU",
+          "logging": [],
+          "name": "non_compliant_example_1",
+          "public_access_prevention": "inherited",
+          "requester_pays": null,
+          "retention_policy": [],
+          "storage_class": "STANDARD",
+          "terraform_labels": {
+            "goog-terraform-provisioned": "true"
+          },
+          "timeouts": null
+        },
+        "after_unknown": {
+          "autoclass": [],
+          "cors": [],
+          "custom_placement_config": [],
+          "effective_labels": {},
+          "encryption": [],
+          "hierarchical_namespace": [],
+          "id": true,
+          "ip_filter": [],
+          "lifecycle_rule": [],
+          "logging": [],
+          "project": true,
+          "project_number": true,
+          "retention_policy": [],
+          "rpo": true,
+          "self_link": true,
+          "soft_delete_policy": true,
+          "terraform_labels": {},
+          "time_created": true,
+          "uniform_bucket_level_access": true,
+          "updated": true,
+          "url": true,
+          "versioning": true,
+          "website": true
+        },
+        "before_sensitive": false,
+        "after_sensitive": {
+          "autoclass": [],
+          "cors": [],
+          "custom_placement_config": [],
+          "effective_labels": {},
+          "encryption": [],
+          "hierarchical_namespace": [],
+          "ip_filter": [],
+          "lifecycle_rule": [],
+          "logging": [],
+          "retention_policy": [],
+          "soft_delete_policy": [],
+          "terraform_labels": {},
+          "versioning": [],
+          "website": []
+        },
+        "after_identity": {
+          "name": null,
+          "project": null
+        }
+      }
+    }
+  ],
+  "configuration": {
+    "provider_config": {
+      "google": {
+        "name": "google",
+        "full_name": "registry.terraform.io/hashicorp/google",
+        "version_constraint": "7.37.0"
+      }
+    },
+    "root_module": {
+      "resources": [
+        {
+          "address": "google_storage_bucket.compliant_example_1",
+          "mode": "managed",
+          "type": "google_storage_bucket",
+          "name": "compliant_example_1",
+          "provider_config_key": "google",
+          "expressions": {
+            "location": {
+              "constant_value": "AU"
+            },
+            "name": {
+              "constant_value": "compliant_example_1"
+            },
+            "public_access_prevention": {
+              "constant_value": "enforced"
+            }
+          },
+          "schema_version": 4
+        },
+        {
+          "address": "google_storage_bucket.non_compliant_example_1",
+          "mode": "managed",
+          "type": "google_storage_bucket",
+          "name": "non_compliant_example_1",
+          "provider_config_key": "google",
+          "expressions": {
+            "location": {
+              "constant_value": "AU"
+            },
+            "name": {
+              "constant_value": "non_compliant_example_1"
+            },
+            "public_access_prevention": {
+              "constant_value": "inherited"
+            }
+          },
+          "schema_version": 4
+        }
+      ]
+    }
+  },
+  "timestamp": "2026-08-30T08:07:36Z",
+  "applyable": true,
+  "complete": true,
+  "errored": false
+}

--- a/scripts/linters/_tests/fixtures/clean/inputs/gcp/Cloud Storage/google_storage_bucket/public_access_prevention/nonCompliant.tf
+++ b/scripts/linters/_tests/fixtures/clean/inputs/gcp/Cloud Storage/google_storage_bucket/public_access_prevention/nonCompliant.tf
@@ -1,0 +1,5 @@
+resource "google_storage_bucket" "non_compliant_example_1" {
+  name                     = "non_compliant_example_1"
+  location                 = "AU"
+  public_access_prevention = "inherited"
+}

--- a/scripts/linters/_tests/fixtures/clean/policies/gcp/Cloud Storage/google_storage_bucket/_vars.rego
+++ b/scripts/linters/_tests/fixtures/clean/policies/gcp/Cloud Storage/google_storage_bucket/_vars.rego
@@ -1,0 +1,7 @@
+package terraform.gcp.security.cloud_storage.google_storage_bucket.vars
+
+variables := {
+    "friendly_resource_name": "GCS Bucket",
+    "resource_type": "google_storage_bucket",
+    "resource_value_name": "name"
+}

--- a/scripts/linters/_tests/fixtures/clean/policies/gcp/Cloud Storage/google_storage_bucket/public_access_prevention.rego
+++ b/scripts/linters/_tests/fixtures/clean/policies/gcp/Cloud Storage/google_storage_bucket/public_access_prevention.rego
@@ -1,0 +1,22 @@
+package terraform.gcp.security.cloud_storage.google_storage_bucket.public_access_prevention
+
+import data.terraform.helpers
+import data.terraform.gcp.security.cloud_storage.google_storage_bucket.vars
+
+conditions := [
+    [
+        {
+            "situation_description": "Bucket does not have public access prevention enabled.",
+            "remedies": ["Set public_access_prevention to 'enforced'"]
+        },
+        {
+            "condition": "Check if public_access_prevention is enforced.",
+            "attribute_path": ["public_access_prevention"],
+            "values": ["enforced"],
+            "policy_type": "whitelist"
+        }
+    ]
+]
+
+message := helpers.get_multi_summary(conditions, vars.variables).message
+details := helpers.get_multi_summary(conditions, vars.variables).details

--- a/scripts/linters/_tests/fixtures/fixture_identity_drift/docs/gcp/Cloud Storage/google_storage_bucket_iam_binding.json
+++ b/scripts/linters/_tests/fixtures/fixture_identity_drift/docs/gcp/Cloud Storage/google_storage_bucket_iam_binding.json
@@ -1,0 +1,5 @@
+{
+  "last_updated": "2026-08-30T00:00:00Z",
+  "provider_version": "7.37.0",
+  "arguments": {}
+}

--- a/scripts/linters/_tests/fixtures/fixture_identity_drift/inputs/gcp/Cloud Storage/google_storage_bucket_iam_binding/role/compliant.tf
+++ b/scripts/linters/_tests/fixtures/fixture_identity_drift/inputs/gcp/Cloud Storage/google_storage_bucket_iam_binding/role/compliant.tf
@@ -1,0 +1,7 @@
+resource "google_storage_bucket_iam_binding" "compliant_example_1" {
+  bucket = "prod-data-bucket"
+  role   = "roles/storage.objectViewer"
+  members = [
+    "user:jane@example.com",
+  ]
+}

--- a/scripts/linters/_tests/fixtures/fixture_identity_drift/inputs/gcp/Cloud Storage/google_storage_bucket_iam_binding/role/config.tf
+++ b/scripts/linters/_tests/fixtures/fixture_identity_drift/inputs/gcp/Cloud Storage/google_storage_bucket_iam_binding/role/config.tf
@@ -1,0 +1,11 @@
+##### DO NOT EDIT ######
+
+terraform {
+  required_providers {
+    google = {
+      source  = "hashicorp/google"
+    }
+  }
+}
+
+provider "google" {}

--- a/scripts/linters/_tests/fixtures/fixture_identity_drift/inputs/gcp/Cloud Storage/google_storage_bucket_iam_binding/role/expected_plan.json
+++ b/scripts/linters/_tests/fixtures/fixture_identity_drift/inputs/gcp/Cloud Storage/google_storage_bucket_iam_binding/role/expected_plan.json
@@ -1,0 +1,191 @@
+{
+  "format_version": "1.2",
+  "terraform_version": "1.15.7",
+  "planned_values": {
+    "root_module": {
+      "resources": [
+        {
+          "address": "google_storage_bucket_iam_binding.compliant_example_1",
+          "mode": "managed",
+          "type": "google_storage_bucket_iam_binding",
+          "name": "compliant_example_1",
+          "provider_name": "registry.terraform.io/hashicorp/google",
+          "schema_version": 0,
+          "values": {
+            "bucket": "prod-data-bucket",
+            "condition": [],
+            "members": [
+              "user:jane@example.com"
+            ],
+            "role": "roles/storage.objectViewer",
+            "timeouts": null
+          },
+          "sensitive_values": {
+            "condition": [],
+            "members": [
+              false
+            ]
+          }
+        },
+        {
+          "address": "google_storage_bucket_iam_binding.non_compliant_example_1",
+          "mode": "managed",
+          "type": "google_storage_bucket_iam_binding",
+          "name": "non_compliant_example_1",
+          "provider_name": "registry.terraform.io/hashicorp/google",
+          "schema_version": 0,
+          "values": {
+            "bucket": "dev-scratch-bucket",
+            "condition": [],
+            "members": [
+              "user:jane@example.com"
+            ],
+            "role": "roles/storage.admin",
+            "timeouts": null
+          },
+          "sensitive_values": {
+            "condition": [],
+            "members": [
+              false
+            ]
+          }
+        }
+      ]
+    }
+  },
+  "resource_changes": [
+    {
+      "address": "google_storage_bucket_iam_binding.compliant_example_1",
+      "mode": "managed",
+      "type": "google_storage_bucket_iam_binding",
+      "name": "compliant_example_1",
+      "provider_name": "registry.terraform.io/hashicorp/google",
+      "change": {
+        "actions": [
+          "create"
+        ],
+        "before": null,
+        "after": {
+          "bucket": "prod-data-bucket",
+          "condition": [],
+          "members": [
+            "user:jane@example.com"
+          ],
+          "role": "roles/storage.objectViewer",
+          "timeouts": null
+        },
+        "after_unknown": {
+          "condition": [],
+          "etag": true,
+          "id": true,
+          "members": [
+            false
+          ]
+        },
+        "before_sensitive": false,
+        "after_sensitive": {
+          "condition": [],
+          "members": [
+            false
+          ]
+        }
+      }
+    },
+    {
+      "address": "google_storage_bucket_iam_binding.non_compliant_example_1",
+      "mode": "managed",
+      "type": "google_storage_bucket_iam_binding",
+      "name": "non_compliant_example_1",
+      "provider_name": "registry.terraform.io/hashicorp/google",
+      "change": {
+        "actions": [
+          "create"
+        ],
+        "before": null,
+        "after": {
+          "bucket": "dev-scratch-bucket",
+          "condition": [],
+          "members": [
+            "user:jane@example.com"
+          ],
+          "role": "roles/storage.admin",
+          "timeouts": null
+        },
+        "after_unknown": {
+          "condition": [],
+          "etag": true,
+          "id": true,
+          "members": [
+            false
+          ]
+        },
+        "before_sensitive": false,
+        "after_sensitive": {
+          "condition": [],
+          "members": [
+            false
+          ]
+        }
+      }
+    }
+  ],
+  "configuration": {
+    "provider_config": {
+      "google": {
+        "name": "google",
+        "full_name": "registry.terraform.io/hashicorp/google",
+        "version_constraint": "7.37.0"
+      }
+    },
+    "root_module": {
+      "resources": [
+        {
+          "address": "google_storage_bucket_iam_binding.compliant_example_1",
+          "mode": "managed",
+          "type": "google_storage_bucket_iam_binding",
+          "name": "compliant_example_1",
+          "provider_config_key": "google",
+          "expressions": {
+            "bucket": {
+              "constant_value": "prod-data-bucket"
+            },
+            "members": {
+              "constant_value": [
+                "user:jane@example.com"
+              ]
+            },
+            "role": {
+              "constant_value": "roles/storage.objectViewer"
+            }
+          },
+          "schema_version": 0
+        },
+        {
+          "address": "google_storage_bucket_iam_binding.non_compliant_example_1",
+          "mode": "managed",
+          "type": "google_storage_bucket_iam_binding",
+          "name": "non_compliant_example_1",
+          "provider_config_key": "google",
+          "expressions": {
+            "bucket": {
+              "constant_value": "dev-scratch-bucket"
+            },
+            "members": {
+              "constant_value": [
+                "user:jane@example.com"
+              ]
+            },
+            "role": {
+              "constant_value": "roles/storage.admin"
+            }
+          },
+          "schema_version": 0
+        }
+      ]
+    }
+  },
+  "timestamp": "2026-08-30T08:31:35Z",
+  "applyable": true,
+  "complete": true,
+  "errored": false
+}

--- a/scripts/linters/_tests/fixtures/fixture_identity_drift/inputs/gcp/Cloud Storage/google_storage_bucket_iam_binding/role/nonCompliant.tf
+++ b/scripts/linters/_tests/fixtures/fixture_identity_drift/inputs/gcp/Cloud Storage/google_storage_bucket_iam_binding/role/nonCompliant.tf
@@ -1,0 +1,7 @@
+resource "google_storage_bucket_iam_binding" "non_compliant_example_1" {
+  bucket = "dev-scratch-bucket"
+  role   = "roles/storage.admin"
+  members = [
+    "user:jane@example.com",
+  ]
+}

--- a/scripts/linters/_tests/fixtures/fixture_identity_drift/policies/gcp/Cloud Storage/google_storage_bucket_iam_binding/_vars.rego
+++ b/scripts/linters/_tests/fixtures/fixture_identity_drift/policies/gcp/Cloud Storage/google_storage_bucket_iam_binding/_vars.rego
@@ -1,0 +1,7 @@
+package terraform.gcp.security.cloud_storage.google_storage_bucket_iam_binding.vars
+
+variables := {
+  "friendly_resource_name": "GCS bucket IAM binding",
+  "resource_type": "google_storage_bucket_iam_binding",
+  "resource_value_name": "bucket"
+}

--- a/scripts/linters/_tests/fixtures/fixture_identity_drift/policies/gcp/Cloud Storage/google_storage_bucket_iam_binding/role.rego
+++ b/scripts/linters/_tests/fixtures/fixture_identity_drift/policies/gcp/Cloud Storage/google_storage_bucket_iam_binding/role.rego
@@ -1,0 +1,22 @@
+package terraform.gcp.security.cloud_storage.google_storage_bucket_iam_binding.role
+
+import data.terraform.helpers
+import data.terraform.gcp.security.cloud_storage.google_storage_bucket_iam_binding.vars
+
+conditions := [
+    [
+        {
+            "situation_description": "Binding grants a role that is broader than needed.",
+            "remedies": ["Use roles/storage.objectViewer instead of an admin role."]
+        },
+        {
+            "condition": "Role must not be an admin role.",
+            "attribute_path": ["role"],
+            "values": ["roles/storage.admin"],
+            "policy_type": "blacklist"
+        }
+    ]
+]
+
+message := helpers.get_multi_summary(conditions, vars.variables).message
+details := helpers.get_multi_summary(conditions, vars.variables).details

--- a/scripts/linters/_tests/fixtures/fixture_noise/docs/gcp/Cloud Storage/google_storage_bucket.json
+++ b/scripts/linters/_tests/fixtures/fixture_noise/docs/gcp/Cloud Storage/google_storage_bucket.json
@@ -1,0 +1,8 @@
+{
+  "last_updated": "2026-08-30T00:00:00Z",
+  "provider_version": "7.37.0",
+  "arguments": {
+    "labels": {"description": "Fixture argument.", "required": false, "type": "map(string)", "security_impact": true, "rationale": "Fixture."},
+    "members": {"description": "Fixture argument.", "required": false, "type": "list(string)", "security_impact": true, "rationale": "Fixture."}
+  }
+}

--- a/scripts/linters/_tests/fixtures/fixture_noise/docs/gcp/Cloud Storage/google_storage_bucket_iam_binding.json
+++ b/scripts/linters/_tests/fixtures/fixture_noise/docs/gcp/Cloud Storage/google_storage_bucket_iam_binding.json
@@ -1,0 +1,8 @@
+{
+  "last_updated": "2026-08-30T00:00:00Z",
+  "provider_version": "7.37.0",
+  "arguments": {
+    "labels": {"description": "Fixture argument.", "required": false, "type": "map(string)", "security_impact": true, "rationale": "Fixture."},
+    "members": {"description": "Fixture argument.", "required": false, "type": "list(string)", "security_impact": true, "rationale": "Fixture."}
+  }
+}

--- a/scripts/linters/_tests/fixtures/fixture_noise/inputs/gcp/Cloud Storage/google_storage_bucket/labels/compliant.tf
+++ b/scripts/linters/_tests/fixtures/fixture_noise/inputs/gcp/Cloud Storage/google_storage_bucket/labels/compliant.tf
@@ -1,0 +1,7 @@
+resource "google_storage_bucket" "compliant_example_1" {
+  name     = "compliant_example_1"
+  location = "AU"
+  labels = {
+    environment = "prod"
+  }
+}

--- a/scripts/linters/_tests/fixtures/fixture_noise/inputs/gcp/Cloud Storage/google_storage_bucket/labels/config.tf
+++ b/scripts/linters/_tests/fixtures/fixture_noise/inputs/gcp/Cloud Storage/google_storage_bucket/labels/config.tf
@@ -1,0 +1,11 @@
+##### DO NOT EDIT ######
+
+terraform {
+  required_providers {
+    google = {
+      source  = "hashicorp/google"
+    }
+  }
+}
+
+provider "google" {}

--- a/scripts/linters/_tests/fixtures/fixture_noise/inputs/gcp/Cloud Storage/google_storage_bucket/labels/expected_plan.json
+++ b/scripts/linters/_tests/fixtures/fixture_noise/inputs/gcp/Cloud Storage/google_storage_bucket/labels/expected_plan.json
@@ -1,0 +1,379 @@
+{
+  "format_version": "1.2",
+  "terraform_version": "1.15.7",
+  "planned_values": {
+    "root_module": {
+      "resources": [
+        {
+          "address": "google_storage_bucket.compliant_example_1",
+          "mode": "managed",
+          "type": "google_storage_bucket",
+          "name": "compliant_example_1",
+          "provider_name": "registry.terraform.io/hashicorp/google",
+          "schema_version": 4,
+          "values": {
+            "autoclass": [],
+            "cors": [],
+            "custom_placement_config": [],
+            "default_event_based_hold": null,
+            "deletion_policy": "DELETE",
+            "effective_labels": {
+              "environment": "prod",
+              "goog-terraform-provisioned": "true"
+            },
+            "enable_object_retention": null,
+            "encryption": [],
+            "force_destroy": false,
+            "hierarchical_namespace": [],
+            "ip_filter": [],
+            "labels": {
+              "environment": "prod"
+            },
+            "lifecycle_rule": [],
+            "location": "AU",
+            "logging": [],
+            "name": "compliant_example_1",
+            "requester_pays": null,
+            "retention_policy": [],
+            "storage_class": "STANDARD",
+            "terraform_labels": {
+              "environment": "prod",
+              "goog-terraform-provisioned": "true"
+            },
+            "timeouts": null
+          },
+          "sensitive_values": {
+            "autoclass": [],
+            "cors": [],
+            "custom_placement_config": [],
+            "effective_labels": {},
+            "encryption": [],
+            "hierarchical_namespace": [],
+            "ip_filter": [],
+            "labels": {},
+            "lifecycle_rule": [],
+            "logging": [],
+            "retention_policy": [],
+            "soft_delete_policy": [],
+            "terraform_labels": {},
+            "versioning": [],
+            "website": []
+          },
+          "identity_schema_version": 1,
+          "identity": {
+            "name": null,
+            "project": null
+          }
+        },
+        {
+          "address": "google_storage_bucket.non_compliant_example_1",
+          "mode": "managed",
+          "type": "google_storage_bucket",
+          "name": "non_compliant_example_1",
+          "provider_name": "registry.terraform.io/hashicorp/google",
+          "schema_version": 4,
+          "values": {
+            "autoclass": [],
+            "cors": [],
+            "custom_placement_config": [],
+            "default_event_based_hold": null,
+            "deletion_policy": "DELETE",
+            "effective_labels": {
+              "environment": "whatever",
+              "goog-terraform-provisioned": "true"
+            },
+            "enable_object_retention": null,
+            "encryption": [],
+            "force_destroy": false,
+            "hierarchical_namespace": [],
+            "ip_filter": [],
+            "labels": {
+              "environment": "whatever"
+            },
+            "lifecycle_rule": [],
+            "location": "AU",
+            "logging": [],
+            "name": "non_compliant_example_1",
+            "requester_pays": null,
+            "retention_policy": [],
+            "storage_class": "STANDARD",
+            "terraform_labels": {
+              "environment": "whatever",
+              "goog-terraform-provisioned": "true"
+            },
+            "timeouts": null
+          },
+          "sensitive_values": {
+            "autoclass": [],
+            "cors": [],
+            "custom_placement_config": [],
+            "effective_labels": {},
+            "encryption": [],
+            "hierarchical_namespace": [],
+            "ip_filter": [],
+            "labels": {},
+            "lifecycle_rule": [],
+            "logging": [],
+            "retention_policy": [],
+            "soft_delete_policy": [],
+            "terraform_labels": {},
+            "versioning": [],
+            "website": []
+          },
+          "identity_schema_version": 1,
+          "identity": {
+            "name": null,
+            "project": null
+          }
+        }
+      ]
+    }
+  },
+  "resource_changes": [
+    {
+      "address": "google_storage_bucket.compliant_example_1",
+      "mode": "managed",
+      "type": "google_storage_bucket",
+      "name": "compliant_example_1",
+      "provider_name": "registry.terraform.io/hashicorp/google",
+      "change": {
+        "actions": [
+          "create"
+        ],
+        "before": null,
+        "after": {
+          "autoclass": [],
+          "cors": [],
+          "custom_placement_config": [],
+          "default_event_based_hold": null,
+          "deletion_policy": "DELETE",
+          "effective_labels": {
+            "environment": "prod",
+            "goog-terraform-provisioned": "true"
+          },
+          "enable_object_retention": null,
+          "encryption": [],
+          "force_destroy": false,
+          "hierarchical_namespace": [],
+          "ip_filter": [],
+          "labels": {
+            "environment": "prod"
+          },
+          "lifecycle_rule": [],
+          "location": "AU",
+          "logging": [],
+          "name": "compliant_example_1",
+          "requester_pays": null,
+          "retention_policy": [],
+          "storage_class": "STANDARD",
+          "terraform_labels": {
+            "environment": "prod",
+            "goog-terraform-provisioned": "true"
+          },
+          "timeouts": null
+        },
+        "after_unknown": {
+          "autoclass": [],
+          "cors": [],
+          "custom_placement_config": [],
+          "effective_labels": {},
+          "encryption": [],
+          "hierarchical_namespace": [],
+          "id": true,
+          "ip_filter": [],
+          "labels": {},
+          "lifecycle_rule": [],
+          "logging": [],
+          "project": true,
+          "project_number": true,
+          "public_access_prevention": true,
+          "retention_policy": [],
+          "rpo": true,
+          "self_link": true,
+          "soft_delete_policy": true,
+          "terraform_labels": {},
+          "time_created": true,
+          "uniform_bucket_level_access": true,
+          "updated": true,
+          "url": true,
+          "versioning": true,
+          "website": true
+        },
+        "before_sensitive": false,
+        "after_sensitive": {
+          "autoclass": [],
+          "cors": [],
+          "custom_placement_config": [],
+          "effective_labels": {},
+          "encryption": [],
+          "hierarchical_namespace": [],
+          "ip_filter": [],
+          "labels": {},
+          "lifecycle_rule": [],
+          "logging": [],
+          "retention_policy": [],
+          "soft_delete_policy": [],
+          "terraform_labels": {},
+          "versioning": [],
+          "website": []
+        },
+        "after_identity": {
+          "name": null,
+          "project": null
+        }
+      }
+    },
+    {
+      "address": "google_storage_bucket.non_compliant_example_1",
+      "mode": "managed",
+      "type": "google_storage_bucket",
+      "name": "non_compliant_example_1",
+      "provider_name": "registry.terraform.io/hashicorp/google",
+      "change": {
+        "actions": [
+          "create"
+        ],
+        "before": null,
+        "after": {
+          "autoclass": [],
+          "cors": [],
+          "custom_placement_config": [],
+          "default_event_based_hold": null,
+          "deletion_policy": "DELETE",
+          "effective_labels": {
+            "environment": "whatever",
+            "goog-terraform-provisioned": "true"
+          },
+          "enable_object_retention": null,
+          "encryption": [],
+          "force_destroy": false,
+          "hierarchical_namespace": [],
+          "ip_filter": [],
+          "labels": {
+            "environment": "whatever"
+          },
+          "lifecycle_rule": [],
+          "location": "AU",
+          "logging": [],
+          "name": "non_compliant_example_1",
+          "requester_pays": null,
+          "retention_policy": [],
+          "storage_class": "STANDARD",
+          "terraform_labels": {
+            "environment": "whatever",
+            "goog-terraform-provisioned": "true"
+          },
+          "timeouts": null
+        },
+        "after_unknown": {
+          "autoclass": [],
+          "cors": [],
+          "custom_placement_config": [],
+          "effective_labels": {},
+          "encryption": [],
+          "hierarchical_namespace": [],
+          "id": true,
+          "ip_filter": [],
+          "labels": {},
+          "lifecycle_rule": [],
+          "logging": [],
+          "project": true,
+          "project_number": true,
+          "public_access_prevention": true,
+          "retention_policy": [],
+          "rpo": true,
+          "self_link": true,
+          "soft_delete_policy": true,
+          "terraform_labels": {},
+          "time_created": true,
+          "uniform_bucket_level_access": true,
+          "updated": true,
+          "url": true,
+          "versioning": true,
+          "website": true
+        },
+        "before_sensitive": false,
+        "after_sensitive": {
+          "autoclass": [],
+          "cors": [],
+          "custom_placement_config": [],
+          "effective_labels": {},
+          "encryption": [],
+          "hierarchical_namespace": [],
+          "ip_filter": [],
+          "labels": {},
+          "lifecycle_rule": [],
+          "logging": [],
+          "retention_policy": [],
+          "soft_delete_policy": [],
+          "terraform_labels": {},
+          "versioning": [],
+          "website": []
+        },
+        "after_identity": {
+          "name": null,
+          "project": null
+        }
+      }
+    }
+  ],
+  "configuration": {
+    "provider_config": {
+      "google": {
+        "name": "google",
+        "full_name": "registry.terraform.io/hashicorp/google",
+        "version_constraint": "7.37.0"
+      }
+    },
+    "root_module": {
+      "resources": [
+        {
+          "address": "google_storage_bucket.compliant_example_1",
+          "mode": "managed",
+          "type": "google_storage_bucket",
+          "name": "compliant_example_1",
+          "provider_config_key": "google",
+          "expressions": {
+            "labels": {
+              "constant_value": {
+                "environment": "prod"
+              }
+            },
+            "location": {
+              "constant_value": "AU"
+            },
+            "name": {
+              "constant_value": "compliant_example_1"
+            }
+          },
+          "schema_version": 4
+        },
+        {
+          "address": "google_storage_bucket.non_compliant_example_1",
+          "mode": "managed",
+          "type": "google_storage_bucket",
+          "name": "non_compliant_example_1",
+          "provider_config_key": "google",
+          "expressions": {
+            "labels": {
+              "constant_value": {
+                "environment": "whatever"
+              }
+            },
+            "location": {
+              "constant_value": "AU"
+            },
+            "name": {
+              "constant_value": "non_compliant_example_1"
+            }
+          },
+          "schema_version": 4
+        }
+      ]
+    }
+  },
+  "timestamp": "2026-08-30T08:14:28Z",
+  "applyable": true,
+  "complete": true,
+  "errored": false
+}

--- a/scripts/linters/_tests/fixtures/fixture_noise/inputs/gcp/Cloud Storage/google_storage_bucket/labels/nonCompliant.tf
+++ b/scripts/linters/_tests/fixtures/fixture_noise/inputs/gcp/Cloud Storage/google_storage_bucket/labels/nonCompliant.tf
@@ -1,0 +1,7 @@
+resource "google_storage_bucket" "non_compliant_example_1" {
+  name     = "non_compliant_example_1"
+  location = "AU"
+  labels = {
+    environment = "whatever"
+  }
+}

--- a/scripts/linters/_tests/fixtures/fixture_noise/inputs/gcp/Cloud Storage/google_storage_bucket_iam_binding/members/compliant.tf
+++ b/scripts/linters/_tests/fixtures/fixture_noise/inputs/gcp/Cloud Storage/google_storage_bucket_iam_binding/members/compliant.tf
@@ -1,0 +1,7 @@
+resource "google_storage_bucket_iam_binding" "compliant_example_1" {
+  bucket = "compliant_example_1"
+  role   = "roles/storage.admin"
+  members = [
+    "user:jane@example.com",
+  ]
+}

--- a/scripts/linters/_tests/fixtures/fixture_noise/inputs/gcp/Cloud Storage/google_storage_bucket_iam_binding/members/config.tf
+++ b/scripts/linters/_tests/fixtures/fixture_noise/inputs/gcp/Cloud Storage/google_storage_bucket_iam_binding/members/config.tf
@@ -1,0 +1,11 @@
+##### DO NOT EDIT ######
+
+terraform {
+  required_providers {
+    google = {
+      source  = "hashicorp/google"
+    }
+  }
+}
+
+provider "google" {}

--- a/scripts/linters/_tests/fixtures/fixture_noise/inputs/gcp/Cloud Storage/google_storage_bucket_iam_binding/members/expected_plan.json
+++ b/scripts/linters/_tests/fixtures/fixture_noise/inputs/gcp/Cloud Storage/google_storage_bucket_iam_binding/members/expected_plan.json
@@ -1,0 +1,191 @@
+{
+  "format_version": "1.2",
+  "terraform_version": "1.15.7",
+  "planned_values": {
+    "root_module": {
+      "resources": [
+        {
+          "address": "google_storage_bucket_iam_binding.compliant_example_1",
+          "mode": "managed",
+          "type": "google_storage_bucket_iam_binding",
+          "name": "compliant_example_1",
+          "provider_name": "registry.terraform.io/hashicorp/google",
+          "schema_version": 0,
+          "values": {
+            "bucket": "compliant_example_1",
+            "condition": [],
+            "members": [
+              "user:jane@example.com"
+            ],
+            "role": "roles/storage.admin",
+            "timeouts": null
+          },
+          "sensitive_values": {
+            "condition": [],
+            "members": [
+              false
+            ]
+          }
+        },
+        {
+          "address": "google_storage_bucket_iam_binding.non_compliant_example_1",
+          "mode": "managed",
+          "type": "google_storage_bucket_iam_binding",
+          "name": "non_compliant_example_1",
+          "provider_name": "registry.terraform.io/hashicorp/google",
+          "schema_version": 0,
+          "values": {
+            "bucket": "non_compliant_example_1",
+            "condition": [],
+            "members": [
+              "allUsers"
+            ],
+            "role": "roles/storage.admin",
+            "timeouts": null
+          },
+          "sensitive_values": {
+            "condition": [],
+            "members": [
+              false
+            ]
+          }
+        }
+      ]
+    }
+  },
+  "resource_changes": [
+    {
+      "address": "google_storage_bucket_iam_binding.compliant_example_1",
+      "mode": "managed",
+      "type": "google_storage_bucket_iam_binding",
+      "name": "compliant_example_1",
+      "provider_name": "registry.terraform.io/hashicorp/google",
+      "change": {
+        "actions": [
+          "create"
+        ],
+        "before": null,
+        "after": {
+          "bucket": "compliant_example_1",
+          "condition": [],
+          "members": [
+            "user:jane@example.com"
+          ],
+          "role": "roles/storage.admin",
+          "timeouts": null
+        },
+        "after_unknown": {
+          "condition": [],
+          "etag": true,
+          "id": true,
+          "members": [
+            false
+          ]
+        },
+        "before_sensitive": false,
+        "after_sensitive": {
+          "condition": [],
+          "members": [
+            false
+          ]
+        }
+      }
+    },
+    {
+      "address": "google_storage_bucket_iam_binding.non_compliant_example_1",
+      "mode": "managed",
+      "type": "google_storage_bucket_iam_binding",
+      "name": "non_compliant_example_1",
+      "provider_name": "registry.terraform.io/hashicorp/google",
+      "change": {
+        "actions": [
+          "create"
+        ],
+        "before": null,
+        "after": {
+          "bucket": "non_compliant_example_1",
+          "condition": [],
+          "members": [
+            "allUsers"
+          ],
+          "role": "roles/storage.admin",
+          "timeouts": null
+        },
+        "after_unknown": {
+          "condition": [],
+          "etag": true,
+          "id": true,
+          "members": [
+            false
+          ]
+        },
+        "before_sensitive": false,
+        "after_sensitive": {
+          "condition": [],
+          "members": [
+            false
+          ]
+        }
+      }
+    }
+  ],
+  "configuration": {
+    "provider_config": {
+      "google": {
+        "name": "google",
+        "full_name": "registry.terraform.io/hashicorp/google",
+        "version_constraint": "7.37.0"
+      }
+    },
+    "root_module": {
+      "resources": [
+        {
+          "address": "google_storage_bucket_iam_binding.compliant_example_1",
+          "mode": "managed",
+          "type": "google_storage_bucket_iam_binding",
+          "name": "compliant_example_1",
+          "provider_config_key": "google",
+          "expressions": {
+            "bucket": {
+              "constant_value": "compliant_example_1"
+            },
+            "members": {
+              "constant_value": [
+                "user:jane@example.com"
+              ]
+            },
+            "role": {
+              "constant_value": "roles/storage.admin"
+            }
+          },
+          "schema_version": 0
+        },
+        {
+          "address": "google_storage_bucket_iam_binding.non_compliant_example_1",
+          "mode": "managed",
+          "type": "google_storage_bucket_iam_binding",
+          "name": "non_compliant_example_1",
+          "provider_config_key": "google",
+          "expressions": {
+            "bucket": {
+              "constant_value": "non_compliant_example_1"
+            },
+            "members": {
+              "constant_value": [
+                "allUsers"
+              ]
+            },
+            "role": {
+              "constant_value": "roles/storage.admin"
+            }
+          },
+          "schema_version": 0
+        }
+      ]
+    }
+  },
+  "timestamp": "2026-08-30T08:14:26Z",
+  "applyable": true,
+  "complete": true,
+  "errored": false
+}

--- a/scripts/linters/_tests/fixtures/fixture_noise/inputs/gcp/Cloud Storage/google_storage_bucket_iam_binding/members/nonCompliant.tf
+++ b/scripts/linters/_tests/fixtures/fixture_noise/inputs/gcp/Cloud Storage/google_storage_bucket_iam_binding/members/nonCompliant.tf
@@ -1,0 +1,7 @@
+resource "google_storage_bucket_iam_binding" "non_compliant_example_1" {
+  bucket = "non_compliant_example_1"
+  role   = "roles/storage.admin"
+  members = [
+    "allUsers",
+  ]
+}

--- a/scripts/linters/_tests/fixtures/fixture_noise/policies/gcp/Cloud Storage/google_storage_bucket/_vars.rego
+++ b/scripts/linters/_tests/fixtures/fixture_noise/policies/gcp/Cloud Storage/google_storage_bucket/_vars.rego
@@ -1,0 +1,7 @@
+package terraform.gcp.security.cloud_storage.google_storage_bucket.vars
+
+variables := {
+    "friendly_resource_name": "GCS Bucket",
+    "resource_type": "google_storage_bucket",
+    "resource_value_name": "name"
+}

--- a/scripts/linters/_tests/fixtures/fixture_noise/policies/gcp/Cloud Storage/google_storage_bucket/labels.rego
+++ b/scripts/linters/_tests/fixtures/fixture_noise/policies/gcp/Cloud Storage/google_storage_bucket/labels.rego
@@ -1,0 +1,22 @@
+package terraform.gcp.security.cloud_storage.google_storage_bucket.labels
+
+import data.terraform.helpers
+import data.terraform.gcp.security.cloud_storage.google_storage_bucket.vars
+
+conditions := [
+    [
+        {
+            "situation_description": "Bucket must carry an 'environment' label naming a real environment.",
+            "remedies": ["Set labels.environment to prod, staging or dev."]
+        },
+        {
+            "condition": "Label environment must name a known environment.",
+            "attribute_path": ["labels", "environment"],
+            "values": ["prod", "staging", "dev"],
+            "policy_type": "whitelist"
+        }
+    ]
+]
+
+message := helpers.get_multi_summary(conditions, vars.variables).message
+details := helpers.get_multi_summary(conditions, vars.variables).details

--- a/scripts/linters/_tests/fixtures/fixture_noise/policies/gcp/Cloud Storage/google_storage_bucket_iam_binding/_vars.rego
+++ b/scripts/linters/_tests/fixtures/fixture_noise/policies/gcp/Cloud Storage/google_storage_bucket_iam_binding/_vars.rego
@@ -1,0 +1,7 @@
+package terraform.gcp.security.cloud_storage.google_storage_bucket_iam_binding.vars
+
+variables := {
+  "friendly_resource_name": "GCS bucket IAM binding",
+  "resource_type": "google_storage_bucket_iam_binding",
+  "resource_value_name": "bucket"
+}

--- a/scripts/linters/_tests/fixtures/fixture_noise/policies/gcp/Cloud Storage/google_storage_bucket_iam_binding/members.rego
+++ b/scripts/linters/_tests/fixtures/fixture_noise/policies/gcp/Cloud Storage/google_storage_bucket_iam_binding/members.rego
@@ -1,0 +1,22 @@
+package terraform.gcp.security.cloud_storage.google_storage_bucket_iam_binding.members
+
+import data.terraform.helpers
+import data.terraform.gcp.security.cloud_storage.google_storage_bucket_iam_binding.vars
+
+conditions := [
+    [
+        {
+            "situation_description": "Access is granted to the whole internet.",
+            "remedies": ["Remove allUsers and allAuthenticatedUsers from members."]
+        },
+        {
+            "condition": "Public access should be prohibited.",
+            "attribute_path": ["members"],
+            "values": ["allUsers", "allAuthenticatedUsers"],
+            "policy_type": "element blacklist"
+        }
+    ]
+]
+
+message := helpers.get_multi_summary(conditions, vars.variables).message
+details := helpers.get_multi_summary(conditions, vars.variables).details

--- a/scripts/linters/_tests/fixtures/fixtures_bad/docs/gcp/Cloud Storage/google_storage_bucket.json
+++ b/scripts/linters/_tests/fixtures/fixtures_bad/docs/gcp/Cloud Storage/google_storage_bucket.json
@@ -1,0 +1,8 @@
+{
+  "last_updated": "2026-08-30T00:00:00Z",
+  "provider_version": "7.37.0",
+  "arguments": {
+    "public_access_prevention": {"description": "Fixture argument.", "required": false, "type": "string", "security_impact": true, "rationale": "Fixture."},
+    "uniform_bucket_level_access": {"description": "Fixture argument.", "required": false, "type": "bool", "security_impact": true, "rationale": "Fixture."}
+  }
+}

--- a/scripts/linters/_tests/fixtures/fixtures_bad/inputs/gcp/Cloud Storage/google_storage_bucket/public_access_prevention/compliant.tf
+++ b/scripts/linters/_tests/fixtures/fixtures_bad/inputs/gcp/Cloud Storage/google_storage_bucket/public_access_prevention/compliant.tf
@@ -1,0 +1,6 @@
+resource "google_storage_bucket" "compliant_example_1" {
+  name                     = "compliant_example_1"
+  location                 = "AU"
+  storage_class            = "STANDARD"
+  public_access_prevention = "enforced"
+}

--- a/scripts/linters/_tests/fixtures/fixtures_bad/inputs/gcp/Cloud Storage/google_storage_bucket/public_access_prevention/config.tf
+++ b/scripts/linters/_tests/fixtures/fixtures_bad/inputs/gcp/Cloud Storage/google_storage_bucket/public_access_prevention/config.tf
@@ -1,0 +1,11 @@
+##### DO NOT EDIT ######
+
+terraform {
+  required_providers {
+    google = {
+      source  = "hashicorp/google"
+    }
+  }
+}
+
+provider "google" {}

--- a/scripts/linters/_tests/fixtures/fixtures_bad/inputs/gcp/Cloud Storage/google_storage_bucket/public_access_prevention/expected_plan.json
+++ b/scripts/linters/_tests/fixtures/fixtures_bad/inputs/gcp/Cloud Storage/google_storage_bucket/public_access_prevention/expected_plan.json
@@ -1,0 +1,361 @@
+{
+  "format_version": "1.2",
+  "terraform_version": "1.15.7",
+  "planned_values": {
+    "root_module": {
+      "resources": [
+        {
+          "address": "google_storage_bucket.compliant_example_1",
+          "mode": "managed",
+          "type": "google_storage_bucket",
+          "name": "compliant_example_1",
+          "provider_name": "registry.terraform.io/hashicorp/google",
+          "schema_version": 4,
+          "values": {
+            "autoclass": [],
+            "cors": [],
+            "custom_placement_config": [],
+            "default_event_based_hold": null,
+            "deletion_policy": "DELETE",
+            "effective_labels": {
+              "goog-terraform-provisioned": "true"
+            },
+            "enable_object_retention": null,
+            "encryption": [],
+            "force_destroy": false,
+            "hierarchical_namespace": [],
+            "ip_filter": [],
+            "labels": null,
+            "lifecycle_rule": [],
+            "location": "AU",
+            "logging": [],
+            "name": "compliant_example_1",
+            "public_access_prevention": "enforced",
+            "requester_pays": null,
+            "retention_policy": [],
+            "storage_class": "STANDARD",
+            "terraform_labels": {
+              "goog-terraform-provisioned": "true"
+            },
+            "timeouts": null
+          },
+          "sensitive_values": {
+            "autoclass": [],
+            "cors": [],
+            "custom_placement_config": [],
+            "effective_labels": {},
+            "encryption": [],
+            "hierarchical_namespace": [],
+            "ip_filter": [],
+            "lifecycle_rule": [],
+            "logging": [],
+            "retention_policy": [],
+            "soft_delete_policy": [],
+            "terraform_labels": {},
+            "versioning": [],
+            "website": []
+          },
+          "identity_schema_version": 1,
+          "identity": {
+            "name": null,
+            "project": null
+          }
+        },
+        {
+          "address": "google_storage_bucket.non_compliant_example_1",
+          "mode": "managed",
+          "type": "google_storage_bucket",
+          "name": "non_compliant_example_1",
+          "provider_name": "registry.terraform.io/hashicorp/google",
+          "schema_version": 4,
+          "values": {
+            "autoclass": [],
+            "cors": [],
+            "custom_placement_config": [],
+            "default_event_based_hold": null,
+            "deletion_policy": "DELETE",
+            "effective_labels": {
+              "goog-terraform-provisioned": "true"
+            },
+            "enable_object_retention": null,
+            "encryption": [],
+            "force_destroy": false,
+            "hierarchical_namespace": [],
+            "ip_filter": [],
+            "labels": null,
+            "lifecycle_rule": [],
+            "location": "AU",
+            "logging": [],
+            "name": "non_compliant_example_1",
+            "public_access_prevention": "inherited",
+            "requester_pays": null,
+            "retention_policy": [],
+            "storage_class": "NEARLINE",
+            "terraform_labels": {
+              "goog-terraform-provisioned": "true"
+            },
+            "timeouts": null
+          },
+          "sensitive_values": {
+            "autoclass": [],
+            "cors": [],
+            "custom_placement_config": [],
+            "effective_labels": {},
+            "encryption": [],
+            "hierarchical_namespace": [],
+            "ip_filter": [],
+            "lifecycle_rule": [],
+            "logging": [],
+            "retention_policy": [],
+            "soft_delete_policy": [],
+            "terraform_labels": {},
+            "versioning": [],
+            "website": []
+          },
+          "identity_schema_version": 1,
+          "identity": {
+            "name": null,
+            "project": null
+          }
+        }
+      ]
+    }
+  },
+  "resource_changes": [
+    {
+      "address": "google_storage_bucket.compliant_example_1",
+      "mode": "managed",
+      "type": "google_storage_bucket",
+      "name": "compliant_example_1",
+      "provider_name": "registry.terraform.io/hashicorp/google",
+      "change": {
+        "actions": [
+          "create"
+        ],
+        "before": null,
+        "after": {
+          "autoclass": [],
+          "cors": [],
+          "custom_placement_config": [],
+          "default_event_based_hold": null,
+          "deletion_policy": "DELETE",
+          "effective_labels": {
+            "goog-terraform-provisioned": "true"
+          },
+          "enable_object_retention": null,
+          "encryption": [],
+          "force_destroy": false,
+          "hierarchical_namespace": [],
+          "ip_filter": [],
+          "labels": null,
+          "lifecycle_rule": [],
+          "location": "AU",
+          "logging": [],
+          "name": "compliant_example_1",
+          "public_access_prevention": "enforced",
+          "requester_pays": null,
+          "retention_policy": [],
+          "storage_class": "STANDARD",
+          "terraform_labels": {
+            "goog-terraform-provisioned": "true"
+          },
+          "timeouts": null
+        },
+        "after_unknown": {
+          "autoclass": [],
+          "cors": [],
+          "custom_placement_config": [],
+          "effective_labels": {},
+          "encryption": [],
+          "hierarchical_namespace": [],
+          "id": true,
+          "ip_filter": [],
+          "lifecycle_rule": [],
+          "logging": [],
+          "project": true,
+          "project_number": true,
+          "retention_policy": [],
+          "rpo": true,
+          "self_link": true,
+          "soft_delete_policy": true,
+          "terraform_labels": {},
+          "time_created": true,
+          "uniform_bucket_level_access": true,
+          "updated": true,
+          "url": true,
+          "versioning": true,
+          "website": true
+        },
+        "before_sensitive": false,
+        "after_sensitive": {
+          "autoclass": [],
+          "cors": [],
+          "custom_placement_config": [],
+          "effective_labels": {},
+          "encryption": [],
+          "hierarchical_namespace": [],
+          "ip_filter": [],
+          "lifecycle_rule": [],
+          "logging": [],
+          "retention_policy": [],
+          "soft_delete_policy": [],
+          "terraform_labels": {},
+          "versioning": [],
+          "website": []
+        },
+        "after_identity": {
+          "name": null,
+          "project": null
+        }
+      }
+    },
+    {
+      "address": "google_storage_bucket.non_compliant_example_1",
+      "mode": "managed",
+      "type": "google_storage_bucket",
+      "name": "non_compliant_example_1",
+      "provider_name": "registry.terraform.io/hashicorp/google",
+      "change": {
+        "actions": [
+          "create"
+        ],
+        "before": null,
+        "after": {
+          "autoclass": [],
+          "cors": [],
+          "custom_placement_config": [],
+          "default_event_based_hold": null,
+          "deletion_policy": "DELETE",
+          "effective_labels": {
+            "goog-terraform-provisioned": "true"
+          },
+          "enable_object_retention": null,
+          "encryption": [],
+          "force_destroy": false,
+          "hierarchical_namespace": [],
+          "ip_filter": [],
+          "labels": null,
+          "lifecycle_rule": [],
+          "location": "AU",
+          "logging": [],
+          "name": "non_compliant_example_1",
+          "public_access_prevention": "inherited",
+          "requester_pays": null,
+          "retention_policy": [],
+          "storage_class": "NEARLINE",
+          "terraform_labels": {
+            "goog-terraform-provisioned": "true"
+          },
+          "timeouts": null
+        },
+        "after_unknown": {
+          "autoclass": [],
+          "cors": [],
+          "custom_placement_config": [],
+          "effective_labels": {},
+          "encryption": [],
+          "hierarchical_namespace": [],
+          "id": true,
+          "ip_filter": [],
+          "lifecycle_rule": [],
+          "logging": [],
+          "project": true,
+          "project_number": true,
+          "retention_policy": [],
+          "rpo": true,
+          "self_link": true,
+          "soft_delete_policy": true,
+          "terraform_labels": {},
+          "time_created": true,
+          "uniform_bucket_level_access": true,
+          "updated": true,
+          "url": true,
+          "versioning": true,
+          "website": true
+        },
+        "before_sensitive": false,
+        "after_sensitive": {
+          "autoclass": [],
+          "cors": [],
+          "custom_placement_config": [],
+          "effective_labels": {},
+          "encryption": [],
+          "hierarchical_namespace": [],
+          "ip_filter": [],
+          "lifecycle_rule": [],
+          "logging": [],
+          "retention_policy": [],
+          "soft_delete_policy": [],
+          "terraform_labels": {},
+          "versioning": [],
+          "website": []
+        },
+        "after_identity": {
+          "name": null,
+          "project": null
+        }
+      }
+    }
+  ],
+  "configuration": {
+    "provider_config": {
+      "google": {
+        "name": "google",
+        "full_name": "registry.terraform.io/hashicorp/google",
+        "version_constraint": "7.37.0"
+      }
+    },
+    "root_module": {
+      "resources": [
+        {
+          "address": "google_storage_bucket.compliant_example_1",
+          "mode": "managed",
+          "type": "google_storage_bucket",
+          "name": "compliant_example_1",
+          "provider_config_key": "google",
+          "expressions": {
+            "location": {
+              "constant_value": "AU"
+            },
+            "name": {
+              "constant_value": "compliant_example_1"
+            },
+            "public_access_prevention": {
+              "constant_value": "enforced"
+            },
+            "storage_class": {
+              "constant_value": "STANDARD"
+            }
+          },
+          "schema_version": 4
+        },
+        {
+          "address": "google_storage_bucket.non_compliant_example_1",
+          "mode": "managed",
+          "type": "google_storage_bucket",
+          "name": "non_compliant_example_1",
+          "provider_config_key": "google",
+          "expressions": {
+            "location": {
+              "constant_value": "AU"
+            },
+            "name": {
+              "constant_value": "non_compliant_example_1"
+            },
+            "public_access_prevention": {
+              "constant_value": "inherited"
+            },
+            "storage_class": {
+              "constant_value": "NEARLINE"
+            }
+          },
+          "schema_version": 4
+        }
+      ]
+    }
+  },
+  "timestamp": "2026-08-30T08:07:38Z",
+  "applyable": true,
+  "complete": true,
+  "errored": false
+}

--- a/scripts/linters/_tests/fixtures/fixtures_bad/inputs/gcp/Cloud Storage/google_storage_bucket/public_access_prevention/nonCompliant.tf
+++ b/scripts/linters/_tests/fixtures/fixtures_bad/inputs/gcp/Cloud Storage/google_storage_bucket/public_access_prevention/nonCompliant.tf
@@ -1,0 +1,6 @@
+resource "google_storage_bucket" "non_compliant_example_1" {
+  name                     = "non_compliant_example_1"
+  location                 = "AU"
+  storage_class            = "NEARLINE"
+  public_access_prevention = "inherited"
+}

--- a/scripts/linters/_tests/fixtures/fixtures_bad/inputs/gcp/Cloud Storage/google_storage_bucket/uniform_bucket_level_access/compliant.tf
+++ b/scripts/linters/_tests/fixtures/fixtures_bad/inputs/gcp/Cloud Storage/google_storage_bucket/uniform_bucket_level_access/compliant.tf
@@ -1,0 +1,5 @@
+resource "google_storage_bucket" "compliant_example_1" {
+  name                        = "compliant_example_1"
+  location                    = "AU"
+  uniform_bucket_level_access = true
+}

--- a/scripts/linters/_tests/fixtures/fixtures_bad/inputs/gcp/Cloud Storage/google_storage_bucket/uniform_bucket_level_access/config.tf
+++ b/scripts/linters/_tests/fixtures/fixtures_bad/inputs/gcp/Cloud Storage/google_storage_bucket/uniform_bucket_level_access/config.tf
@@ -1,0 +1,11 @@
+##### DO NOT EDIT ######
+
+terraform {
+  required_providers {
+    google = {
+      source  = "hashicorp/google"
+    }
+  }
+}
+
+provider "google" {}

--- a/scripts/linters/_tests/fixtures/fixtures_bad/inputs/gcp/Cloud Storage/google_storage_bucket/uniform_bucket_level_access/nonCompliant.tf
+++ b/scripts/linters/_tests/fixtures/fixtures_bad/inputs/gcp/Cloud Storage/google_storage_bucket/uniform_bucket_level_access/nonCompliant.tf
@@ -1,0 +1,5 @@
+resource "google_storage_bucket" "non_compliant_example_1" {
+  name                        = "non_compliant_example_1"
+  location                    = "AU"
+  uniform_bucket_level_access = false
+}

--- a/scripts/linters/_tests/fixtures/fixtures_bad/policies/gcp/Cloud Storage/google_storage_bucket/_vars.rego
+++ b/scripts/linters/_tests/fixtures/fixtures_bad/policies/gcp/Cloud Storage/google_storage_bucket/_vars.rego
@@ -1,0 +1,7 @@
+package terraform.gcp.security.cloud_storage.google_storage_bucket.vars
+
+variables := {
+    "friendly_resource_name": "GCS Bucket",
+    "resource_type": "google_storage_bucket",
+    "resource_value_name": "name"
+}

--- a/scripts/linters/_tests/fixtures/fixtures_bad/policies/gcp/Cloud Storage/google_storage_bucket/public_access_prevention.rego
+++ b/scripts/linters/_tests/fixtures/fixtures_bad/policies/gcp/Cloud Storage/google_storage_bucket/public_access_prevention.rego
@@ -1,0 +1,22 @@
+package terraform.gcp.security.cloud_storage.google_storage_bucket.public_access_prevention
+
+import data.terraform.helpers
+import data.terraform.gcp.security.cloud_storage.google_storage_bucket.vars
+
+conditions := [
+    [
+        {
+            "situation_description": "Bucket does not have public access prevention enabled.",
+            "remedies": ["Set public_access_prevention to 'enforced'"]
+        },
+        {
+            "condition": "Check if public_access_prevention is enforced.",
+            "attribute_path": ["public_access_prevention"],
+            "values": ["enforced"],
+            "policy_type": "whitelist"
+        }
+    ]
+]
+
+message := helpers.get_multi_summary(conditions, vars.variables).message
+details := helpers.get_multi_summary(conditions, vars.variables).details

--- a/scripts/linters/_tests/fixtures/fixtures_bad/policies/gcp/Cloud Storage/google_storage_bucket/uniform_bucket_level_access.rego
+++ b/scripts/linters/_tests/fixtures/fixtures_bad/policies/gcp/Cloud Storage/google_storage_bucket/uniform_bucket_level_access.rego
@@ -1,0 +1,22 @@
+package terraform.gcp.security.cloud_storage.google_storage_bucket.uniform_bucket_level_access
+
+import data.terraform.helpers
+import data.terraform.gcp.security.cloud_storage.google_storage_bucket.vars
+
+conditions := [
+    [
+        {
+            "situation_description": "Bucket does not enforce uniform bucket-level access.",
+            "remedies": ["Set uniform_bucket_level_access to true."]
+        },
+        {
+            "condition": "Uniform bucket-level access must be enabled.",
+            "attribute_path": ["uniform_bucket_level_access"],
+            "values": [true],
+            "policy_type": "whitelist"
+        }
+    ]
+]
+
+message := helpers.get_multi_summary(conditions, vars.variables).message
+details := helpers.get_multi_summary(conditions, vars.variables).details

--- a/scripts/linters/_tests/fixtures/policy_smells/docs/gcp/Backup for GKE/google_gke_backup_restore_channel.json
+++ b/scripts/linters/_tests/fixtures/policy_smells/docs/gcp/Backup for GKE/google_gke_backup_restore_channel.json
@@ -1,0 +1,69 @@
+{
+  "last_updated": "2026-08-30T00:00:00Z",
+  "provider_version": "7.37.0",
+  "arguments": {
+    "destination_project": {
+      "description": "Fixture argument.",
+      "required": false,
+      "type": "string",
+      "security_impact": true,
+      "rationale": "Fixture."
+    },
+    "location": {
+      "description": "Fixture argument.",
+      "required": false,
+      "type": "string",
+      "security_impact": true,
+      "rationale": "Fixture."
+    },
+    "members": {
+      "description": "Fixture argument.",
+      "required": false,
+      "type": "list(string)",
+      "security_impact": true,
+      "rationale": "Fixture."
+    },
+    "labels": {
+      "description": "Fixture argument.",
+      "required": false,
+      "type": "map(string)",
+      "security_impact": true,
+      "rationale": "Fixture."
+    },
+    "constraint": {
+      "description": "Fixture argument.",
+      "required": false,
+      "type": "string",
+      "security_impact": true,
+      "rationale": "Fixture."
+    },
+    "brief": {
+      "description": "Fixture argument.",
+      "required": false,
+      "type": "string",
+      "security_impact": true,
+      "rationale": "Fixture."
+    },
+    "legacy": {
+      "description": "Fixture argument.",
+      "required": false,
+      "type": "string",
+      "security_impact": true,
+      "rationale": "Fixture."
+    },
+    "badcase": {
+      "description": "Fixture argument.",
+      "required": false,
+      "type": "string",
+      "security_impact": true,
+      "rationale": "Fixture."
+    },
+    "short": {
+      "description": "Fixture argument.",
+      "required": false,
+      "type": "string",
+      "security_impact": true,
+      "rationale": "Fixture."
+    }
+  }
+}

--- a/scripts/linters/_tests/fixtures/policy_smells/policies/gcp/Backup for GKE/google_gke_backup_restore_channel/_vars.rego
+++ b/scripts/linters/_tests/fixtures/policy_smells/policies/gcp/Backup for GKE/google_gke_backup_restore_channel/_vars.rego
@@ -1,0 +1,7 @@
+package terraform.gcp.security.backup_for_gke.google_gke_backup_restore_channel.vars
+
+variables := {
+    "friendly_resource_name": "GKE Restore Channel",
+    "resource_type": "google_gke_backup_restore_channel",
+    "resource_value_name": "name"
+}

--- a/scripts/linters/_tests/fixtures/policy_smells/policies/gcp/Backup for GKE/google_gke_backup_restore_channel/badcase.rego
+++ b/scripts/linters/_tests/fixtures/policy_smells/policies/gcp/Backup for GKE/google_gke_backup_restore_channel/badcase.rego
@@ -1,0 +1,22 @@
+package terraform.gcp.security.BackupForGKE.google_gke_backup_restore_channel.badcase
+
+import data.terraform.helpers
+import data.terraform.gcp.security.backup_for_gke.google_gke_backup_restore_channel.vars
+
+conditions := [
+    [
+        {
+            "situation_description": "Badcase argument is set to an unapproved value.",
+            "remedies": ["Set badcase to 'approved'."]
+        },
+        {
+            "condition": "Badcase must be approved.",
+            "attribute_path": ["badcase"],
+            "values": ["approved"],
+            "policy_type": "whitelist"
+        }
+    ]
+]
+
+message := helpers.get_multi_summary(conditions, vars.variables).message
+details := helpers.get_multi_summary(conditions, vars.variables).details

--- a/scripts/linters/_tests/fixtures/policy_smells/policies/gcp/Backup for GKE/google_gke_backup_restore_channel/brief.rego
+++ b/scripts/linters/_tests/fixtures/policy_smells/policies/gcp/Backup for GKE/google_gke_backup_restore_channel/brief.rego
@@ -1,0 +1,22 @@
+package terraform.gcp.security.backup_for_gke.google_gke_backup_restore_channel.brief
+
+import data.terraform.helpers
+import data.terraform.gcp.security.backup_for_gke.google_gke_backup_restore_channel.vars
+
+conditions := [
+    [
+        {
+            "situation_description": "Brief is set to an unapproved value.",
+            "remedies": []
+        },
+        {
+            "condition": "Brief must be approved.",
+            "attribute_path": ["brief"],
+            "values": ["approved"],
+            "policy_type": "whitelist"
+        }
+    ]
+]
+
+message := helpers.get_multi_summary(conditions, vars.variables).message
+details := helpers.get_multi_summary(conditions, vars.variables).details

--- a/scripts/linters/_tests/fixtures/policy_smells/policies/gcp/Backup for GKE/google_gke_backup_restore_channel/constraint.rego
+++ b/scripts/linters/_tests/fixtures/policy_smells/policies/gcp/Backup for GKE/google_gke_backup_restore_channel/constraint.rego
@@ -1,0 +1,22 @@
+package terraform.gcp.security.backup_for_gke.google_gke_backup_restore_channel.constraint
+
+import data.terraform.helpers
+import data.terraform.gcp.security.backup_for_gke.google_gke_backup_restore_channel.vars
+
+conditions := [
+    [
+        {
+            "situation_description": "List policies must not inherit from the parent folder.",
+            "remedies": ["Set list_policy.inherit_from_parent to false."]
+        },
+        {
+            "condition": "Block inheritance from parent.",
+            "attribute_path": ["list_policy", "inherit_from_parent"],
+            "values": [true],
+            "policy_type": "blacklist"
+        }
+    ]
+]
+
+message := helpers.get_multi_summary(conditions, vars.variables).message
+details := helpers.get_multi_summary(conditions, vars.variables).details

--- a/scripts/linters/_tests/fixtures/policy_smells/policies/gcp/Backup for GKE/google_gke_backup_restore_channel/destination_project.rego
+++ b/scripts/linters/_tests/fixtures/policy_smells/policies/gcp/Backup for GKE/google_gke_backup_restore_channel/destination_project.rego
@@ -1,0 +1,22 @@
+package terraform.gcp.security.backup_for_gke.google_gke_backup_restore_channel.destination_project
+
+import data.terraform.helpers
+import data.terraform.gcp.security.backup_for_gke.google_gke_backup_restore_channel.vars
+
+conditions := [
+    [
+        {
+            "situation_description": "Restore channel points at an unapproved destination project.",
+            "remedies": ["Set destination_project to an approved project."]
+        },
+        {
+            "condition": "Destination project must be the approved one.",
+            "attribute_path": ["destination_project"],
+            "values": ["projects/PDE"],
+            "policy_type": "whitelist"
+        }
+    ]
+]
+
+message := helpers.get_multi_summary(conditions, vars.variables).message
+details := helpers.get_multi_summary(conditions, vars.variables).details

--- a/scripts/linters/_tests/fixtures/policy_smells/policies/gcp/Backup for GKE/google_gke_backup_restore_channel/labels.rego
+++ b/scripts/linters/_tests/fixtures/policy_smells/policies/gcp/Backup for GKE/google_gke_backup_restore_channel/labels.rego
@@ -1,0 +1,22 @@
+package terraform.gcp.security.backup_for_gke.google_gke_backup_restore_channel.labels
+
+import data.terraform.helpers
+import data.terraform.gcp.security.backup_for_gke.google_gke_backup_restore_channel.vars
+
+conditions := [
+    [
+        {
+            "situation_description": "Restore channel must carry an 'environment' label.",
+            "remedies": ["Ensure labels.environment is set and not empty."]
+        },
+        {
+            "condition": "Label environment must not be empty.",
+            "attribute_path": ["labels", "environment"],
+            "values": [null, ""],
+            "policy_type": "blacklist"
+        }
+    ]
+]
+
+message := helpers.get_multi_summary(conditions, vars.variables).message
+details := helpers.get_multi_summary(conditions, vars.variables).details

--- a/scripts/linters/_tests/fixtures/policy_smells/policies/gcp/Backup for GKE/google_gke_backup_restore_channel/legacy.rego
+++ b/scripts/linters/_tests/fixtures/policy_smells/policies/gcp/Backup for GKE/google_gke_backup_restore_channel/legacy.rego
@@ -1,0 +1,22 @@
+package terraform.gcp.security.backup_for_gke.google_gke_backup_restore_channel.legacy
+
+import data.terraform.helpers
+import data.terraform.gcp.security.backup_for_gke.google_gke_backup_restore_channel.vars
+
+conditions := [
+    [
+        {
+            "situation_description": "Legacy argument is set to an unapproved value.",
+            "remedies": ["Set legacy to 'approved'."]
+        },
+        {
+            "condition": "Legacy must be approved.",
+            "attribute_path": ["legacy"],
+            "values": ["approved"],
+            "policy_type": "whitelist"
+        }
+    ]
+]
+
+message = helpers.get_multi_summary(conditions, vars.variables).message
+details = helpers.get_multi_summary(conditions, vars.variables).details

--- a/scripts/linters/_tests/fixtures/policy_smells/policies/gcp/Backup for GKE/google_gke_backup_restore_channel/location.rego
+++ b/scripts/linters/_tests/fixtures/policy_smells/policies/gcp/Backup for GKE/google_gke_backup_restore_channel/location.rego
@@ -1,0 +1,22 @@
+package terraform.gcp.security.backup_for_gke.google_gke_backup_restore_channel.location
+
+import data.terraform.helpers
+import data.terraform.gcp.security.backup_for_gke.google_gke_backup_restore_channel.vars
+
+conditions := [
+    [
+        {
+            "situation_description": "Restore channel must live in an approved location.",
+            "remedies": ["Set location to australia-southeast1."]
+        },
+        {
+            "condition": "Location must be australia-southeast1.",
+            "attribute_path": ["location"],
+            "values": ["projects/pde-prod/locations/australia-southeast1"],
+            "policy_type": "whitelist"
+        }
+    ]
+]
+
+message := helpers.get_multi_summary(conditions, vars.variables).message
+details := helpers.get_multi_summary(conditions, vars.variables).details

--- a/scripts/linters/_tests/fixtures/policy_smells/policies/gcp/Backup for GKE/google_gke_backup_restore_channel/members.rego
+++ b/scripts/linters/_tests/fixtures/policy_smells/policies/gcp/Backup for GKE/google_gke_backup_restore_channel/members.rego
@@ -1,0 +1,22 @@
+package terraform.gcp.security.backup_for_gke.google_gke_backup_restore_channel.members
+
+import data.terraform.helpers
+import data.terraform.gcp.security.backup_for_gke.google_gke_backup_restore_channel.vars
+
+conditions := [
+    [
+        {
+            "situation_description": "Access granted to the whole internet.",
+            "remedies": ["Remove allUsers and allAuthenticatedUsers from members."]
+        },
+        {
+            "condition": "Public access should be prohibited.",
+            "attribute_path": ["members", 0],
+            "values": ["allUsers", "allAuthenticatedUsers"],
+            "policy_type": "blacklist"
+        }
+    ]
+]
+
+message := helpers.get_multi_summary(conditions, vars.variables).message
+details := helpers.get_multi_summary(conditions, vars.variables).details

--- a/scripts/linters/_tests/fixtures/policy_smells/policies/gcp/Backup for GKE/google_gke_backup_restore_channel/short.rego
+++ b/scripts/linters/_tests/fixtures/policy_smells/policies/gcp/Backup for GKE/google_gke_backup_restore_channel/short.rego
@@ -1,0 +1,22 @@
+package terraform.gcp.security.backup_for_gke.google_gke_backup_restore_channel.short
+
+import data.terraform.helpers
+import data.terraform.gcp.security.backup_for_gke.google_gke_backup_restore_channel.vars
+
+conditions := [
+    [
+        {
+            "situation_description": "Bad value.",
+            "remedies": ["Set short to 'approved'."]
+        },
+        {
+            "condition": "Short must be approved.",
+            "attribute_path": ["short"],
+            "values": ["approved"],
+            "policy_type": "whitelist"
+        }
+    ]
+]
+
+message := helpers.get_multi_summary(conditions, vars.variables).message
+details := helpers.get_multi_summary(conditions, vars.variables).details

--- a/scripts/linters/_tests/fixtures/string_path/docs/gcp/Cloud Platform/google_service_account.json
+++ b/scripts/linters/_tests/fixtures/string_path/docs/gcp/Cloud Platform/google_service_account.json
@@ -1,0 +1,5 @@
+{
+  "last_updated": "2026-08-30T00:00:00Z",
+  "provider_version": "7.37.0",
+  "arguments": {}
+}

--- a/scripts/linters/_tests/fixtures/string_path/policies/gcp/Cloud Platform/google_service_account/_vars.rego
+++ b/scripts/linters/_tests/fixtures/string_path/policies/gcp/Cloud Platform/google_service_account/_vars.rego
@@ -1,0 +1,7 @@
+package terraform.gcp.security.cloud_platform_service.google_service_account.vars
+
+variables := {
+    "friendly_resource_name": "Service Account",
+    "resource_type": "google_service_account",
+    "resource_value_name": "account_id"
+}

--- a/scripts/linters/_tests/fixtures/string_path/policies/gcp/Cloud Platform/google_service_account/disabled.rego
+++ b/scripts/linters/_tests/fixtures/string_path/policies/gcp/Cloud Platform/google_service_account/disabled.rego
@@ -1,0 +1,19 @@
+package terraform.gcp.security.cloud_platform_service.google_service_account.disabled
+
+import data.terraform.helpers
+import data.terraform.gcp.security.cloud_platform_service.google_service_account.vars
+
+# attribute_path given as a bare string — a form shared.rego supports.
+conditions := [
+  [
+    {"situation_description": "Service account is created in a disabled state.",
+     "remedies": ["Create active identities; disable later with justification."]},
+    {"condition": "Disabled on creation",
+     "attribute_path": "disabled",
+     "values": [true],
+     "policy_type": "blacklist"}
+  ]
+]
+
+message := helpers.get_multi_summary(conditions, vars.variables).message
+details := helpers.get_multi_summary(conditions, vars.variables).details

--- a/scripts/linters/_tests/fixtures/string_path/policies/gcp/Cloud Platform/google_service_account/keys.key_algorithm.rego
+++ b/scripts/linters/_tests/fixtures/string_path/policies/gcp/Cloud Platform/google_service_account/keys.key_algorithm.rego
@@ -1,0 +1,18 @@
+package terraform.gcp.security.cloud_platform_service.google_service_account.keys_key_algorithm
+
+import data.terraform.helpers
+import data.terraform.gcp.security.cloud_platform_service.google_service_account.vars
+
+conditions := [
+  [
+    {"situation_description": "Service account key uses a weak signing algorithm.",
+     "remedies": ["Use KEY_ALG_RSA_2048 or stronger."]},
+    {"condition": "Key algorithm must be strong",
+     "attribute_path": "keys.key_algorithm",
+     "values": ["KEY_ALG_RSA_2048"],
+     "policy_type": "whitelist"}
+  ]
+]
+
+message := helpers.get_multi_summary(conditions, vars.variables).message
+details := helpers.get_multi_summary(conditions, vars.variables).details

--- a/scripts/linters/_tests/fixtures/vars_bad/docs/gcp/Compute Service/google_a_thing.json
+++ b/scripts/linters/_tests/fixtures/vars_bad/docs/gcp/Compute Service/google_a_thing.json
@@ -1,0 +1,5 @@
+{
+  "last_updated": "2026-08-30T00:00:00Z",
+  "provider_version": "7.37.0",
+  "arguments": {}
+}

--- a/scripts/linters/_tests/fixtures/vars_bad/docs/gcp/Compute Service/google_b_thing.json
+++ b/scripts/linters/_tests/fixtures/vars_bad/docs/gcp/Compute Service/google_b_thing.json
@@ -1,0 +1,5 @@
+{
+  "last_updated": "2026-08-30T00:00:00Z",
+  "provider_version": "7.37.0",
+  "arguments": {}
+}

--- a/scripts/linters/_tests/fixtures/vars_bad/docs/gcp/Compute Service/google_c_thing.json
+++ b/scripts/linters/_tests/fixtures/vars_bad/docs/gcp/Compute Service/google_c_thing.json
@@ -1,0 +1,5 @@
+{
+  "last_updated": "2026-08-30T00:00:00Z",
+  "provider_version": "7.37.0",
+  "arguments": {}
+}

--- a/scripts/linters/_tests/fixtures/vars_bad/docs/gcp/Compute Service/google_d_thing.json
+++ b/scripts/linters/_tests/fixtures/vars_bad/docs/gcp/Compute Service/google_d_thing.json
@@ -1,0 +1,5 @@
+{
+  "last_updated": "2026-08-30T00:00:00Z",
+  "provider_version": "7.37.0",
+  "arguments": {}
+}

--- a/scripts/linters/_tests/fixtures/vars_bad/docs/gcp/Compute Service/google_e_thing.json
+++ b/scripts/linters/_tests/fixtures/vars_bad/docs/gcp/Compute Service/google_e_thing.json
@@ -1,0 +1,5 @@
+{
+  "last_updated": "2026-08-30T00:00:00Z",
+  "provider_version": "7.37.0",
+  "arguments": {}
+}

--- a/scripts/linters/_tests/fixtures/vars_bad/policies/gcp/Compute Service/google_a_thing/_vars.rego
+++ b/scripts/linters/_tests/fixtures/vars_bad/policies/gcp/Compute Service/google_a_thing/_vars.rego
@@ -1,0 +1,7 @@
+package terraform.gcp.security.compute_service.google_a_thing.vars
+
+variables := {
+    "friendly_resource_name": "Shared Fixture Name",
+    "resource_type": "a_thing",
+    "resource_value_name": "name"
+}

--- a/scripts/linters/_tests/fixtures/vars_bad/policies/gcp/Compute Service/google_b_thing/_vars.rego
+++ b/scripts/linters/_tests/fixtures/vars_bad/policies/gcp/Compute Service/google_b_thing/_vars.rego
@@ -1,0 +1,7 @@
+package terraform.gcp.security.compute_service.google_b_thing.vars
+
+variables := {
+    "friendly_resource_name": "Shared Fixture Name",
+    "resource_type": "google_b_thing",
+    "resource_value_name": "name"
+}

--- a/scripts/linters/_tests/fixtures/vars_bad/policies/gcp/Compute Service/google_c_thing/_vars.rego
+++ b/scripts/linters/_tests/fixtures/vars_bad/policies/gcp/Compute Service/google_c_thing/_vars.rego
@@ -1,0 +1,7 @@
+package terraform.gcp.security.compute_service.google_c_thing.vars
+
+variables := {
+    "friendly_resource_name": "",
+    "resource_type": "google_c_thing",
+    "resource_value_name": "name"
+}

--- a/scripts/linters/_tests/fixtures/vars_bad/policies/gcp/Compute Service/google_d_thing/_vars.rego
+++ b/scripts/linters/_tests/fixtures/vars_bad/policies/gcp/Compute Service/google_d_thing/_vars.rego
@@ -1,0 +1,7 @@
+package terraform.gcp.security.compute_service.google_d_thing.vars
+
+variables := {
+    "friendly_resource_name": "google_d_thing",
+    "resource_type": "google_d_thing",
+    "resource_value_name": "name"
+}

--- a/scripts/linters/_tests/fixtures/vars_bad/policies/gcp/Compute Service/google_e_thing/_vars.rego
+++ b/scripts/linters/_tests/fixtures/vars_bad/policies/gcp/Compute Service/google_e_thing/_vars.rego
@@ -1,0 +1,7 @@
+package terraform.gcp.security.compute_service.google_e_thing.vars
+
+variables := {
+    "friendly_resource_name": "E Thing",
+    "resource_type": "google_e_thing",
+    "resource_value_name": "name"
+}

--- a/scripts/linters/_tests/test_policy_lint.py
+++ b/scripts/linters/_tests/test_policy_lint.py
@@ -110,14 +110,16 @@ def test_hard_coded_value_message_names_the_literal(tmp_path):
     assert "projects/PDE" in hard[0].message
 
 
-def test_only_style_rules_are_warnings(tmp_path):
+def test_only_advisory_rules_are_warnings(tmp_path):
+    # The two style conventions plus presence-only, which is a judgement about
+    # the argument's rationale that the reviewer makes, not the linter.
     root = build_tree(tmp_path, "policy_smells")
     findings = policy_lint.lint_resource(
         root, "gcp", "Backup for GKE", "google_gke_backup_restore_channel")
     warns = {f.rule for f in findings if f.severity == "warn"}
     errors = {f.rule for f in findings if f.severity == "error"}
-    assert warns == {"legacy-assign", "package-case"}
-    assert "legacy-assign" not in errors and "package-case" not in errors
+    assert warns == {"legacy-assign", "package-case", "presence-only"}
+    assert not (warns & errors), "a rule must have one severity, not both"
 
 
 def test_findings_carry_the_service_and_resource(tmp_path):
@@ -257,7 +259,7 @@ def test_cli_exits_zero_on_a_clean_resource(tmp_path, capsys):
 def test_cli_exits_zero_when_only_warnings_are_found(tmp_path, capsys):
     # A tree whose only findings are warn-severity must not fail the build.
     root = build_tree(tmp_path, "policy_smells")
-    for name in ("destination_project", "members", "labels", "constraint", "brief", "short"):
+    for name in ("destination_project", "members", "constraint", "brief", "short"):
         (root / "policies" / "gcp" / "Backup for GKE"
          / "google_gke_backup_restore_channel" / f"{name}.rego").unlink()
     rc = policy_lint.main([
@@ -265,6 +267,7 @@ def test_cli_exits_zero_when_only_warnings_are_found(tmp_path, capsys):
         "gcp/Backup for GKE/google_gke_backup_restore_channel"])
     data = json.loads(capsys.readouterr().out)
     assert {e["severity"] for e in data} == {"warn"}
+    assert {e["rule"] for e in data} == {"legacy-assign", "package-case", "presence-only"}
     assert rc == 0
 
 
@@ -408,3 +411,148 @@ def test_identity_exemption_only_covers_the_fixture_labels(tmp_path):
     drift = [f for f in findings if f.rule == "fixture-drift"]
     assert len(drift) == 1
     assert "bucket" in drift[0].message
+
+
+# --------------------------------------------------------------------------- #
+# Fix wave 2: a broken file must not make the vars index fan out.
+# --------------------------------------------------------------------------- #
+def _break_one_policy(root):
+    """Drop an unparseable .rego into a tree, so the batched eval fails."""
+    broken = (root / "policies" / "gcp" / "Compute Service" / "google_a_thing"
+              / "oops.rego")
+    broken.write_text("package terraform.gcp.security.compute_service."
+                      "google_a_thing.oops\n\nconditions := [[[[\n")
+    return broken
+
+
+def test_friendly_index_does_not_fan_out_when_the_batch_fails(tmp_path, monkeypatch):
+    # The batched eval fails because of the broken file. Falling back to one opa
+    # call per _vars.rego cost 370 subprocesses (~9s); the text of the file is
+    # enough to read a friendly name, so no fan-out is needed.
+    root = build_tree(tmp_path, "vars_bad")
+    _break_one_policy(root)
+    policy_lint.clear_caches()
+
+    real_run = subprocess.run
+    calls = []
+
+    def counting_run(cmd, *args, **kwargs):
+        calls.append(cmd)
+        return real_run(cmd, *args, **kwargs)
+
+    monkeypatch.setattr(policy_lint.subprocess, "run", counting_run)
+    index = policy_lint._friendly_name_index(root / "policies", "gcp")
+
+    assert len(calls) <= 2, f"the index fanned out: {len(calls)} opa calls"
+    # ...and it is still complete: the duplicate pair is still detected.
+    assert sorted(rt for _, rt in index["shared fixture name"]) == [
+        "google_a_thing", "google_b_thing"]
+
+
+def test_duplicate_friendly_names_still_found_with_a_broken_file(tmp_path):
+    root = build_tree(tmp_path, "vars_bad")
+    _break_one_policy(root)
+    findings = policy_lint.lint_resource(root, "gcp", "Compute Service", "google_b_thing")
+    assert ("_vars", "vars-friendly-name") in pairs(findings)
+
+
+# --------------------------------------------------------------------------- #
+# Fix wave 2: presence-only is a warning — the reviewer rules on the rationale.
+# --------------------------------------------------------------------------- #
+def test_presence_only_is_a_warning(tmp_path):
+    root = build_tree(tmp_path, "policy_smells")
+    findings = policy_lint.lint_resource(
+        root, "gcp", "Backup for GKE", "google_gke_backup_restore_channel")
+    presence = [f for f in findings if f.rule == "presence-only"]
+    assert len(presence) == 1
+    assert presence[0].severity == "warn"
+    assert "presence-only" in policy_lint.WARN_RULES
+
+
+# --------------------------------------------------------------------------- #
+# Fix wave 2: a malformed plan cache is a finding, not an AttributeError.
+# --------------------------------------------------------------------------- #
+@pytest.mark.parametrize("payload", ['[]', '"nope"', '{"planned_values": []}',
+                                     '{"planned_values": {"root_module": "x"}}'])
+def test_malformed_plan_cache_is_a_lint_error(tmp_path, payload):
+    root = build_tree(tmp_path, "clean")
+    input_dir = (root / "inputs" / "gcp" / "Cloud Storage" / "google_storage_bucket"
+                 / "public_access_prevention")
+    policy_lint.plan_cache_for(root, input_dir).write_text(payload)
+    findings = policy_lint.lint_resource(root, "gcp", "Cloud Storage", "google_storage_bucket")
+    assert pairs(findings) == {("public_access_prevention", "lint-error")}
+
+
+# --------------------------------------------------------------------------- #
+# Fix wave 2: no `opa` on PATH is one environment error, not N findings.
+# --------------------------------------------------------------------------- #
+def test_missing_opa_binary_propagates_once(tmp_path, monkeypatch):
+    root = build_tree(tmp_path, "policy_smells")
+    policy_lint.clear_caches()
+
+    def no_opa(cmd, *args, **kwargs):
+        raise FileNotFoundError(2, "No such file or directory", "opa")
+
+    monkeypatch.setattr(policy_lint.subprocess, "run", no_opa)
+    with pytest.raises(policy_lint.PolicyLintError) as excinfo:
+        policy_lint.lint_resource(
+            root, "gcp", "Backup for GKE", "google_gke_backup_restore_channel")
+    assert "opa" in str(excinfo.value)
+    # run_precommit_linter.py catches PolicyLintError for exactly this case.
+    assert isinstance(excinfo.value, policy_lint.PolicyLintError)
+
+
+def test_missing_opa_binary_is_one_cli_error(tmp_path, monkeypatch, capsys):
+    root = build_tree(tmp_path, "policy_smells")
+    policy_lint.clear_caches()
+    monkeypatch.setattr(policy_lint.subprocess, "run",
+                        lambda *a, **k: (_ for _ in ()).throw(FileNotFoundError()))
+    rc = policy_lint.main([
+        "--root", str(root), "gcp/Backup for GKE/google_gke_backup_restore_channel"])
+    err = capsys.readouterr().err
+    assert rc == 2
+    assert err.count("[ERROR]") == 1, f"expected a single environment error, got:\n{err}"
+
+
+# --------------------------------------------------------------------------- #
+# Fix wave 2: unpaired fixture resources are reported, not skipped.
+# --------------------------------------------------------------------------- #
+def test_unpaired_fixture_resource_is_reported(tmp_path):
+    root = build_tree(tmp_path, "clean")
+    input_dir = (root / "inputs" / "gcp" / "Cloud Storage" / "google_storage_bucket"
+                 / "public_access_prevention")
+    cache = policy_lint.plan_cache_for(root, input_dir)
+    plan = json.loads(cache.read_text())
+    resources = plan["planned_values"]["root_module"]["resources"]
+    # A second non-compliant example with no compliant counterpart.
+    orphan = json.loads(json.dumps(
+        [r for r in resources if r["name"] == "non_compliant_example_1"][0]))
+    orphan["name"] = "non_compliant_example_2"
+    orphan["values"]["name"] = "non_compliant_example_2"
+    resources.append(orphan)
+    cache.write_text(json.dumps(plan))
+
+    findings = policy_lint.lint_resource(root, "gcp", "Cloud Storage", "google_storage_bucket")
+    assert pairs(findings) == {("public_access_prevention", "fixture-unpaired")}
+    assert "non_compliant_example_2" in findings[0].message
+    assert "fixture-unpaired" in policy_lint.RULES
+
+
+# --------------------------------------------------------------------------- #
+# Fix wave 2: a resource type with no policies directory is machine-readable.
+# --------------------------------------------------------------------------- #
+def test_missing_policies_dir_prints_a_marker(tmp_path, capsys):
+    root = build_tree(tmp_path, "clean")
+    target = "gcp/Cloud Storage/google_storage_bucket_iam_binding"
+    rc = policy_lint.main(["--root", str(root), target])
+    err = capsys.readouterr().err
+    assert rc == 2
+    assert f"[ERROR] no-policies-dir: {target}" in err
+
+
+def test_mistyped_service_is_not_a_no_policies_dir_marker(tmp_path, capsys):
+    root = build_tree(tmp_path, "clean")
+    rc = policy_lint.main(["--root", str(root), "gcp/Clod Storage/google_storage_bucket"])
+    err = capsys.readouterr().err
+    assert rc == 2
+    assert "no-policies-dir" not in err

--- a/scripts/linters/_tests/test_policy_lint.py
+++ b/scripts/linters/_tests/test_policy_lint.py
@@ -1,0 +1,278 @@
+"""Unit tests for scripts/linters/policy_lint.py.
+
+Each case under ``fixtures/`` is a miniature repo tree (``docs/``, ``policies/``,
+``inputs/``). The trees are copied into ``tmp_path`` before every test and the
+committed ``expected_plan.json`` next to a fixture's ``*.tf`` files is installed
+at the sha-named path ``inputs/plan_cache/<platform>/<sha>.json`` that
+``auto_test.plan_cache_path`` derives. Installing it at copy time (instead of
+committing it under that name) keeps the tests correct when the pinned provider
+version changes — the sha is recomputed from the same function the pipeline uses.
+"""
+
+import json
+import shutil
+import sys
+from pathlib import Path
+
+import pytest
+
+project_root = Path(__file__).parent.parent.parent.parent
+sys.path.insert(0, str(project_root))
+
+from scripts.auto_test import auto_test
+from scripts.linters import policy_lint
+
+FIXTURES = Path(__file__).parent / "fixtures"
+
+
+def build_tree(tmp_path, case):
+    """Copy fixture ``case`` into tmp_path and install its plan-cache entries."""
+    dst = tmp_path / case
+    shutil.copytree(FIXTURES / case, dst)
+    for template in sorted(dst.rglob("expected_plan.json")):
+        cache = policy_lint.plan_cache_for(dst, template.parent)
+        # Guard rail: a bug in the re-rooting would otherwise have these tests
+        # writing plan-cache entries into the real repo.
+        assert dst in cache.parents, f"{cache} escaped the fixture tree {dst}"
+        cache.parent.mkdir(parents=True, exist_ok=True)
+        shutil.copyfile(template, cache)
+        template.unlink()
+    return dst
+
+
+def pairs(findings):
+    """{(policy, rule)} — the assertion surface for most rules."""
+    return {(f.policy, f.rule) for f in findings}
+
+
+# --------------------------------------------------------------------------- #
+# Control: a clean resource produces nothing at all.
+# --------------------------------------------------------------------------- #
+def test_clean_resource_has_no_findings(tmp_path):
+    root = build_tree(tmp_path, "clean")
+    findings = policy_lint.lint_resource(root, "gcp", "Cloud Storage", "google_storage_bucket")
+    assert findings == [], f"clean fixture must be silent, got {findings}"
+
+
+# --------------------------------------------------------------------------- #
+# Policy-body rules.
+# --------------------------------------------------------------------------- #
+def test_policy_body_rules_fire_exactly_once_each(tmp_path):
+    root = build_tree(tmp_path, "policy_smells")
+    findings = policy_lint.lint_resource(
+        root, "gcp", "Backup for GKE", "google_gke_backup_restore_channel")
+
+    assert pairs(findings) == {
+        ("destination_project", "hard-coded-value"),
+        ("members", "index-path"),
+        ("labels", "presence-only"),
+        ("constraint", "wrong-argument"),
+        ("brief", "trivial-message"),
+        ("short", "trivial-message"),
+        ("legacy", "legacy-assign"),
+        ("badcase", "package-case"),
+    }
+
+
+def test_trivial_message_flags_short_text_and_empty_remedies_separately(tmp_path):
+    root = build_tree(tmp_path, "policy_smells")
+    findings = policy_lint.lint_resource(
+        root, "gcp", "Backup for GKE", "google_gke_backup_restore_channel")
+    by_policy = {f.policy: f.message for f in findings if f.rule == "trivial-message"}
+    assert "remedies is empty" in by_policy["brief"]     # long enough, no remedies
+    assert "under 20 characters" in by_policy["short"]   # has remedies, too short
+
+
+def test_location_argument_is_exempt_from_hard_coded_value(tmp_path):
+    # location.rego carries "projects/pde-prod/locations/australia-southeast1" —
+    # the same literal shape that flags destination_project — and must stay clean.
+    root = build_tree(tmp_path, "policy_smells")
+    findings = policy_lint.lint_resource(
+        root, "gcp", "Backup for GKE", "google_gke_backup_restore_channel")
+    assert [f for f in findings if f.policy == "location"] == []
+
+
+def test_hard_coded_value_message_names_the_literal(tmp_path):
+    root = build_tree(tmp_path, "policy_smells")
+    findings = policy_lint.lint_resource(
+        root, "gcp", "Backup for GKE", "google_gke_backup_restore_channel")
+    hard = [f for f in findings if f.rule == "hard-coded-value"]
+    assert len(hard) == 1
+    assert "projects/PDE" in hard[0].message
+
+
+def test_only_style_rules_are_warnings(tmp_path):
+    root = build_tree(tmp_path, "policy_smells")
+    findings = policy_lint.lint_resource(
+        root, "gcp", "Backup for GKE", "google_gke_backup_restore_channel")
+    warns = {f.rule for f in findings if f.severity == "warn"}
+    errors = {f.rule for f in findings if f.severity == "error"}
+    assert warns == {"legacy-assign", "package-case"}
+    assert "legacy-assign" not in errors and "package-case" not in errors
+
+
+def test_findings_carry_the_service_and_resource(tmp_path):
+    root = build_tree(tmp_path, "policy_smells")
+    findings = policy_lint.lint_resource(
+        root, "gcp", "Backup for GKE", "google_gke_backup_restore_channel")
+    assert {f.service for f in findings} == {"Backup for GKE"}
+    assert {f.resource for f in findings} == {"google_gke_backup_restore_channel"}
+
+
+# --------------------------------------------------------------------------- #
+# _vars.rego rules.
+# --------------------------------------------------------------------------- #
+@pytest.mark.parametrize("resource_type,expected", [
+    # a_thing: resource_type doesn't match the directory AND shares a friendly name
+    ("google_a_thing", {("_vars", "vars-resource-type"), ("_vars", "vars-friendly-name")}),
+    ("google_b_thing", {("_vars", "vars-friendly-name")}),   # duplicate friendly name
+    ("google_c_thing", {("_vars", "vars-friendly-name")}),   # empty
+    ("google_d_thing", {("_vars", "vars-friendly-name")}),   # equals the raw TF type
+    ("google_e_thing", set()),                               # control
+])
+def test_vars_rules(tmp_path, resource_type, expected):
+    root = build_tree(tmp_path, "vars_bad")
+    findings = policy_lint.lint_resource(root, "gcp", "Compute Service", resource_type)
+    assert pairs(findings) == expected
+
+
+def test_duplicate_friendly_name_message_names_the_other_resource(tmp_path):
+    root = build_tree(tmp_path, "vars_bad")
+    findings = policy_lint.lint_resource(root, "gcp", "Compute Service", "google_a_thing")
+    dup = [f for f in findings if f.rule == "vars-friendly-name"]
+    assert len(dup) == 1
+    assert "google_b_thing" in dup[0].message
+
+
+# --------------------------------------------------------------------------- #
+# Fixture rules.
+# --------------------------------------------------------------------------- #
+def test_fixture_drift_and_missing_plan(tmp_path):
+    root = build_tree(tmp_path, "fixtures_bad")
+    findings = policy_lint.lint_resource(root, "gcp", "Cloud Storage", "google_storage_bucket")
+    assert pairs(findings) == {
+        ("public_access_prevention", "fixture-drift"),
+        ("uniform_bucket_level_access", "fixture-missing-plan"),
+    }
+    missing = [f for f in findings if f.rule == "fixture-missing-plan"][0]
+    assert "no committed plan cache" in missing.message
+    drift = [f for f in findings if f.rule == "fixture-drift"][0]
+    # storage_class is the only attribute that differs besides name and the
+    # argument under test — it must be the one named.
+    assert "storage_class" in drift.message
+    assert "public_access_prevention" not in drift.message.split(":", 1)[-1]
+
+
+@pytest.mark.parametrize("resource_type,noise", [
+    # `bucket` is this resource's identity attribute (_vars.resource_value_name),
+    # so the two fixtures must differ on it — that is not drift.
+    ("google_storage_bucket_iam_binding", "bucket"),
+    # effective_labels/terraform_labels are provider-computed mirrors of `labels`
+    # and always move with it.
+    ("google_storage_bucket", "effective_labels"),
+])
+def test_fixture_drift_ignores_identity_and_computed_mirrors(tmp_path, resource_type, noise):
+    root = build_tree(tmp_path, "fixture_noise")
+    findings = policy_lint.lint_resource(root, "gcp", "Cloud Storage", resource_type)
+    assert [f for f in findings if f.rule == "fixture-drift"] == [], \
+        f"{noise} must not be read as drift"
+    # And the plan really does differ on it, so the exemption is doing work.
+    plan_dir = root / "inputs" / "gcp" / "Cloud Storage" / resource_type
+    cache = policy_lint.plan_cache_for(root, next(plan_dir.iterdir()))
+    plan = json.loads(cache.read_text())
+    values = {r["name"]: r["values"]
+              for r in plan["planned_values"]["root_module"]["resources"]}
+    good, bad = values["compliant_example_1"], values["non_compliant_example_1"]
+    assert good.get(noise) != bad.get(noise)
+
+
+def test_plan_cache_for_matches_auto_test_on_the_real_repo():
+    # Re-rooting must be a no-op when the tree IS the repo, so the linter reads
+    # exactly the cache entries auto_test writes.
+    input_dir = (project_root / "inputs" / "gcp" / "Cloud Storage"
+                 / "google_storage_bucket" / "public_access_prevention")
+    assert input_dir.is_dir(), "real fixture moved — update this test"
+    assert (policy_lint.plan_cache_for(project_root, input_dir)
+            == auto_test.plan_cache_path(input_dir))
+
+
+# --------------------------------------------------------------------------- #
+# load_conditions
+# --------------------------------------------------------------------------- #
+def test_load_conditions_returns_the_declared_conditions(tmp_path):
+    root = build_tree(tmp_path, "clean")
+    rego = (root / "policies" / "gcp" / "Cloud Storage" / "google_storage_bucket"
+            / "public_access_prevention.rego")
+    conditions = policy_lint.load_conditions(rego, root / "policies", policy_lint.HELPERS_DIR)
+    assert len(conditions) == 1
+    meta, check = conditions[0]
+    assert meta["remedies"] == ["Set public_access_prevention to 'enforced'"]
+    assert check["attribute_path"] == ["public_access_prevention"]
+    assert check["policy_type"] == "whitelist"
+
+
+# --------------------------------------------------------------------------- #
+# CLI
+# --------------------------------------------------------------------------- #
+def test_cli_json_output_and_exit_code(tmp_path, capsys):
+    root = build_tree(tmp_path, "policy_smells")
+    rc = policy_lint.main([
+        "--root", str(root), "--json",
+        "gcp/Backup for GKE/google_gke_backup_restore_channel",
+    ])
+    assert rc == 1
+    data = json.loads(capsys.readouterr().out)
+    assert isinstance(data, list)
+    for entry in data:
+        assert {"service", "resource", "policy", "rule", "message", "severity"} == set(entry)
+    assert {(e["policy"], e["rule"]) for e in data} == {
+        ("destination_project", "hard-coded-value"),
+        ("members", "index-path"),
+        ("labels", "presence-only"),
+        ("constraint", "wrong-argument"),
+        ("brief", "trivial-message"),
+        ("short", "trivial-message"),
+        ("legacy", "legacy-assign"),
+        ("badcase", "package-case"),
+    }
+
+
+def test_cli_exits_zero_on_a_clean_resource(tmp_path, capsys):
+    root = build_tree(tmp_path, "clean")
+    rc = policy_lint.main([
+        "--root", str(root), "gcp/Cloud Storage/google_storage_bucket"])
+    capsys.readouterr()
+    assert rc == 0
+
+
+def test_cli_exits_zero_when_only_warnings_are_found(tmp_path, capsys):
+    # A tree whose only findings are warn-severity must not fail the build.
+    root = build_tree(tmp_path, "policy_smells")
+    for name in ("destination_project", "members", "labels", "constraint", "brief", "short"):
+        (root / "policies" / "gcp" / "Backup for GKE"
+         / "google_gke_backup_restore_channel" / f"{name}.rego").unlink()
+    rc = policy_lint.main([
+        "--root", str(root), "--json",
+        "gcp/Backup for GKE/google_gke_backup_restore_channel"])
+    data = json.loads(capsys.readouterr().out)
+    assert {e["severity"] for e in data} == {"warn"}
+    assert rc == 0
+
+
+def test_cli_list_rules_prints_every_id(capsys):
+    rc = policy_lint.main(["--list-rules"])
+    out = capsys.readouterr().out
+    assert rc == 0
+    for rule_id, description in policy_lint.RULES.items():
+        assert rule_id in out
+        assert description.split(".")[0][:30] in out
+
+
+def test_cli_accepts_a_service_scoped_target(tmp_path, capsys):
+    # "<platform>/<Service folder>" lints every resource type in the folder.
+    root = build_tree(tmp_path, "vars_bad")
+    rc = policy_lint.main(["--root", str(root), "--json", "gcp/Compute Service"])
+    data = json.loads(capsys.readouterr().out)
+    assert rc == 1
+    assert {e["resource"] for e in data} == {
+        "google_a_thing", "google_b_thing", "google_c_thing", "google_d_thing"}

--- a/scripts/linters/_tests/test_policy_lint.py
+++ b/scripts/linters/_tests/test_policy_lint.py
@@ -11,6 +11,7 @@ version changes — the sha is recomputed from the same function the pipeline us
 
 import json
 import shutil
+import subprocess
 import sys
 from pathlib import Path
 
@@ -23,6 +24,14 @@ from scripts.auto_test import auto_test
 from scripts.linters import policy_lint
 
 FIXTURES = Path(__file__).parent / "fixtures"
+
+
+@pytest.fixture(autouse=True)
+def _clean_caches():
+    """The OPA-evaluation caches are process-global; no test may inherit one."""
+    policy_lint.clear_caches()
+    yield
+    policy_lint.clear_caches()
 
 
 def build_tree(tmp_path, case):
@@ -276,3 +285,126 @@ def test_cli_accepts_a_service_scoped_target(tmp_path, capsys):
     assert rc == 1
     assert {e["resource"] for e in data} == {
         "google_a_thing", "google_b_thing", "google_c_thing", "google_d_thing"}
+
+
+# --------------------------------------------------------------------------- #
+# Fix round 1: attribute_path given as a string.
+# --------------------------------------------------------------------------- #
+@pytest.mark.parametrize("policy", ["disabled", "keys.key_algorithm"])
+def test_string_attribute_path_is_split_not_iterated(tmp_path, policy):
+    # `"attribute_path": "disabled"` is a form shared.rego supports. Iterating it
+    # character by character made every such policy a false wrong-argument.
+    root = build_tree(tmp_path, "string_path")
+    findings = policy_lint.lint_resource(root, "gcp", "Cloud Platform", "google_service_account")
+    assert [f for f in findings if f.policy == policy] == []
+
+
+def test_string_attribute_path_still_reaches_the_value_rules(tmp_path):
+    # Normalising must not make the checks blind: a hard-coded literal behind a
+    # string path is still found.
+    root = build_tree(tmp_path, "string_path")
+    rego = (root / "policies" / "gcp" / "Cloud Platform" / "google_service_account"
+            / "disabled.rego")
+    rego.write_text(rego.read_text().replace(
+        '"attribute_path": "disabled",\n     "values": [true],',
+        '"attribute_path": "disabled",\n     "values": ["projects/PDE"],'))
+    findings = policy_lint.lint_resource(root, "gcp", "Cloud Platform", "google_service_account")
+    assert ("disabled", "hard-coded-value") in pairs(findings)
+
+
+# --------------------------------------------------------------------------- #
+# Fix round 1: a broken kit must degrade, never abort the run.
+# --------------------------------------------------------------------------- #
+def test_broken_policy_reports_lint_error_and_lets_siblings_through(tmp_path):
+    root = build_tree(tmp_path, "broken")
+    findings = policy_lint.lint_resource(root, "gcp", "Cloud Platform", "google_broken_thing")
+    assert pairs(findings) == {
+        ("broken", "lint-error"),           # unparseable
+        ("noconditions", "lint-error"),     # declares no `conditions` at all
+        # A file whose conditions cannot be read is still checked for everything
+        # that does not depend on them...
+        ("noconditions", "fixture-missing-plan"),
+        ("good", "fixture-missing-plan"),   # ...and the healthy sibling is still linted
+    }
+
+
+def test_lint_error_message_carries_the_opa_reason(tmp_path):
+    # `opa eval` writes parse errors to stdout, not stderr — the reason must
+    # still reach the finding.
+    root = build_tree(tmp_path, "broken")
+    findings = policy_lint.lint_resource(root, "gcp", "Cloud Platform", "google_broken_thing")
+    broken = [f for f in findings if f.policy == "broken"][0]
+    assert broken.severity == "error"
+    assert "rego_parse_error" in broken.message or "unexpected eof" in broken.message
+
+
+def test_missing_vars_file_is_not_a_crash(tmp_path):
+    # The broken kit has no _vars.rego at all.
+    root = build_tree(tmp_path, "broken")
+    findings = policy_lint.lint_resource(root, "gcp", "Cloud Platform", "google_broken_thing")
+    assert [f for f in findings if f.rule.startswith("vars-")] == []
+
+
+def test_lint_error_is_a_documented_rule():
+    assert "lint-error" in policy_lint.RULES
+
+
+# --------------------------------------------------------------------------- #
+# Fix round 1: the friendly-name index is one OPA call, not one per resource.
+# --------------------------------------------------------------------------- #
+def test_friendly_name_index_uses_a_single_opa_call(tmp_path, monkeypatch):
+    root = build_tree(tmp_path, "vars_bad")
+    policy_lint.clear_caches()
+
+    real_run = subprocess.run
+    calls = []
+
+    def counting_run(cmd, *args, **kwargs):
+        calls.append(cmd)
+        return real_run(cmd, *args, **kwargs)
+
+    monkeypatch.setattr(policy_lint.subprocess, "run", counting_run)
+    index = policy_lint._friendly_name_index(root / "policies", "gcp")
+
+    assert len(calls) == 1, f"expected one batched opa eval, got {len(calls)}"
+    assert sorted(rt for names in index.values() for _, rt in names) == [
+        "google_a_thing", "google_b_thing", "google_d_thing", "google_e_thing"]
+
+
+# --------------------------------------------------------------------------- #
+# Fix round 1: usage errors exit 2, distinct from findings (1).
+# --------------------------------------------------------------------------- #
+@pytest.mark.parametrize("target,needle", [
+    ("aws/Cloud Storage/google_storage_bucket", "aws"),          # no such platform tree
+    ("gcp/Nonexistent Service/google_storage_bucket", "Nonexistent Service"),
+    ("gcp/Cloud Storage/google_nonexistent_thing", "google_nonexistent_thing"),
+    ("gcp/a/b/c", "a/b/c"),                                       # malformed
+])
+def test_unknown_target_is_a_usage_error(tmp_path, capsys, target, needle):
+    root = build_tree(tmp_path, "clean")
+    rc = policy_lint.main(["--root", str(root), target])
+    err = capsys.readouterr().err
+    assert rc == 2, "a mistyped target must be a usage error, not 0 findings or 1"
+    assert needle in err
+
+
+def test_findings_still_exit_one(tmp_path, capsys):
+    root = build_tree(tmp_path, "policy_smells")
+    rc = policy_lint.main([
+        "--root", str(root), "gcp/Backup for GKE/google_gke_backup_restore_channel"])
+    capsys.readouterr()
+    assert rc == 1
+
+
+# --------------------------------------------------------------------------- #
+# Fix round 1: the identity-attribute exemption is only for label-shaped values.
+# --------------------------------------------------------------------------- #
+def test_identity_exemption_only_covers_the_fixture_labels(tmp_path):
+    # `bucket` is this resource's resource_value_name, but here the two fixtures
+    # name two genuinely different buckets — that is real drift, not identity.
+    root = build_tree(tmp_path, "fixture_identity_drift")
+    findings = policy_lint.lint_resource(
+        root, "gcp", "Cloud Storage", "google_storage_bucket_iam_binding")
+    drift = [f for f in findings if f.rule == "fixture-drift"]
+    assert len(drift) == 1
+    assert "bucket" in drift[0].message

--- a/scripts/linters/_tests/test_run_precommit_policy_lint.py
+++ b/scripts/linters/_tests/test_run_precommit_policy_lint.py
@@ -1,0 +1,199 @@
+"""Unit tests for the policy_lint wiring in run_precommit_linter.py.
+
+These exercise the owned-triple derivation and the "fail only on findings the
+contributor's own changes reached" filter in isolation, with a fake
+``policy_lint.lint_resource`` (monkeypatched) — no git repo, no OPA, and no
+real policy tree required.
+"""
+
+import re
+import sys
+from pathlib import Path
+
+project_root = Path(__file__).parent.parent.parent.parent
+sys.path.insert(0, str(project_root))
+
+from scripts.linters import policy_lint
+from scripts.linters import run_precommit_linter as rpl
+
+Finding = policy_lint.Finding
+
+
+# --------------------------------------------------------------------------- #
+# _owned_triples
+# --------------------------------------------------------------------------- #
+def test_owned_triples_from_a_policy_file():
+    changed = {"policies/gcp/BigQuery/google_bigquery_dataset/dataset_id.rego"}
+    assert rpl._owned_triples(changed) == {("gcp", "BigQuery", "google_bigquery_dataset")}
+
+
+def test_owned_triples_from_an_input_fixture_file():
+    changed = {"inputs/gcp/BigQuery/google_bigquery_dataset/dataset_id/compliant.tf"}
+    assert rpl._owned_triples(changed) == {("gcp", "BigQuery", "google_bigquery_dataset")}
+
+
+def test_owned_triples_dedupes_across_multiple_files_in_the_same_resource():
+    changed = {
+        "policies/gcp/BigQuery/google_bigquery_dataset/dataset_id.rego",
+        "policies/gcp/BigQuery/google_bigquery_dataset/_vars.rego",
+        "inputs/gcp/BigQuery/google_bigquery_dataset/dataset_id/compliant.tf",
+    }
+    assert rpl._owned_triples(changed) == {("gcp", "BigQuery", "google_bigquery_dataset")}
+
+
+def test_owned_triples_ignores_docs_and_shallow_paths():
+    changed = {
+        "docs/gcp/BigQuery/google_bigquery_dataset.json",
+        "policies/gcp",             # too shallow: no resource type segment
+        "README.md",
+    }
+    assert rpl._owned_triples(changed) == set()
+
+
+def test_owned_triples_spans_multiple_resource_types():
+    changed = {
+        "policies/gcp/BigQuery/google_bigquery_dataset/dataset_id.rego",
+        "policies/gcp/Cloud Storage/google_storage_bucket/location.rego",
+    }
+    assert rpl._owned_triples(changed) == {
+        ("gcp", "BigQuery", "google_bigquery_dataset"),
+        ("gcp", "Cloud Storage", "google_storage_bucket"),
+    }
+
+
+# --------------------------------------------------------------------------- #
+# _finding_path / _finding_owned
+# --------------------------------------------------------------------------- #
+def test_finding_path_for_a_policy_finding():
+    finding = Finding("BigQuery", "google_bigquery_dataset", "dataset_id",
+                       "hard-coded-value", "msg")
+    path = rpl._finding_path("gcp", "BigQuery", "google_bigquery_dataset", finding)
+    assert path == "policies/gcp/BigQuery/google_bigquery_dataset/dataset_id.rego"
+
+
+def test_finding_path_for_a_vars_finding():
+    finding = Finding("BigQuery", "google_bigquery_dataset", "_vars",
+                       "vars-resource-type", "msg")
+    path = rpl._finding_path("gcp", "BigQuery", "google_bigquery_dataset", finding)
+    assert path == "policies/gcp/BigQuery/google_bigquery_dataset/_vars.rego"
+
+
+def test_finding_path_for_a_fixture_finding_is_the_argument_directory():
+    finding = Finding("BigQuery", "google_bigquery_dataset", "dataset_id",
+                       "fixture-drift", "msg")
+    path = rpl._finding_path("gcp", "BigQuery", "google_bigquery_dataset", finding)
+    assert path == "inputs/gcp/BigQuery/google_bigquery_dataset/dataset_id"
+
+
+def test_finding_owned_when_the_exact_policy_file_changed():
+    path = "policies/gcp/BigQuery/google_bigquery_dataset/dataset_id.rego"
+    assert rpl._finding_owned(path, {path})
+
+
+def test_finding_owned_when_a_file_under_the_fixture_directory_changed():
+    directory = "inputs/gcp/BigQuery/google_bigquery_dataset/dataset_id"
+    changed = {f"{directory}/compliant.tf"}
+    assert rpl._finding_owned(directory, changed)
+
+
+def test_finding_not_owned_for_a_sibling_argument():
+    # The contributor touched dataset_id.rego; a pre-existing error on a
+    # different argument in the same resource type must not be attributed to
+    # them.
+    changed = {"policies/gcp/BigQuery/google_bigquery_dataset/dataset_id.rego"}
+    other = "policies/gcp/BigQuery/google_bigquery_dataset/max_time_travel_hours.rego"
+    assert not rpl._finding_owned(other, changed)
+
+
+# --------------------------------------------------------------------------- #
+# _policy_lint_findings — fake lint_resource, no OPA/git required
+# --------------------------------------------------------------------------- #
+def test_policy_lint_findings_keeps_only_owned_errors(monkeypatch):
+    findings_by_triple = {
+        ("gcp", "BigQuery", "google_bigquery_dataset"): [
+            Finding("BigQuery", "google_bigquery_dataset", "dataset_id",
+                    "hard-coded-value", "owned error"),
+            Finding("BigQuery", "google_bigquery_dataset", "other_arg",
+                    "hard-coded-value", "sibling, not owned"),
+            Finding("BigQuery", "google_bigquery_dataset", "dataset_id",
+                    "legacy-assign", "owned warning", severity="warn"),
+        ],
+    }
+
+    def fake_lint_resource(root, platform, service, resource_type):
+        return findings_by_triple[(platform, service, resource_type)]
+
+    monkeypatch.setattr(policy_lint, "lint_resource", fake_lint_resource)
+
+    changed = {"policies/gcp/BigQuery/google_bigquery_dataset/dataset_id.rego"}
+    triples = rpl._owned_triples(changed)
+
+    owned, backlog = rpl._policy_lint_findings(triples, changed, root="/repo")
+
+    assert [f.rule for _, f in owned] == ["hard-coded-value"]
+    assert owned[0][0] == "policies/gcp/BigQuery/google_bigquery_dataset/dataset_id.rego"
+    # The sibling-argument error is backlog; the warning is never counted at all.
+    assert backlog == 1
+
+
+def test_policy_lint_findings_covers_multiple_owned_triples(monkeypatch):
+    findings_by_triple = {
+        ("gcp", "BigQuery", "google_bigquery_dataset"): [
+            Finding("BigQuery", "google_bigquery_dataset", "dataset_id",
+                    "hard-coded-value", "e1"),
+        ],
+        ("gcp", "Cloud Storage", "google_storage_bucket"): [
+            Finding("Cloud Storage", "google_storage_bucket", "location",
+                    "hard-coded-value", "e2"),
+        ],
+    }
+
+    def fake_lint_resource(root, platform, service, resource_type):
+        return findings_by_triple[(platform, service, resource_type)]
+
+    monkeypatch.setattr(policy_lint, "lint_resource", fake_lint_resource)
+
+    changed = {
+        "policies/gcp/BigQuery/google_bigquery_dataset/dataset_id.rego",
+        "policies/gcp/Cloud Storage/google_storage_bucket/location.rego",
+    }
+    triples = rpl._owned_triples(changed)
+
+    owned, backlog = rpl._policy_lint_findings(triples, changed, root="/repo")
+
+    assert {f.message for _, f in owned} == {"e1", "e2"}
+    assert backlog == 0
+
+
+def test_policy_lint_findings_owns_a_fixture_finding_via_the_argument_directory(monkeypatch):
+    findings_by_triple = {
+        ("gcp", "BigQuery", "google_bigquery_dataset"): [
+            Finding("BigQuery", "google_bigquery_dataset", "dataset_id",
+                    "fixture-drift", "compliant.tf and nonCompliant.tf also differ on: x"),
+        ],
+    }
+
+    def fake_lint_resource(root, platform, service, resource_type):
+        return findings_by_triple[(platform, service, resource_type)]
+
+    monkeypatch.setattr(policy_lint, "lint_resource", fake_lint_resource)
+
+    changed = {"inputs/gcp/BigQuery/google_bigquery_dataset/dataset_id/compliant.tf"}
+    triples = rpl._owned_triples(changed)
+
+    owned, backlog = rpl._policy_lint_findings(triples, changed, root="/repo")
+
+    assert len(owned) == 1
+    assert owned[0][0] == "inputs/gcp/BigQuery/google_bigquery_dataset/dataset_id"
+    assert backlog == 0
+
+
+# --------------------------------------------------------------------------- #
+# The rules page carries every rule id
+# --------------------------------------------------------------------------- #
+def test_every_rule_has_an_anchored_heading_in_the_rules_page():
+    page = (project_root / "Guide" / "Policy_writing_tutorial" / "policy-lint.md").read_text(
+        encoding="utf-8")
+    headings = set(re.findall(r"^##\s+([a-z0-9-]+)\s*$", page, re.MULTILINE))
+    missing = set(policy_lint.RULES) - headings
+    assert not missing, f"policy-lint.md is missing headings for: {sorted(missing)}"

--- a/scripts/linters/policy_lint.py
+++ b/scripts/linters/policy_lint.py
@@ -40,8 +40,9 @@ Usage
     python3 scripts/linters/policy_lint.py --json "gcp/BigQuery/google_bigquery_table"
     python3 scripts/linters/policy_lint.py --list-rules
 
-Exit code is 1 when any *error*-severity finding is reported, else 0; warnings
-never fail a build on their own.
+Exit codes: 0 clean, 1 at least one *error*-severity finding (warnings never fail
+a build on their own), 2 a usage error — a target naming a platform, service or
+resource type that is not in the tree.
 """
 
 import argparse
@@ -93,6 +94,9 @@ RULES = {
         "`situation_description` under 20 characters or `remedies` empty."),
     "legacy-assign": "Use `:=` for message/details/summary (warn).",
     "package-case": "Package service segment is not lowercase snake_case (warn).",
+    "lint-error": (
+        "The linter could not evaluate this policy (parse/opa failure) — run "
+        "`opa check` on the file."),
 }
 
 # Only style rules are advisory; everything else is a correctness/quality error.
@@ -132,13 +136,12 @@ SNAKE_CASE_RE = re.compile(r"^[a-z][a-z0-9_]*$")
 # Fixture resource labels, per the auto_test convention.
 FIXTURE_LABEL_RE = re.compile(r"^(compliant|non_compliant)_example_(\d+)$")
 # Keys that are *expected* to differ between the two fixture resources: the
-# resource's own identity, and the provider-computed mirrors of `labels` (which
-# always move with it). The resource's `resource_value_name` — the attribute the
-# violation message quotes, which is `bucket` on an IAM binding, not `name` — is
-# added per resource type.
+# resource's label ("name") and `labels`, plus the two provider-computed mirrors
+# of `labels`, which always move with it and would double-report every labels
+# policy. The resource's `resource_value_name` is handled separately — see
+# `_lint_fixtures` — because it is only exempt when it holds the fixture label.
 FIXTURE_IGNORED_KEYS = {
-    "name", "id", "labels", "label",
-    "effective_labels", "terraform_labels", "effective_annotations",
+    "name", "labels", "label", "effective_labels", "terraform_labels",
 }
 
 # Blacklist/whitelist only — a pattern or range policy with empty values means
@@ -148,7 +151,15 @@ EMPTY_VALUES = (None, "", [], {})
 
 
 class PolicyLintError(RuntimeError):
-    """A policy kit could not be read at all (OPA refused to evaluate it)."""
+    """One policy file could not be read (OPA refused to evaluate it).
+
+    Reported as a ``lint-error`` finding against that file — never fatal, so one
+    unparseable policy cannot hide every other finding in the run.
+    """
+
+
+class TargetError(ValueError):
+    """A CLI target names a platform/service/resource that does not exist."""
 
 
 @dataclass(frozen=True)
@@ -167,6 +178,29 @@ class Finding:
 _eval_cache: dict[tuple, dict] = {}
 
 
+def _opa_reason(proc):
+    """A one-line reason from a failed ``opa eval``.
+
+    Parse errors are written to *stdout* as a JSON ``errors`` array, not to
+    stderr, so reading stderr alone loses the reason entirely.
+    """
+    stderr = (proc.stderr or "").strip()
+    if stderr:
+        return stderr.splitlines()[0]
+    stdout = (proc.stdout or "").strip()
+    try:
+        errors = json.loads(stdout).get("errors") or []
+    except (json.JSONDecodeError, AttributeError):
+        errors = []
+    if errors:
+        first = errors[0]
+        location = first.get("location") or {}
+        where = (f" ({Path(location['file']).name}:{location.get('row')})"
+                 if location.get("file") else "")
+        return f"{first.get('code', 'error')}: {first.get('message', '')}{where}"
+    return stdout.splitlines()[0] if stdout else "no output"
+
+
 def _run_opa(query, *data_dirs):
     """``opa eval --format json`` over ``data_dirs``; returns the query value."""
     cmd = ["opa", "eval", "--format", "json"]
@@ -178,7 +212,7 @@ def _run_opa(query, *data_dirs):
     except FileNotFoundError as exc:                     # pragma: no cover - env
         raise PolicyLintError("`opa` is not on PATH — install it to run policy_lint.") from exc
     if proc.returncode != 0:
-        raise PolicyLintError(f"opa eval {query!r} failed: {proc.stderr.strip()}")
+        raise PolicyLintError(f"opa eval {query!r} failed: {_opa_reason(proc)}")
     result = json.loads(proc.stdout or "{}").get("result") or []
     if not result:
         return None                                       # undefined, not an error
@@ -224,9 +258,10 @@ def _rule_value(rego_path, helpers_dir, rule_name):
         node = _walk(tree, package.split(".")[1:] + [rule_name])
         if node is not None:
             return node
-    # Batch evaluation failed or the rule is undefined in it — ask directly, so a
-    # genuine OPA error surfaces as an error rather than as a silent empty list.
-    return _run_opa(f"data.{package}.{rule_name}", helpers_dir, Path(rego_path).parent)
+    # Batch evaluation failed or the rule is undefined in it — ask again with just
+    # this one file, so a genuine OPA error surfaces (rather than becoming a silent
+    # empty list) and an unparseable *sibling* cannot poison a healthy policy.
+    return _run_opa(f"data.{package}.{rule_name}", helpers_dir, Path(rego_path))
 
 
 def load_conditions(rego_path, policies_root, helpers_dir=None):
@@ -238,14 +273,20 @@ def load_conditions(rego_path, policies_root, helpers_dir=None):
     """
     helpers_dir = _resolve_helpers(policies_root, helpers_dir)
     value = _rule_value(rego_path, helpers_dir, "conditions")
-    return value if isinstance(value, list) else []
+    if not isinstance(value, list):
+        raise PolicyLintError(
+            "declares no `conditions` list (the rule is undefined or not an array)")
+    return value
 
 
 def load_variables(vars_path, policies_root, helpers_dir=None):
     """The evaluated ``variables`` object of a ``_vars.rego`` file."""
     helpers_dir = _resolve_helpers(policies_root, helpers_dir)
     value = _rule_value(vars_path, helpers_dir, "variables")
-    return value if isinstance(value, dict) else {}
+    if not isinstance(value, dict):
+        raise PolicyLintError(
+            "declares no `variables` object (the rule is undefined or not an object)")
+    return value
 
 
 def _resolve_helpers(policies_root, helpers_dir=None):
@@ -302,9 +343,26 @@ def _strings_in(value):
             yield from _strings_in(item)
 
 
+def _normalise_path(attribute_path):
+    """An ``attribute_path`` as a list, whatever form the policy declared it in.
+
+    ``policies/_helpers/shared.rego`` accepts both an array (``["labels", 0]``)
+    and a bare string (``"disabled"`` — see
+    ``format_attribute_path``/``get_attribute_value``'s ``is_string`` branches).
+    Left as a string, every rule here would iterate it *character by character*,
+    which made `google_service_account/disabled` a false `wrong-argument`. Dots
+    are the same nesting separator the policy file names use.
+    """
+    if isinstance(attribute_path, str):
+        return [segment for segment in attribute_path.split(".") if segment]
+    if isinstance(attribute_path, list):
+        return attribute_path
+    return []
+
+
 def _path_segments(attribute_path):
     """String segments of an attribute_path, list indices dropped."""
-    return [p for p in (attribute_path or []) if isinstance(p, str)]
+    return [p for p in _normalise_path(attribute_path) if isinstance(p, str)]
 
 
 def _is_index(segment):
@@ -349,7 +407,15 @@ def _lint_policy_file(root, platform, service, resource_type, rego_path, policie
     if legacy:
         add("legacy-assign", f"{', '.join(legacy)} assigned with '=' instead of ':='")
 
-    conditions = load_conditions(rego_path, policies_root)
+    try:
+        conditions = load_conditions(rego_path, policies_root)
+    except PolicyLintError as exc:
+        # A kit that cannot be evaluated is itself a finding. The style rules
+        # above already ran, and the fixture rules below still can, so one bad
+        # file never silences the rest of the run.
+        add("lint-error", str(exc))
+        return out + _lint_fixtures(root, platform, service, resource_type, stem,
+                                    identity_key)
 
     seen = set()
 
@@ -376,7 +442,7 @@ def _lint_policy_file(root, platform, service, resource_type, rego_path, policie
                          f"remedies is empty for {str(description)!r}")
 
         for check in checks:
-            attribute_path = check.get("attribute_path") or []
+            attribute_path = _normalise_path(check.get("attribute_path"))
             values = check.get("values")
             policy_type = (check.get("policy_type") or "").strip().lower()
             path_text = ".".join(str(p) for p in attribute_path)
@@ -419,6 +485,11 @@ def _lint_policy_file(root, platform, service, resource_type, rego_path, policie
 # --------------------------------------------------------------------------- #
 # Rules over the fixture pair
 # --------------------------------------------------------------------------- #
+def _is_fixture_label(value):
+    """True when a planned value is just the fixture's own label."""
+    return isinstance(value, str) and bool(FIXTURE_LABEL_RE.match(value))
+
+
 def _lint_fixtures(root, platform, service, resource_type, stem, identity_key=None):
     input_dir = Path(root) / "inputs" / platform / service / resource_type / stem
     # A missing input directory is linter.py's finding (an orphan policy), not
@@ -453,15 +524,23 @@ def _lint_fixtures(root, platform, service, resource_type, stem, identity_key=No
     # argument (a.b.c) is compared at its block key, since the plan nests it.
     argument_key = stem.split(".")[0]
     ignored = FIXTURE_IGNORED_KEYS | {argument_key}
-    if identity_key:
-        ignored.add(identity_key)
 
     drifted = set()
     for index in sorted(set(compliant) & set(non_compliant)):
         good, bad = compliant[index], non_compliant[index]
         for key in set(good) | set(bad):
-            if key not in ignored and good.get(key) != bad.get(key):
-                drifted.add(key)
+            if key in ignored:
+                continue
+            good_value, bad_value = good.get(key), bad.get(key)
+            if good_value == bad_value:
+                continue
+            # The identity attribute (`bucket` on an IAM binding, `name`
+            # elsewhere) is exempt ONLY when it *is* the fixture label — two
+            # genuinely different bucket names are drift like any other.
+            if (key == identity_key
+                    and _is_fixture_label(good_value) and _is_fixture_label(bad_value)):
+                continue
+            drifted.add(key)
 
     if drifted:
         return [Finding(service, resource_type, stem, "fixture-drift",
@@ -479,20 +558,36 @@ _friendly_index_cache: dict[tuple, dict] = {}
 def _friendly_name_index(policies_root, platform):
     """{normalised friendly name: [(service, resource_type), ...]} for a platform.
 
-    Scanned once per platform root and cached: duplicate detection is only
-    meaningful across the whole tree.
+    Duplicate detection is only meaningful across the whole tree, so this reads
+    *every* ``_vars.rego`` under ``policies/<platform>/``. It does that in ONE
+    ``opa eval`` over the platform (~0.6s); asking per file cost 370 subprocesses
+    and ~9s for a single-resource lint. Package names are read from the files
+    themselves (a plain regex, no subprocess) so each result maps back to its
+    real service folder and resource-type directory.
     """
     policies_root = Path(policies_root)
     key = (str(policies_root.resolve()), platform)
     if key in _friendly_index_cache:
         return _friendly_index_cache[key]
 
-    index = {}
     platform_root = policies_root / platform
-    for vars_path in sorted(platform_root.glob(f"*/*/{VARS_FILE}")):
+    vars_paths = sorted(platform_root.glob(f"*/*/{VARS_FILE}"))
+    helpers_dir = _resolve_helpers(policies_root)
+    try:
+        tree = _run_opa("data.terraform", helpers_dir, platform_root) or {}
+    except PolicyLintError:
+        tree = None      # one bad file in the tree — fall back to per-file reads
+
+    index = {}
+    for vars_path in vars_paths:
         try:
-            variables = load_variables(vars_path, policies_root)
-        except PolicyLintError:
+            package = _package_of(vars_path)
+            variables = None
+            if tree is not None:
+                variables = _walk(tree, package.split(".")[1:] + ["variables"])
+            if not isinstance(variables, dict):
+                variables = load_variables(vars_path, policies_root)
+        except (PolicyLintError, OSError):
             continue
         friendly = variables.get("friendly_resource_name")
         friendly = friendly.strip().lower() if isinstance(friendly, str) else ""
@@ -501,6 +596,12 @@ def _friendly_name_index(policies_root, platform):
                 (vars_path.parent.parent.name, vars_path.parent.name))
     _friendly_index_cache[key] = index
     return index
+
+
+def clear_caches():
+    """Drop every cached OPA evaluation (the caches are process-global)."""
+    _eval_cache.clear()
+    _friendly_index_cache.clear()
 
 
 def _lint_vars_file(platform, service, resource_type, vars_path, policies_root):
@@ -552,37 +653,67 @@ def lint_resource(root, platform, service_folder, resource_type):
     identity_key = None
     vars_path = resource_dir / VARS_FILE
     if vars_path.is_file():
-        findings += _lint_vars_file(platform, service_folder, resource_type,
-                                    vars_path, policies_root)
-        identity_key = load_variables(vars_path, policies_root).get("resource_value_name")
+        # _vars.rego is optional; when it exists but cannot be read, say so and
+        # keep going — the argument policies are still worth linting.
+        try:
+            findings += _lint_vars_file(platform, service_folder, resource_type,
+                                        vars_path, policies_root)
+            identity_key = load_variables(
+                vars_path, policies_root).get("resource_value_name")
+        except (PolicyLintError, OSError, UnicodeDecodeError) as exc:
+            findings.append(Finding(service_folder, resource_type, "_vars",
+                                    "lint-error", str(exc)))
+
     for rego_path in sorted(resource_dir.glob(f"*{REGO_EXT}")):
         if rego_path.name == VARS_FILE:
             continue
-        findings += _lint_policy_file(root, platform, service_folder, resource_type,
-                                      rego_path, policies_root, identity_key)
+        try:
+            findings += _lint_policy_file(root, platform, service_folder, resource_type,
+                                          rego_path, policies_root, identity_key)
+        except (PolicyLintError, OSError, UnicodeDecodeError) as exc:
+            findings.append(Finding(service_folder, resource_type, rego_path.stem,
+                                    "lint-error", str(exc)))
     return findings
 
 
 def _expand_target(root, target):
-    """A ``platform[/service[/resource]]`` target into (platform, service, resource)."""
+    """A ``platform[/service[/resource]]`` target into (platform, service, resource).
+
+    Every segment is checked against the tree. A mistyped target must be a *usage*
+    error — silently linting nothing and exiting 0 is the worst possible answer to
+    a typo.
+    """
     parts = [p for p in target.split("/") if p]
     if not parts or len(parts) > 3:
-        raise ValueError(
+        raise TargetError(
             f"target {target!r} must be '<platform>', '<platform>/<Service folder>' or "
             "'<platform>/<Service folder>/<resource_type>'")
+
     platform = parts[0]
     platform_root = Path(root) / "policies" / platform
-    if len(parts) == 3:
-        return [(platform, parts[1], parts[2])]
-    services = [parts[1]] if len(parts) == 2 else [
+    if not platform_root.is_dir():
+        available = sorted(d.name for d in (Path(root) / "policies").glob("*")
+                           if d.is_dir() and not d.name.startswith("_"))
+        raise TargetError(
+            f"no policies for platform '{platform}' "
+            f"(available: {', '.join(available) or 'none'})")
+
+    services = [parts[1]] if len(parts) >= 2 else [
         d.name for d in sorted(platform_root.iterdir()) if d.is_dir()]
+
     out = []
     for service in services:
         service_dir = platform_root / service
         if not service_dir.is_dir():
-            raise ValueError(f"no policies directory for '{platform}/{service}'")
-        out += [(platform, service, d.name)
-                for d in sorted(service_dir.iterdir()) if d.is_dir()]
+            raise TargetError(f"no policies directory for '{platform}/{service}'")
+        resources = [d.name for d in sorted(service_dir.iterdir()) if d.is_dir()]
+        if len(parts) == 3:
+            if parts[2] not in resources:
+                raise TargetError(
+                    f"no resource type '{parts[2]}' in '{platform}/{service}' "
+                    f"({len(resources)} available)")
+            resources = [parts[2]]
+        out += [(platform, service, resource) for resource in resources]
     return out
 
 
@@ -615,14 +746,14 @@ def main(argv=None):
         parser.error("at least one TARGET is required (or use --list-rules)")
 
     root = Path(args.root)
-    findings, failed = [], False
+    findings, usage_error = [], False
     for target in args.targets:
         try:
             for platform, service, resource_type in _expand_target(root, target):
                 findings += lint_resource(root, platform, service, resource_type)
-        except (ValueError, PolicyLintError) as exc:
+        except TargetError as exc:
             print(f"[ERROR] {target}: {exc}", file=sys.stderr)
-            failed = True
+            usage_error = True
 
     findings.sort(key=lambda f: (f.service, f.resource, f.policy, f.rule, f.message))
 
@@ -634,10 +765,17 @@ def main(argv=None):
                   f"{finding.policy}: {finding.rule} — {finding.message}")
         errors = sum(1 for f in findings if f.severity == "error")
         warns = len(findings) - errors
-        print(f"\n{errors} error(s), {warns} warning(s)."
-              if findings else "\nNo findings.")
+        if findings:
+            print(f"\n{errors} error(s), {warns} warning(s).")
+        elif not usage_error:
+            # "No findings." after a bad target would read as an all-clear.
+            print("\nNo findings.")
 
-    return 1 if failed or any(f.severity == "error" for f in findings) else 0
+    # 2 = the caller asked for something that does not exist (a typo); 1 = the
+    # tree was linted and has error-severity findings; 0 = clean.
+    if usage_error:
+        return 2
+    return 1 if any(f.severity == "error" for f in findings) else 0
 
 
 if __name__ == "__main__":

--- a/scripts/linters/policy_lint.py
+++ b/scripts/linters/policy_lint.py
@@ -41,8 +41,11 @@ Usage
     python3 scripts/linters/policy_lint.py --list-rules
 
 Exit codes: 0 clean, 1 at least one *error*-severity finding (warnings never fail
-a build on their own), 2 a usage error — a target naming a platform, service or
-resource type that is not in the tree.
+a build on their own), 2 a usage or environment error — a target naming a
+platform, service or resource type that is not in the tree, or a missing ``opa``
+binary. When the named resource type simply has no ``policies/`` directory yet,
+the stderr line is marked ``[ERROR] no-policies-dir: <target> (...)`` so a caller
+can treat it as "nothing to lint" rather than as a typo.
 """
 
 import argparse
@@ -75,8 +78,9 @@ RULES = {
         "`attribute_path` ends in a list index; check the whole list with "
         "`element blacklist`."),
     "presence-only": (
-        "`values` is only null/\"\": presence is the whole check. Pair with a pattern "
-        "or justify presence in the rationale."),
+        "`values` is only null/\"\": presence is the whole check. Acceptable when the "
+        "rationale says presence is the control — the reviewer decides; pair with a "
+        "pattern where a shape exists (warn)."),
     "wrong-argument": (
         "No condition in `<arg>.rego` reads the argument the file is named after."),
     "fixture-drift": (
@@ -85,6 +89,9 @@ RULES = {
     "fixture-missing-plan": (
         "No committed plan cache for this fixture pair — run the test locally and "
         "commit inputs/plan_cache."),
+    "fixture-unpaired": (
+        "A compliant_example_N or non_compliant_example_N has no counterpart with the "
+        "same N — every example must be one half of a pair."),
     "vars-resource-type": (
         "`_vars.resource_type` does not match the resource-type directory."),
     "vars-friendly-name": (
@@ -99,8 +106,11 @@ RULES = {
         "`opa check` on the file."),
 }
 
-# Only style rules are advisory; everything else is a correctness/quality error.
-WARN_RULES = {"legacy-assign", "package-case"}
+# Advisory rules: the two style conventions, plus presence-only — whether
+# "presence is the control" is a judgement about the argument's rationale, which
+# a human (or the AI reviewer) makes, not something a linter can decide. It is
+# surfaced to the reviewer rather than failing a build.
+WARN_RULES = {"legacy-assign", "package-case", "presence-only"}
 
 # --------------------------------------------------------------------------- #
 # Rule constants
@@ -158,8 +168,26 @@ class PolicyLintError(RuntimeError):
     """
 
 
+class OpaUnavailableError(PolicyLintError):
+    """The ``opa`` binary is missing — nothing in the tree can be evaluated.
+
+    A ``PolicyLintError`` so callers that already handle "policy_lint could not
+    run" (``run_precommit_linter.py``) catch it, but deliberately *not* caught by
+    the per-file guards: a missing toolchain is one environment error, not one
+    ``lint-error`` finding per policy file.
+    """
+
+
 class TargetError(ValueError):
     """A CLI target names a platform/service/resource that does not exist."""
+
+    #: Prefix printed before the target when the marker is set, so a caller can
+    #: distinguish "nothing to lint yet" from "you typed the name wrong".
+    marker = None
+
+    def __init__(self, message, marker=None):
+        super().__init__(message)
+        self.marker = marker
 
 
 @dataclass(frozen=True)
@@ -209,8 +237,9 @@ def _run_opa(query, *data_dirs):
     cmd.append(query)
     try:
         proc = subprocess.run(cmd, capture_output=True, text=True)
-    except FileNotFoundError as exc:                     # pragma: no cover - env
-        raise PolicyLintError("`opa` is not on PATH — install it to run policy_lint.") from exc
+    except FileNotFoundError as exc:
+        raise OpaUnavailableError(
+            "`opa` is not on PATH — install it to run policy_lint.") from exc
     if proc.returncode != 0:
         raise PolicyLintError(f"opa eval {query!r} failed: {_opa_reason(proc)}")
     result = json.loads(proc.stdout or "{}").get("result") or []
@@ -229,6 +258,8 @@ def _eval_dir(directory, helpers_dir):
     if key not in _eval_cache:
         try:
             _eval_cache[key] = _run_opa("data.terraform", helpers_dir, directory) or {}
+        except OpaUnavailableError:
+            raise                                         # environment, not content
         except PolicyLintError:
             _eval_cache[key] = None                       # force the per-file path
     return _eval_cache[key]
@@ -409,6 +440,8 @@ def _lint_policy_file(root, platform, service, resource_type, rego_path, policie
 
     try:
         conditions = load_conditions(rego_path, policies_root)
+    except OpaUnavailableError:
+        raise
     except PolicyLintError as exc:
         # A kit that cannot be evaluated is itself a finding. The style rules
         # above already ran, and the fixture rules below still can, so one bad
@@ -485,6 +518,22 @@ def _lint_policy_file(root, platform, service, resource_type, rego_path, policie
 # --------------------------------------------------------------------------- #
 # Rules over the fixture pair
 # --------------------------------------------------------------------------- #
+def _plan_resources(plan):
+    """``planned_values.root_module.resources`` — or None if this is not a plan."""
+    if not isinstance(plan, dict):
+        return None
+    planned = plan.get("planned_values")
+    if not isinstance(planned, dict):
+        return None
+    root_module = planned.get("root_module")
+    if not isinstance(root_module, dict):
+        return None
+    resources = root_module.get("resources")
+    if resources is None:
+        return []
+    return resources if isinstance(resources, list) else None
+
+
 def _is_fixture_label(value):
     """True when a planned value is just the fixture's own label."""
     return isinstance(value, str) and bool(FIXTURE_LABEL_RE.match(value))
@@ -509,16 +558,35 @@ def _lint_fixtures(root, platform, service, resource_type, stem, identity_key=No
         return [Finding(service, resource_type, stem, "fixture-missing-plan",
                         f"plan cache {cache.name} is unreadable: {exc}")]
 
-    resources = (plan.get("planned_values", {}).get("root_module", {}).get("resources") or [])
+    # A cache written by an older/other tool (or a truncated file) must be a
+    # finding, not an AttributeError halfway down this function.
+    resources = _plan_resources(plan)
+    if resources is None:
+        return [Finding(service, resource_type, stem, "lint-error",
+                        f"plan cache {cache.name} is not a Terraform plan "
+                        "(no planned_values.root_module.resources list)")]
+
     compliant, non_compliant = {}, {}
     for resource in resources:
-        if resource.get("type") != resource_type:
+        if not isinstance(resource, dict) or resource.get("type") != resource_type:
             continue
-        match = FIXTURE_LABEL_RE.match(resource.get("name", ""))
+        match = FIXTURE_LABEL_RE.match(resource.get("name") or "")
         if not match:
             continue
         bucket = compliant if match.group(1) == "compliant" else non_compliant
-        bucket[match.group(2)] = resource.get("values") or {}
+        values = resource.get("values")
+        bucket[match.group(2)] = values if isinstance(values, dict) else {}
+
+    # Every example must be half of a pair; a lone one is never compared, so
+    # without this it would silently escape every fixture rule.
+    unpaired = ([f"compliant_example_{i}" for i in sorted(set(compliant) - set(non_compliant))]
+                + [f"non_compliant_example_{i}"
+                   for i in sorted(set(non_compliant) - set(compliant))])
+    findings = []
+    if unpaired:
+        findings.append(Finding(
+            service, resource_type, stem, "fixture-unpaired",
+            "no counterpart with the same number for: " + ", ".join(unpaired)))
 
     # Only the argument's *top-level* key is expected to differ; a nested
     # argument (a.b.c) is compared at its block key, since the plan nests it.
@@ -543,16 +611,28 @@ def _lint_fixtures(root, platform, service, resource_type, stem, identity_key=No
             drifted.add(key)
 
     if drifted:
-        return [Finding(service, resource_type, stem, "fixture-drift",
-                        "compliant.tf and nonCompliant.tf also differ on: "
-                        + ", ".join(sorted(drifted)))]
-    return []
+        findings.append(Finding(
+            service, resource_type, stem, "fixture-drift",
+            "compliant.tf and nonCompliant.tf also differ on: " + ", ".join(sorted(drifted))))
+    return findings
 
 
 # --------------------------------------------------------------------------- #
 # Rules over _vars.rego
 # --------------------------------------------------------------------------- #
 _friendly_index_cache: dict[tuple, dict] = {}
+
+# Text fallback for the friendly-name index only. It is deliberately not used for
+# anything else: every rule that decides a finding reads *evaluated* Rego, never
+# scraped text.
+FRIENDLY_NAME_RE = re.compile(
+    r'"friendly_resource_name"\s*:\s*"((?:[^"\\]|\\.)*)"')
+
+
+def _friendly_name_from_text(vars_path):
+    """The declared friendly_resource_name scraped from a _vars.rego, or None."""
+    match = FRIENDLY_NAME_RE.search(Path(vars_path).read_text(encoding="utf-8"))
+    return match.group(1) if match else None
 
 
 def _friendly_name_index(policies_root, platform):
@@ -575,21 +655,28 @@ def _friendly_name_index(policies_root, platform):
     helpers_dir = _resolve_helpers(policies_root)
     try:
         tree = _run_opa("data.terraform", helpers_dir, platform_root) or {}
+    except OpaUnavailableError:
+        raise
     except PolicyLintError:
-        tree = None      # one bad file in the tree — fall back to per-file reads
+        # ONE unparseable file anywhere under the platform fails the batch. Asking
+        # per file instead meant ~370 subprocesses (0.8s -> 9.3s) just because of an
+        # unrelated typo, so read the names out of the text instead: a friendly name
+        # is a literal in the file, and this index only needs that one field.
+        tree = None
 
     index = {}
     for vars_path in vars_paths:
         try:
-            package = _package_of(vars_path)
             variables = None
             if tree is not None:
-                variables = _walk(tree, package.split(".")[1:] + ["variables"])
-            if not isinstance(variables, dict):
-                variables = load_variables(vars_path, policies_root)
-        except (PolicyLintError, OSError):
+                variables = _walk(tree, _package_of(vars_path).split(".")[1:]
+                                  + ["variables"])
+            friendly = (variables.get("friendly_resource_name")
+                        if isinstance(variables, dict) else None)
+            if friendly is None:
+                friendly = _friendly_name_from_text(vars_path)
+        except (PolicyLintError, OSError, UnicodeDecodeError):
             continue
-        friendly = variables.get("friendly_resource_name")
         friendly = friendly.strip().lower() if isinstance(friendly, str) else ""
         if friendly:
             index.setdefault(friendly, []).append(
@@ -660,6 +747,8 @@ def lint_resource(root, platform, service_folder, resource_type):
                                         vars_path, policies_root)
             identity_key = load_variables(
                 vars_path, policies_root).get("resource_value_name")
+        except OpaUnavailableError:
+            raise
         except (PolicyLintError, OSError, UnicodeDecodeError) as exc:
             findings.append(Finding(service_folder, resource_type, "_vars",
                                     "lint-error", str(exc)))
@@ -670,6 +759,8 @@ def lint_resource(root, platform, service_folder, resource_type):
         try:
             findings += _lint_policy_file(root, platform, service_folder, resource_type,
                                           rego_path, policies_root, identity_key)
+        except OpaUnavailableError:
+            raise
         except (PolicyLintError, OSError, UnicodeDecodeError) as exc:
             findings.append(Finding(service_folder, resource_type, rego_path.stem,
                                     "lint-error", str(exc)))
@@ -709,9 +800,13 @@ def _expand_target(root, target):
         resources = [d.name for d in sorted(service_dir.iterdir()) if d.is_dir()]
         if len(parts) == 3:
             if parts[2] not in resources:
+                # The service folder exists, so the name is plausible — this is
+                # usually a resource whose policies have not been written yet, not
+                # a typo. Marked so the portal can treat it as "nothing to lint".
                 raise TargetError(
-                    f"no resource type '{parts[2]}' in '{platform}/{service}' "
-                    f"({len(resources)} available)")
+                    f"no policies directory {platform}/{service}/{parts[2]}/ "
+                    f"({len(resources)} resource type(s) in that service)",
+                    marker="no-policies-dir")
             resources = [parts[2]]
         out += [(platform, service, resource) for resource in resources]
     return out
@@ -729,7 +824,11 @@ def main(argv=None):
         formatter_class=argparse.RawDescriptionHelpFormatter)
     parser.add_argument("targets", nargs="*", metavar="TARGET",
                         help="'<platform>', '<platform>/<Service folder>' or "
-                             "'<platform>/<Service folder>/<resource_type>'")
+                             "'<platform>/<Service folder>/<resource_type>'. "
+                             "Exit 2 means the target does not exist; when the "
+                             "resource type simply has no policies/ directory yet "
+                             "the stderr line reads "
+                             "'[ERROR] no-policies-dir: <target> (...)'.")
     parser.add_argument("--root", default=str(REPO_ROOT),
                         help="repo root holding docs/, policies/ and inputs/ "
                              "(default: this checkout)")
@@ -752,8 +851,13 @@ def main(argv=None):
             for platform, service, resource_type in _expand_target(root, target):
                 findings += lint_resource(root, platform, service, resource_type)
         except TargetError as exc:
-            print(f"[ERROR] {target}: {exc}", file=sys.stderr)
+            marker = f"{exc.marker}: " if exc.marker else ""
+            print(f"[ERROR] {marker}{target}: {exc}", file=sys.stderr)
             usage_error = True
+        except OpaUnavailableError as exc:
+            # One environment error for the whole run, not one per policy file.
+            print(f"[ERROR] policy_lint could not run: {exc}", file=sys.stderr)
+            return 2
 
     findings.sort(key=lambda f: (f.service, f.resource, f.policy, f.rule, f.message))
 

--- a/scripts/linters/policy_lint.py
+++ b/scripts/linters/policy_lint.py
@@ -1,0 +1,644 @@
+#!/usr/bin/env python3
+"""
+policy_lint — deterministic quality rules for the *content* of a policy kit.
+
+``linter.py`` checks that the ``docs/``, ``inputs/`` and ``policies/`` trees
+reconcile with each other (does every documented argument have a policy, a
+fixture pair and the right file names). It says nothing about whether the policy
+those files contain is any good. This linter reads the declarations themselves —
+the ``conditions`` list of every ``<argument>.rego``, the ``variables`` of every
+``_vars.rego``, and the committed Terraform plan behind every fixture pair — and
+reports the smells a marker would otherwise have to find by hand.
+
+Every rule is deterministic and carries a stable id (see ``RULES``), so a finding
+can be cited, suppressed by fixing it, and counted over time. Nothing here writes
+to ``docs/``, ``policies/`` or ``inputs/``.
+
+How a policy is read
+--------------------
+A policy file is a *data declaration*, not logic::
+
+    package terraform.<platform>.security.<service>.<resource_type>.<argument>
+
+    conditions := [
+      [ {"situation_description": ..., "remedies": [...]},        # what the human is told
+        {"condition": ..., "attribute_path": [...],               # what is actually checked
+         "values": [...], "policy_type": "whitelist"} ],
+      ...
+    ]
+
+so the conditions are read by evaluating them with ``opa eval`` rather than by
+parsing Rego text — the evaluated value is what the pipeline actually uses.
+``_vars.rego`` (``package ....<resource_type>.vars``) holds the shared
+``friendly_resource_name`` / ``resource_type`` / ``resource_value_name``.
+
+Usage
+-----
+    python3 scripts/linters/policy_lint.py "gcp/Cloud Storage/google_storage_bucket"
+    python3 scripts/linters/policy_lint.py "gcp/Cloud Storage"      # whole service
+    python3 scripts/linters/policy_lint.py gcp                      # whole platform
+    python3 scripts/linters/policy_lint.py --json "gcp/BigQuery/google_bigquery_table"
+    python3 scripts/linters/policy_lint.py --list-rules
+
+Exit code is 1 when any *error*-severity finding is reported, else 0; warnings
+never fail a build on their own.
+"""
+
+import argparse
+import json
+import re
+import subprocess
+import sys
+from dataclasses import dataclass, asdict
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
+
+# fixture_sha / plan_cache_path are the pipeline's own definition of "which
+# cached plan belongs to this fixture". Importing keeps the two in lockstep: a
+# provider bump changes the sha in both places at once.
+from scripts.auto_test.auto_test import plan_cache_path  # noqa: E402
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+HELPERS_DIR = REPO_ROOT / "policies" / "_helpers"
+
+VARS_FILE = "_vars.rego"
+REGO_EXT = ".rego"
+
+RULES = {
+    "hard-coded-value": (
+        "A value in `values` is a team-specific literal (project id, email, "
+        "bucket/key/folder/org id). Use a projects/* pattern or a structural check. "
+        "Locations are exempt."),
+    "index-path": (
+        "`attribute_path` ends in a list index; check the whole list with "
+        "`element blacklist`."),
+    "presence-only": (
+        "`values` is only null/\"\": presence is the whole check. Pair with a pattern "
+        "or justify presence in the rationale."),
+    "wrong-argument": (
+        "No condition in `<arg>.rego` reads the argument the file is named after."),
+    "fixture-drift": (
+        "compliant.tf and nonCompliant.tf differ on attributes other than the "
+        "argument under test."),
+    "fixture-missing-plan": (
+        "No committed plan cache for this fixture pair — run the test locally and "
+        "commit inputs/plan_cache."),
+    "vars-resource-type": (
+        "`_vars.resource_type` does not match the resource-type directory."),
+    "vars-friendly-name": (
+        "`_vars.friendly_resource_name` is empty, equals the raw Terraform type, or "
+        "is reused by another resource type."),
+    "trivial-message": (
+        "`situation_description` under 20 characters or `remedies` empty."),
+    "legacy-assign": "Use `:=` for message/details/summary (warn).",
+    "package-case": "Package service segment is not lowercase snake_case (warn).",
+}
+
+# Only style rules are advisory; everything else is a correctness/quality error.
+WARN_RULES = {"legacy-assign", "package-case"}
+
+# --------------------------------------------------------------------------- #
+# Rule constants
+# --------------------------------------------------------------------------- #
+
+# A literal project segment: "projects/PDE", "projects/my-proj/locations/x".
+# "projects/*" and "projects/*/locations/*" are the *recommended* form and must
+# never be flagged, so the segment right after "projects/" may not start with `*`.
+PROJECT_LITERAL_RE = re.compile(r"^projects/[^*][^/]*(?:/|$)")
+EMAIL_RE = re.compile(r"[A-Za-z0-9._%+\-]+@[A-Za-z0-9\-]+\.[A-Za-z0-9.\-]*[A-Za-z]{2,}")
+STORAGE_URI_RE = re.compile(r"^(?:gs|s3)://")
+ORG_FOLDER_RE = re.compile(r"^(?:organizations|folders)/\d+")
+
+HARD_CODED_PATTERNS = (
+    ("project id", PROJECT_LITERAL_RE),
+    ("email address", EMAIL_RE),
+    ("bucket URI", STORAGE_URI_RE),
+    ("organization/folder id", ORG_FOLDER_RE),
+)
+
+# Region/zone names are a separate (much larger) cleanup item; an argument that
+# *is* a location is expected to name one, so it is exempt from hard-coded-value.
+LOCATION_SEGMENTS = {
+    "location", "locations", "region", "regions", "zone", "zones",
+    "replica_zones", "included_locations",
+}
+
+MIN_SITUATION_DESCRIPTION = 20
+LEGACY_ASSIGN_RE = re.compile(r"^\s*(message|details|summary)\s*=\s")
+PACKAGE_RE = re.compile(r"^\s*package\s+([A-Za-z_][\w.]*)", re.MULTILINE)
+SNAKE_CASE_RE = re.compile(r"^[a-z][a-z0-9_]*$")
+
+# Fixture resource labels, per the auto_test convention.
+FIXTURE_LABEL_RE = re.compile(r"^(compliant|non_compliant)_example_(\d+)$")
+# Keys that are *expected* to differ between the two fixture resources: the
+# resource's own identity, and the provider-computed mirrors of `labels` (which
+# always move with it). The resource's `resource_value_name` — the attribute the
+# violation message quotes, which is `bucket` on an IAM binding, not `name` — is
+# added per resource type.
+FIXTURE_IGNORED_KEYS = {
+    "name", "id", "labels", "label",
+    "effective_labels", "terraform_labels", "effective_annotations",
+}
+
+# Blacklist/whitelist only — a pattern or range policy with empty values means
+# something else entirely.
+PRESENCE_POLICY_TYPES = {"blacklist", "whitelist"}
+EMPTY_VALUES = (None, "", [], {})
+
+
+class PolicyLintError(RuntimeError):
+    """A policy kit could not be read at all (OPA refused to evaluate it)."""
+
+
+@dataclass(frozen=True)
+class Finding:
+    service: str
+    resource: str
+    policy: str          # argument path (the .rego file stem) or "_vars"
+    rule: str
+    message: str
+    severity: str = "error"
+
+
+# --------------------------------------------------------------------------- #
+# OPA plumbing
+# --------------------------------------------------------------------------- #
+_eval_cache: dict[tuple, dict] = {}
+
+
+def _run_opa(query, *data_dirs):
+    """``opa eval --format json`` over ``data_dirs``; returns the query value."""
+    cmd = ["opa", "eval", "--format", "json"]
+    for d in data_dirs:
+        cmd += ["-d", str(d)]
+    cmd.append(query)
+    try:
+        proc = subprocess.run(cmd, capture_output=True, text=True)
+    except FileNotFoundError as exc:                     # pragma: no cover - env
+        raise PolicyLintError("`opa` is not on PATH — install it to run policy_lint.") from exc
+    if proc.returncode != 0:
+        raise PolicyLintError(f"opa eval {query!r} failed: {proc.stderr.strip()}")
+    result = json.loads(proc.stdout or "{}").get("result") or []
+    if not result:
+        return None                                       # undefined, not an error
+    return result[0]["expressions"][0]["value"]
+
+
+def _eval_dir(directory, helpers_dir):
+    """Whole-``data.terraform`` value for one policy directory, cached.
+
+    One OPA invocation per resource-type directory covers every policy file in
+    it; a per-file query is only used if this batch evaluation fails.
+    """
+    key = (str(Path(directory).resolve()), str(Path(helpers_dir).resolve()))
+    if key not in _eval_cache:
+        try:
+            _eval_cache[key] = _run_opa("data.terraform", helpers_dir, directory) or {}
+        except PolicyLintError:
+            _eval_cache[key] = None                       # force the per-file path
+    return _eval_cache[key]
+
+
+def _package_of(rego_path):
+    """The package name declared by a .rego file."""
+    match = PACKAGE_RE.search(Path(rego_path).read_text(encoding="utf-8"))
+    if not match:
+        raise PolicyLintError(f"{rego_path}: no `package` declaration")
+    return match.group(1)
+
+
+def _walk(tree, segments):
+    for segment in segments:
+        if not isinstance(tree, dict) or segment not in tree:
+            return None
+        tree = tree[segment]
+    return tree
+
+
+def _rule_value(rego_path, helpers_dir, rule_name):
+    """Value of ``data.<package>.<rule_name>`` for one .rego file."""
+    package = _package_of(rego_path)
+    tree = _eval_dir(Path(rego_path).parent, helpers_dir)
+    if tree is not None:
+        node = _walk(tree, package.split(".")[1:] + [rule_name])
+        if node is not None:
+            return node
+    # Batch evaluation failed or the rule is undefined in it — ask directly, so a
+    # genuine OPA error surfaces as an error rather than as a silent empty list.
+    return _run_opa(f"data.{package}.{rule_name}", helpers_dir, Path(rego_path).parent)
+
+
+def load_conditions(rego_path, policies_root, helpers_dir=None):
+    """The evaluated ``conditions`` of a policy file: a list of condition groups.
+
+    Each group is ``[meta, check, ...]`` — ``meta`` carries
+    ``situation_description``/``remedies``, each ``check`` carries
+    ``condition``/``attribute_path``/``values``/``policy_type``.
+    """
+    helpers_dir = _resolve_helpers(policies_root, helpers_dir)
+    value = _rule_value(rego_path, helpers_dir, "conditions")
+    return value if isinstance(value, list) else []
+
+
+def load_variables(vars_path, policies_root, helpers_dir=None):
+    """The evaluated ``variables`` object of a ``_vars.rego`` file."""
+    helpers_dir = _resolve_helpers(policies_root, helpers_dir)
+    value = _rule_value(vars_path, helpers_dir, "variables")
+    return value if isinstance(value, dict) else {}
+
+
+def _resolve_helpers(policies_root, helpers_dir=None):
+    """Helpers live in the tree under lint when it has them, else in the repo.
+
+    Test fixture trees are miniature repos that deliberately do not carry a copy
+    of ``policies/_helpers`` — they borrow the real one.
+    """
+    if helpers_dir is not None:
+        return Path(helpers_dir)
+    local = Path(policies_root) / "_helpers"
+    return local if local.is_dir() else HELPERS_DIR
+
+
+# --------------------------------------------------------------------------- #
+# Plan cache
+# --------------------------------------------------------------------------- #
+def plan_cache_for(root, input_dir):
+    """``<root>/inputs/plan_cache/<platform>/<sha>.json`` for a fixture dir.
+
+    The sha and platform come from ``auto_test.plan_cache_path`` (the pipeline's
+    own definition); only the *root* is rebased, so a fixture tree under
+    ``_tests/`` resolves inside itself. For the real repo this is the identity.
+    """
+    canonical = plan_cache_path(Path(input_dir))
+    return Path(root) / "inputs" / "plan_cache" / canonical.parent.name / canonical.name
+
+
+# --------------------------------------------------------------------------- #
+# Condition helpers
+# --------------------------------------------------------------------------- #
+def _split_group(group):
+    """A condition group into (meta dicts, check dicts)."""
+    metas, checks = [], []
+    for entry in group if isinstance(group, list) else []:
+        if not isinstance(entry, dict):
+            continue
+        if "attribute_path" in entry:
+            checks.append(entry)
+        elif "situation_description" in entry or "remedies" in entry:
+            metas.append(entry)
+    return metas, checks
+
+
+def _strings_in(value):
+    """Every string anywhere inside ``values`` (pattern group lists included)."""
+    if isinstance(value, str):
+        yield value
+    elif isinstance(value, list):
+        for item in value:
+            yield from _strings_in(item)
+    elif isinstance(value, dict):
+        for item in value.values():
+            yield from _strings_in(item)
+
+
+def _path_segments(attribute_path):
+    """String segments of an attribute_path, list indices dropped."""
+    return [p for p in (attribute_path or []) if isinstance(p, str)]
+
+
+def _is_index(segment):
+    return isinstance(segment, int) and not isinstance(segment, bool)
+
+
+def _is_location_argument(stem, attribute_path):
+    """True when this argument names a location — exempt from hard-coded-value."""
+    candidates = [stem.split(".")[-1]]
+    segments = _path_segments(attribute_path)
+    if segments:
+        candidates.append(segments[-1])
+    if any(c in LOCATION_SEGMENTS for c in candidates):
+        return True
+    return any(stem.endswith("_" + seg) or stem.endswith("." + seg)
+               for seg in LOCATION_SEGMENTS)
+
+
+# --------------------------------------------------------------------------- #
+# Rules over one policy file
+# --------------------------------------------------------------------------- #
+def _lint_policy_file(root, platform, service, resource_type, rego_path, policies_root,
+                      identity_key=None):
+    stem = rego_path.stem
+    text = rego_path.read_text(encoding="utf-8")
+    out = []
+
+    def add(rule, message):
+        out.append(Finding(service, resource_type, stem, rule, message,
+                           "warn" if rule in WARN_RULES else "error"))
+
+    # --- package-case (warn) ---------------------------------------------- #
+    package = _package_of(rego_path)
+    segments = package.split(".")
+    if len(segments) >= 4 and not SNAKE_CASE_RE.match(segments[3]):
+        add("package-case",
+            f"package service segment '{segments[3]}' is not lowercase snake_case")
+
+    # --- legacy-assign (warn) --------------------------------------------- #
+    legacy = sorted({LEGACY_ASSIGN_RE.match(line).group(1)
+                     for line in text.splitlines() if LEGACY_ASSIGN_RE.match(line)})
+    if legacy:
+        add("legacy-assign", f"{', '.join(legacy)} assigned with '=' instead of ':='")
+
+    conditions = load_conditions(rego_path, policies_root)
+
+    seen = set()
+
+    def add_once(rule, key, message):
+        if (rule, key) not in seen:
+            seen.add((rule, key))
+            add(rule, message)
+
+    joined_paths = []
+    for group in conditions:
+        metas, checks = _split_group(group)
+
+        # --- trivial-message ---------------------------------------------- #
+        for meta in metas:
+            description = meta.get("situation_description")
+            too_short = (not isinstance(description, str)
+                         or len(description.strip()) < MIN_SITUATION_DESCRIPTION)
+            if too_short:
+                add_once("trivial-message", ("desc", str(description)),
+                         f"situation_description {str(description)!r} is under "
+                         f"{MIN_SITUATION_DESCRIPTION} characters")
+            if not meta.get("remedies"):
+                add_once("trivial-message", ("rem", str(description)),
+                         f"remedies is empty for {str(description)!r}")
+
+        for check in checks:
+            attribute_path = check.get("attribute_path") or []
+            values = check.get("values")
+            policy_type = (check.get("policy_type") or "").strip().lower()
+            path_text = ".".join(str(p) for p in attribute_path)
+            joined_paths.append(".".join(_path_segments(attribute_path)))
+
+            # --- index-path ------------------------------------------------ #
+            if attribute_path and _is_index(attribute_path[-1]):
+                add_once("index-path", path_text,
+                         f"attribute_path {attribute_path} ends in a list index; use "
+                         "'element blacklist' to check the whole list")
+
+            # --- presence-only --------------------------------------------- #
+            if (isinstance(values, list) and values
+                    and policy_type in PRESENCE_POLICY_TYPES
+                    and all(v in EMPTY_VALUES for v in values)):
+                add_once("presence-only", path_text,
+                         f"'{path_text}' only checks presence ({values!r}) under a "
+                         f"{policy_type} — pair it with a pattern or justify it")
+
+            # --- hard-coded-value ------------------------------------------ #
+            if not _is_location_argument(stem, attribute_path):
+                for literal in _strings_in(values):
+                    for label, pattern in HARD_CODED_PATTERNS:
+                        if pattern.search(literal):
+                            add_once("hard-coded-value", literal,
+                                     f"'{path_text}' pins the team-specific {label} "
+                                     f"{literal!r}")
+                            break
+
+    # --- wrong-argument ---------------------------------------------------- #
+    if conditions and not any(p == stem or p.startswith(stem + ".") for p in joined_paths):
+        add("wrong-argument",
+            f"no condition reads '{stem}' (attribute paths: "
+            f"{', '.join(sorted(set(p for p in joined_paths if p))) or 'none'})")
+
+    out.extend(_lint_fixtures(root, platform, service, resource_type, stem, identity_key))
+    return out
+
+
+# --------------------------------------------------------------------------- #
+# Rules over the fixture pair
+# --------------------------------------------------------------------------- #
+def _lint_fixtures(root, platform, service, resource_type, stem, identity_key=None):
+    input_dir = Path(root) / "inputs" / platform / service / resource_type / stem
+    # A missing input directory is linter.py's finding (an orphan policy), not
+    # ours — we only speak about fixtures that exist.
+    if not input_dir.is_dir() or not any(input_dir.glob("*.tf")):
+        return []
+
+    cache = plan_cache_for(root, input_dir)
+    if not cache.exists():
+        return [Finding(service, resource_type, stem, "fixture-missing-plan",
+                        f"no committed plan cache at inputs/plan_cache/{platform}/"
+                        f"{cache.name} — run auto_test locally and commit it")]
+
+    try:
+        plan = json.loads(cache.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as exc:
+        return [Finding(service, resource_type, stem, "fixture-missing-plan",
+                        f"plan cache {cache.name} is unreadable: {exc}")]
+
+    resources = (plan.get("planned_values", {}).get("root_module", {}).get("resources") or [])
+    compliant, non_compliant = {}, {}
+    for resource in resources:
+        if resource.get("type") != resource_type:
+            continue
+        match = FIXTURE_LABEL_RE.match(resource.get("name", ""))
+        if not match:
+            continue
+        bucket = compliant if match.group(1) == "compliant" else non_compliant
+        bucket[match.group(2)] = resource.get("values") or {}
+
+    # Only the argument's *top-level* key is expected to differ; a nested
+    # argument (a.b.c) is compared at its block key, since the plan nests it.
+    argument_key = stem.split(".")[0]
+    ignored = FIXTURE_IGNORED_KEYS | {argument_key}
+    if identity_key:
+        ignored.add(identity_key)
+
+    drifted = set()
+    for index in sorted(set(compliant) & set(non_compliant)):
+        good, bad = compliant[index], non_compliant[index]
+        for key in set(good) | set(bad):
+            if key not in ignored and good.get(key) != bad.get(key):
+                drifted.add(key)
+
+    if drifted:
+        return [Finding(service, resource_type, stem, "fixture-drift",
+                        "compliant.tf and nonCompliant.tf also differ on: "
+                        + ", ".join(sorted(drifted)))]
+    return []
+
+
+# --------------------------------------------------------------------------- #
+# Rules over _vars.rego
+# --------------------------------------------------------------------------- #
+_friendly_index_cache: dict[tuple, dict] = {}
+
+
+def _friendly_name_index(policies_root, platform):
+    """{normalised friendly name: [(service, resource_type), ...]} for a platform.
+
+    Scanned once per platform root and cached: duplicate detection is only
+    meaningful across the whole tree.
+    """
+    policies_root = Path(policies_root)
+    key = (str(policies_root.resolve()), platform)
+    if key in _friendly_index_cache:
+        return _friendly_index_cache[key]
+
+    index = {}
+    platform_root = policies_root / platform
+    for vars_path in sorted(platform_root.glob(f"*/*/{VARS_FILE}")):
+        try:
+            variables = load_variables(vars_path, policies_root)
+        except PolicyLintError:
+            continue
+        friendly = variables.get("friendly_resource_name")
+        friendly = friendly.strip().lower() if isinstance(friendly, str) else ""
+        if friendly:
+            index.setdefault(friendly, []).append(
+                (vars_path.parent.parent.name, vars_path.parent.name))
+    _friendly_index_cache[key] = index
+    return index
+
+
+def _lint_vars_file(platform, service, resource_type, vars_path, policies_root):
+    out = []
+
+    def add(rule, message):
+        out.append(Finding(service, resource_type, "_vars", rule, message,
+                           "warn" if rule in WARN_RULES else "error"))
+
+    variables = load_variables(vars_path, policies_root)
+
+    declared_type = variables.get("resource_type")
+    if declared_type != resource_type:
+        add("vars-resource-type",
+            f"resource_type is {declared_type!r} but the directory is "
+            f"'{resource_type}' — the policy will never match a planned resource")
+
+    friendly = variables.get("friendly_resource_name")
+    friendly_text = friendly.strip() if isinstance(friendly, str) else ""
+    if not friendly_text:
+        add("vars-friendly-name", "friendly_resource_name is empty")
+    elif friendly_text == resource_type or friendly_text == declared_type:
+        add("vars-friendly-name",
+            f"friendly_resource_name {friendly_text!r} is the raw Terraform type — "
+            "use the name a human would say")
+    else:
+        others = [rt for svc, rt in
+                  _friendly_name_index(policies_root, platform).get(friendly_text.lower(), [])
+                  if rt != resource_type]
+        if others:
+            add("vars-friendly-name",
+                f"friendly_resource_name {friendly_text!r} is also used by "
+                + ", ".join(sorted(others)))
+    return out
+
+
+# --------------------------------------------------------------------------- #
+# Entry points
+# --------------------------------------------------------------------------- #
+def lint_resource(root, platform, service_folder, resource_type):
+    """Every finding for one ``policies/<platform>/<service>/<resource_type>/``."""
+    root = Path(root)
+    policies_root = root / "policies"
+    resource_dir = policies_root / platform / service_folder / resource_type
+    if not resource_dir.is_dir():
+        return []
+
+    findings = []
+    identity_key = None
+    vars_path = resource_dir / VARS_FILE
+    if vars_path.is_file():
+        findings += _lint_vars_file(platform, service_folder, resource_type,
+                                    vars_path, policies_root)
+        identity_key = load_variables(vars_path, policies_root).get("resource_value_name")
+    for rego_path in sorted(resource_dir.glob(f"*{REGO_EXT}")):
+        if rego_path.name == VARS_FILE:
+            continue
+        findings += _lint_policy_file(root, platform, service_folder, resource_type,
+                                      rego_path, policies_root, identity_key)
+    return findings
+
+
+def _expand_target(root, target):
+    """A ``platform[/service[/resource]]`` target into (platform, service, resource)."""
+    parts = [p for p in target.split("/") if p]
+    if not parts or len(parts) > 3:
+        raise ValueError(
+            f"target {target!r} must be '<platform>', '<platform>/<Service folder>' or "
+            "'<platform>/<Service folder>/<resource_type>'")
+    platform = parts[0]
+    platform_root = Path(root) / "policies" / platform
+    if len(parts) == 3:
+        return [(platform, parts[1], parts[2])]
+    services = [parts[1]] if len(parts) == 2 else [
+        d.name for d in sorted(platform_root.iterdir()) if d.is_dir()]
+    out = []
+    for service in services:
+        service_dir = platform_root / service
+        if not service_dir.is_dir():
+            raise ValueError(f"no policies directory for '{platform}/{service}'")
+        out += [(platform, service, d.name)
+                for d in sorted(service_dir.iterdir()) if d.is_dir()]
+    return out
+
+
+def _print_rules():
+    width = max(len(r) for r in RULES)
+    for rule_id, description in RULES.items():
+        print(f"{rule_id.ljust(width)}  {description}")
+
+
+def main(argv=None):
+    parser = argparse.ArgumentParser(
+        description="Lint the content of a policy kit (conditions, _vars, fixtures).",
+        formatter_class=argparse.RawDescriptionHelpFormatter)
+    parser.add_argument("targets", nargs="*", metavar="TARGET",
+                        help="'<platform>', '<platform>/<Service folder>' or "
+                             "'<platform>/<Service folder>/<resource_type>'")
+    parser.add_argument("--root", default=str(REPO_ROOT),
+                        help="repo root holding docs/, policies/ and inputs/ "
+                             "(default: this checkout)")
+    parser.add_argument("--json", action="store_true", dest="as_json",
+                        help="print the findings as a JSON array")
+    parser.add_argument("--list-rules", action="store_true",
+                        help="print every rule id and its description, then exit")
+    args = parser.parse_args(argv)
+
+    if args.list_rules:
+        _print_rules()
+        return 0
+    if not args.targets:
+        parser.error("at least one TARGET is required (or use --list-rules)")
+
+    root = Path(args.root)
+    findings, failed = [], False
+    for target in args.targets:
+        try:
+            for platform, service, resource_type in _expand_target(root, target):
+                findings += lint_resource(root, platform, service, resource_type)
+        except (ValueError, PolicyLintError) as exc:
+            print(f"[ERROR] {target}: {exc}", file=sys.stderr)
+            failed = True
+
+    findings.sort(key=lambda f: (f.service, f.resource, f.policy, f.rule, f.message))
+
+    if args.as_json:
+        print(json.dumps([asdict(f) for f in findings], indent=2))
+    else:
+        for finding in findings:
+            print(f"[{finding.severity}] {finding.service}/{finding.resource}/"
+                  f"{finding.policy}: {finding.rule} — {finding.message}")
+        errors = sum(1 for f in findings if f.severity == "error")
+        warns = len(findings) - errors
+        print(f"\n{errors} error(s), {warns} warning(s)."
+              if findings else "\nNo findings.")
+
+    return 1 if failed or any(f.severity == "error" for f in findings) else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/linters/readme-linters.md
+++ b/scripts/linters/readme-linters.md
@@ -5,11 +5,18 @@ cross-consistency across three trees — `docs/`, `inputs/`, `policies/` —
 treating `docs/` as the source of truth that `inputs/` and `policies/` must
 reconcile to. It uses only the Python standard library (no extra installs).
 
-There are two supporting scripts:
+There are three supporting scripts:
 
 - `run_precommit_linter.py` — runs the linter but fails only on **your** changed
-  files (so you are never blocked by the repo-wide backlog).
+  files (so you are never blocked by the repo-wide backlog). It also runs
+  `policy_lint.py` (below) over every resource type your changed files belong
+  to, on the same "own only what you changed" basis.
 - `check_branch_name.py` — enforces the branch naming convention.
+- `policy_lint.py` — deterministic *content*-quality rules over a policy kit's
+  declared `conditions`/`variables` (hard-coded literals, trivial messages,
+  fixture drift, ...). It answers whether the policy is any good, not just
+  whether the trees reconcile. Every rule and how to run it standalone is
+  documented in `Guide/Policy_writing_tutorial/policy-lint.md`.
 
 ---
 
@@ -74,6 +81,11 @@ is the whole **argument directory** — `compliant.tf` and `nonCompliant.tf` tes
 one argument together, so touching one means you own the pair. Policies/docs are
 file-level. Pre-existing backlog errors elsewhere are counted, never blocking.
 
+It also runs `policy_lint.py` over every resource type a changed file belongs
+to, and fails on an error-severity finding only when the specific `.rego` file
+(or fixture pair) it names was itself changed — see
+`Guide/Policy_writing_tutorial/policy-lint.md`.
+
 ```bash
 python scripts/linters/run_precommit_linter.py            # staged + unstaged (pre-commit)
 python scripts/linters/run_precommit_linter.py --base origin/dev   # everything vs dev (CI)
@@ -84,7 +96,13 @@ python scripts/linters/run_precommit_linter.py --all      # whole tree, fail on 
 (1) `linter.py --tree all --no-content-checks` as a hard whole-tree structural
 gate (structural only, so it never blocks a PR on repo-wide content debt), and
 (2) `run_precommit_linter.py --base origin/<base>` to enforce structural + content
-checks on the PR's own changed files.
+checks (including `policy_lint.py`, which needs OPA installed in the job) on the
+PR's own changed files.
+
+`.github/workflows/policy_check_ALL.yaml` (on every push to `dev`) additionally
+runs `policy_lint.py --json gcp` over the whole tree as a `continue-on-error`
+report, publishing `policy-lint-report.json` as a build artifact for
+maintainers to track the content-quality backlog — it never blocks.
 
 ---
 

--- a/scripts/linters/run_precommit_linter.py
+++ b/scripts/linters/run_precommit_linter.py
@@ -9,6 +9,13 @@ over the whole tree (with --content-checks) and fail only on error lines whose
 path intersects the changed set. Pre-existing errors elsewhere are reported as a
 count but never block.
 
+The same "own it, don't block on the backlog" treatment applies to
+``policy_lint`` (scripts/linters/policy_lint.py): every resource type touched
+under policies/ or inputs/ is content-linted, but an individual finding only
+fails the run when the .rego file (or, for a fixture finding, the argument
+directory) it names was itself changed — a sibling argument's pre-existing
+finding never blocks you. See Guide/Policy_writing_tutorial/policy-lint.md.
+
 Modes (run from the repo root):
   (no args)         pre-commit: changed set = staged + unstaged worktree edits
   --base <ref>      CI/PR:      changed set = everything this branch changed vs
@@ -18,10 +25,21 @@ Modes (run from the repo root):
 import os
 import subprocess
 import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(REPO_ROOT))
+
+from scripts.linters import policy_lint  # noqa: E402
 
 LINTER = [sys.executable, os.path.join("scripts", "linters", "linter.py"),
           "--tree", "all", "--platform", "gcp", "--content-checks"]
 RELEVANT_PREFIXES = ("docs/", "inputs/", "policies/")
+
+# Findings about the fixture pair itself (compliant.tf/nonCompliant.tf), as
+# opposed to a policy .rego file — displayed and owned via the argument
+# directory under inputs/, not a single policy file.
+FIXTURE_RULES = {"fixture-drift", "fixture-missing-plan"}
 
 
 def _git(*args):
@@ -67,6 +85,61 @@ def _owned(changed):
         if f.startswith("inputs/") and "/" in f:
             owned.add(f.rsplit("/", 1)[0])   # the argument directory
     return owned
+
+
+def _owned_triples(changed):
+    """(platform, service, resource_type) triples policy_lint should check.
+
+    Any changed file at least 4 segments deep under ``policies/`` or
+    ``inputs/`` puts its resource type in scope for ``policy_lint`` — the
+    individual *findings* are then scoped back down to the argument or
+    fixture pair actually touched by ``_finding_owned``, so touching one
+    argument does not put a sibling argument's pre-existing findings on you.
+    """
+    triples = set()
+    for f in changed:
+        parts = f.split("/")
+        if len(parts) >= 4 and parts[0] in ("policies", "inputs"):
+            triples.add((parts[1], parts[2], parts[3]))
+    return triples
+
+
+def _finding_path(platform, service, resource_type, finding):
+    """The policy file (or, for a fixture finding, the argument directory)
+    a ``policy_lint`` finding is about."""
+    base = f"{platform}/{service}/{resource_type}"
+    if finding.rule in FIXTURE_RULES:
+        return f"inputs/{base}/{finding.policy}"
+    name = "_vars.rego" if finding.policy == "_vars" else f"{finding.policy}.rego"
+    return f"policies/{base}/{name}"
+
+
+def _finding_owned(path, changed):
+    """True if ``path`` (a file, or a fixture argument directory) is among
+    ``changed`` — either changed directly, or (for a directory) it has a
+    changed file beneath it."""
+    return path in changed or any(c == path or c.startswith(path + "/") for c in changed)
+
+
+def _policy_lint_findings(triples, changed, root=REPO_ROOT):
+    """Error-severity ``policy_lint`` findings for ``triples``, split into
+    ``(owned, backlog_count)``.
+
+    ``owned`` is a list of ``(path, Finding)`` pairs whose file was itself
+    changed; everything else (a sibling argument's pre-existing error, or a
+    warning) is counted in ``backlog_count`` but never attributed.
+    """
+    owned, backlog = [], 0
+    for platform, service, resource_type in sorted(triples):
+        for finding in policy_lint.lint_resource(root, platform, service, resource_type):
+            if finding.severity != "error":
+                continue
+            path = _finding_path(platform, service, resource_type, finding)
+            if _finding_owned(path, changed):
+                owned.append((path, finding))
+            else:
+                backlog += 1
+    return owned, backlog
 
 
 def _error_path(line):
@@ -123,7 +196,33 @@ def main(argv=None):
             print(f"\n({backlog} pre-existing error(s) elsewhere are not attributed to you.)")
         return 1
 
+    # policy_lint: content-quality rules (hard-coded values, trivial messages,
+    # fixture drift, ...) over the resource types this change touches. Only
+    # runs in changed-files modes — `--all` stays a linter.py-only, structural
+    # + reconciliation gate.
+    policy_lint_owned, policy_lint_backlog = [], 0
+    if changed is not None:
+        triples = _owned_triples(changed)
+        if triples:
+            try:
+                policy_lint_owned, policy_lint_backlog = _policy_lint_findings(triples, changed)
+            except policy_lint.PolicyLintError as exc:
+                print(f"\n[FAIL] policy_lint could not run: {exc}")
+                return 1
+
+    if policy_lint_owned:
+        print("\n[FAIL] policy_lint error(s) you must fix:\n")
+        for path, finding in policy_lint_owned:
+            print(f"  {finding.rule}: {path} — {finding.message}")
+        if policy_lint_backlog:
+            print(f"\n({policy_lint_backlog} pre-existing policy_lint error(s) elsewhere "
+                  "are not attributed to you.)")
+        return 1
+
     suffix = f" ({backlog} pre-existing backlog error(s) elsewhere ignored)" if backlog else ""
+    if policy_lint_backlog:
+        suffix += (f"; {policy_lint_backlog} pre-existing policy_lint backlog error(s) "
+                   "elsewhere ignored")
     print(f"\n[OK] no lint errors in scope{suffix}.")
     return 0
 


### PR DESCRIPTION
Adds `scripts/linters/policy_lint.py` — a deterministic linter for student policy kits (one finding per rule id; `--json`, `--list-rules`; exit 0 clean / 1 findings / 2 usage) — and wires it in:

- **Changed-files gate** (`run_precommit_linter.py --base …`, already in the PR workflow): fails only on error-severity findings in files the branch changed. Pre-existing findings on `dev` never block a student.
- **Whole-tree report** (report-only step in `policy_check_ALL.yaml`, JSON artifact + per-rule summary) — the backlog for maintainers.
- **Rules page** `Guide/Policy_writing_tutorial/policy-lint.md`: one anchored section per rule id (the PDE Portal links to them), how to run locally, and the rule that student branches must not modify `scripts/**` or `policies/_helpers/**` (the portal scans with `dev`'s copies).

Rules (error): `hard-coded-value`, `index-path`, `wrong-argument`, `fixture-drift`, `fixture-unpaired`, `fixture-missing-plan`, `vars-resource-type`, `vars-friendly-name`, `trivial-message`, `lint-error`. Warnings: `presence-only`, `package-case`, `legacy-assign`.

Current `dev` sweep (~10s): 764 findings across 273 resource types — 626 error / 138 warn (fixture-drift 419, hard-coded-value 79, vars-friendly-name 55, fixture-unpaired 34, index-path 21, …). These do not fail any PR today; moving to whole-tree failing is a follow-up once the backlog is cleaned.

Tests: 65 passing (`scripts/linters/_tests`, `scripts/auto_test/_tests`); structural linter unchanged and green. Single-rtype lint ≈0.7s.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01K5gP68z4mhyEP9NsGddBDp