### PR TITLE
Branch scope linter: a Service/ branch may only change its own resource type

### DIFF
--- a/.github/workflows/branch-scope.yml
+++ b/.github/workflows/branch-scope.yml
@@ -1,0 +1,59 @@
+name: Branch Scope
+
+# A Service/<platform>/<service_slug>/<resource_type> branch may only change the
+# files belonging to that one resource (plus additions to inputs/plan_cache).
+#
+# Deliberately its own workflow with NO `paths:` filter, unlike
+# policy_check_PR.yaml. That workflow only runs when docs/, inputs/ or policies/
+# changed — so a branch whose *only* change is to scripts/ (the shared harness),
+# to .github/, or to a stray committed binary would never trigger it, and those
+# are exactly the changes this check exists to catch. Keeping it separate also
+# means the expensive terraform/OPA jobs are not dragged into running on PRs
+# that touch nothing they care about.
+on:
+  workflow_dispatch:
+  pull_request:
+    types: [opened, synchronize, reopened]
+
+permissions:
+  contents: read
+
+concurrency:
+  group: branch-scope-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  branch_scope:
+    name: Branch scope
+    runs-on: ubuntu-latest
+    # feature/ branches and dev are out of this check's remit; the script agrees
+    # (it exits 0 on a non-Service branch), but skipping the job keeps the PR
+    # check list honest about what was actually evaluated.
+    if: github.event_name == 'workflow_dispatch' || startsWith(github.head_ref, 'Service/')
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          fetch-depth: 0                                   # need history for the merge-base
+          # Check out the branch tip itself, not the PR's synthetic merge commit,
+          # so the merge-base diff below is exactly the contributor's own changes.
+          ref: ${{ github.event.pull_request.head.sha || github.sha }}
+
+      - name: Setup Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: '3.x'
+
+      # Only the branch's own changes count: the diff is taken from the
+      # merge-base with the base branch, so merging dev in to catch up never
+      # registers as the contributor's edit.
+      - name: Check branch scope
+        env:
+          HEAD_REF: ${{ github.head_ref }}
+          BASE_REF: ${{ github.base_ref || 'dev' }}
+        run: |
+          git fetch --quiet origin "$BASE_REF"
+          python3 scripts/linters/branch_scope.py \
+            --branch "${HEAD_REF:-$GITHUB_REF_NAME}" \
+            --base "origin/$BASE_REF"

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -5,6 +5,9 @@
 #   whole tree but only FAILS on errors in the files you changed (this commit),
 #   so you are never blocked by the repo-wide backlog.
 # - branch-name-check enforces the branch naming convention.
+# - branch-scope-check keeps a Service/ branch to its own resource's files. It
+#   runs with --staged so it sees what you are about to commit, which is where a
+#   stray `git add .` gets caught — before it is ever pushed.
 #
 # Both do their own git inspection, so pass_filenames is false and always_run
 # is true (the script decides whether there is anything to check).
@@ -20,6 +23,12 @@ repos:
       - id: branch-name-check
         name: Branch naming convention
         entry: python scripts/linters/check_branch_name.py
+        language: system
+        pass_filenames: false
+        always_run: true
+      - id: branch-scope-check
+        name: Branch scope (own resource only)
+        entry: python scripts/linters/branch_scope.py --staged
         language: system
         pass_filenames: false
         always_run: true

--- a/Guide/Policy_writing_tutorial/branch-scope.md
+++ b/Guide/Policy_writing_tutorial/branch-scope.md
@@ -1,0 +1,159 @@
+<a id="top"></a>
+<h1 align="center">branch_scope — stay inside your own resource</h1>
+
+> The previous two pages check the files you *meant* to change. This one checks the files you
+> **didn't** mean to change. Your branch is named
+> `Service/<platform>/<service_slug>/<resource_type>`, and that name says exactly which resource
+> you are working on — so it also says exactly which files are yours. Anything else in the repo
+> belongs to another contributor or is shared by everybody, and `branch_scope.py` fails your PR
+> if your branch touches it.
+
+Every rule below has a stable id, so a finding can be quoted, fixed, and the id searched for in
+this page.
+
+---
+
+## What your branch owns
+
+For a branch named `Service/gcp/cloud_storage/google_storage_bucket`, these are yours:
+
+| Path | What it is | Allowed |
+|---|---|---|
+| `docs/gcp/Cloud Storage/google_storage_bucket.json` | your documentation | add or edit |
+| `inputs/gcp/Cloud Storage/google_storage_bucket/**` | your `compliant.tf` / `config.tf` / `nonCompliant.tf` | add or edit |
+| `policies/gcp/Cloud Storage/google_storage_bucket/**` | your `_vars.rego` and `<argument>.rego` | add or edit |
+| `inputs/plan_cache/**` | the shared terraform plan cache | **add only** |
+
+Nothing else. Not another resource type in your own service folder, not the shared harness, not
+the workflow files, and **no deletions anywhere** — not even inside your own folder.
+
+Note that the service in the branch name is a **slug**: docs folder names contain spaces and
+brackets that are illegal in a git branch name, so `docs/gcp/Cloud Run (v2 API)/` is written
+`cloud_run_v2_api` in the branch. The check resolves the slug back to the real folder for you —
+you never have to spell the folder name in the branch.
+
+---
+
+## How to run it
+
+    # Check what you are about to commit (this is what the pre-commit hook runs)
+    python3 scripts/linters/branch_scope.py --staged
+
+    # Check everything your branch has changed so far, against dev
+    python3 scripts/linters/branch_scope.py --base origin/dev
+
+    # Machine-readable output
+    python3 scripts/linters/branch_scope.py --json
+
+    # Every rule id and its one-liner
+    python3 scripts/linters/branch_scope.py --list-rules
+
+Exit code is `1` when the branch changed something outside its scope and `0` when it is clean —
+or when you are not on a `Service/` branch at all, since `feature/` branches are not scoped this
+way. Exit code `2` means the check could not run: usually the service slug in your branch name
+doesn't match any docs folder, which is a **branch-name** problem —
+`python3 scripts/linters/check_branch_name.py` explains that one properly.
+
+You do not need to run it by hand. `pre-commit` runs it on every commit, and the `Branch scope`
+job runs it on every pull request from a `Service/` branch.
+
+**Only your own changes are counted.** The comparison starts from the point where your branch
+left `dev`, so merging `dev` into your branch to catch up never counts as your edit. If you are
+behind, `git merge origin/dev` freely — it cannot make this check fail.
+
+---
+
+## The rules
+
+## out-of-scope-file
+
+The file isn't part of your resource type. Most often this is **another contributor's resource in
+your own service folder** — the two commonest ways it happens are a `git add .` that swept up
+files you were only looking at, and resolving a merge conflict by keeping a whole file that
+wasn't yours. Watch out for near-identical neighbours: `google_compute_target_http_proxy` is not
+`google_compute_target_https_proxy`, and `google_access_context_manager_service_perimeter` is not
+`..._service_perimeters`.
+
+It also covers stray files that were never meant to be committed at all — a downloaded `opa.exe`,
+a screenshot, a scratch `commits.txt`, an edit to `.gitignore` or to a workflow in `.github/`.
+
+Fix it by putting the file back the way `dev` has it:
+
+    git checkout origin/dev -- 'docs/gcp/Compute Engine/google_compute_image.json'
+
+or, if it is a file you created by accident, delete it from your branch and commit that.
+
+Then commit only your own paths, rather than everything:
+
+    git add "docs/gcp/<Service>/<resource type>.json" \
+            "inputs/gcp/<Service>/<resource type>" \
+            "policies/gcp/<Service>/<resource type>"
+
+## deleted-file
+
+Your branch removes a file. Writing a policy only ever **adds** files, so a deletion is nearly
+always an accident — a bad merge resolution, or a "clean up and start again" that took real work
+with it. This applies inside your own folder too: deleting your own `<argument>.rego` and its
+fixture directory silently removes an argument you had already been credited for.
+
+Put it back:
+
+    git checkout origin/dev -- '<the path in the message>'
+
+If you are renaming something you added earlier on this branch, add the new name and leave the
+old file alone. If a file genuinely does need to go, ask a senior team member first.
+
+## shared-harness-edit
+
+`scripts/**`, `policies/_helpers/**`, `tests/**` and `templates/**` are shared by every resource
+in the repo — the test harness, the Rego helper library, the helper tests, and the starter
+templates.
+
+Editing them from a resource branch does not do what you want. When the PDE Portal scans your
+branch it takes `scripts/` and `policies/_helpers/` **from `dev`**, not from your branch, so your
+edit changes nothing about what you are actually assessed against — it only makes your local run
+disagree with CI. Worse, it makes the portal's drift check refuse to scan your branch at all, so
+your progress silently stops updating. See
+[Your branch must not modify the shared harness or linter](policy-lint.md#top) for the whole
+story.
+
+    git checkout origin/dev -- scripts policies/_helpers tests templates
+
+If you think the harness or a template really is wrong — a missing rule, a bug in
+`policy_lint.py` — raise it with a senior team member so it can go in on its own `feature/`
+branch, where it will be reviewed as a change to everybody's tooling.
+
+## plan-cache-modified
+
+`inputs/plan_cache/` holds the committed terraform plan for **every** fixture pair in the repo,
+so that CI does not have to re-run `terraform plan` for a thousand resources on every push. Your
+branch may **add** entries to it — that is what happens when you test a new fixture of your own —
+but it must never change or delete the entries that are already there.
+
+If you see hundreds of these, a local test run cleared the cache and you committed the result.
+That deletes other people's cached plans; it is the single most disruptive thing a resource
+branch can do, and nothing about your own resource looks wrong afterwards. Restore it and commit
+the restoration:
+
+    git checkout origin/dev -- inputs/plan_cache
+    git commit -m "restore plan cache"
+
+Then re-run your tests and commit only the new entries they add.
+
+---
+
+## Why this is a gate and not just advice
+
+The two mistakes this catches are both **silent on the branch that causes them**. Editing the
+harness doesn't break your tests — it stops the portal scanning you, days later, with no failing
+check to point at. Wiping the plan cache doesn't break your resource — it breaks everybody
+else's next CI run. Neither one shows up in the OPA or Terraform checks, which is why the scope
+check runs on its own, on every push, on the branch that introduced the problem.
+
+<div align="center">
+
+[⬅️ Previous: policy_lint — content-quality rules](policy-lint.md#top) &nbsp;&nbsp;&nbsp; | &nbsp;&nbsp;&nbsp;
+[📘 Back to Contents](policy-writing-tutorial.md#top) &nbsp;&nbsp;&nbsp; | &nbsp;&nbsp;&nbsp;
+[Next: Raising a pull request ➡️](raising-pull-request.md#top)
+
+</div>

--- a/Guide/Policy_writing_tutorial/policy-lint.md
+++ b/Guide/Policy_writing_tutorial/policy-lint.md
@@ -344,6 +344,6 @@ changed, exactly like the structural linter on the previous page.
 
 [⬅️ Previous: Testing your policies](testing-policies.md#top) &nbsp;&nbsp;&nbsp; | &nbsp;&nbsp;&nbsp;
 [📘 Back to Contents](policy-writing-tutorial.md#top) &nbsp;&nbsp;&nbsp; | &nbsp;&nbsp;&nbsp;
-[Next: Raising a pull request ➡️](raising-pull-request.md#top)
+[Next: branch_scope — stay inside your own resource ➡️](branch-scope.md#top)
 
 </div>

--- a/Guide/Policy_writing_tutorial/policy-writing-tutorial.md
+++ b/Guide/Policy_writing_tutorial/policy-writing-tutorial.md
@@ -22,6 +22,7 @@
 <a href="policy-rego.md">policy.rego</a><br>
 <a href="testing-policies.md">Testing your policies</a><br>
 <a href="policy-lint.md">policy_lint — content-quality rules</a><br>
+<a href="branch-scope.md">branch_scope — stay inside your own resource</a><br>
 <a href="raising-pull-request.md">Raising a Pull Request</a><br>
 <a href="general-workflow.md">General work flow</a>
 

--- a/Guide/Policy_writing_tutorial/raising-pull-request.md
+++ b/Guide/Policy_writing_tutorial/raising-pull-request.md
@@ -3,9 +3,15 @@
 
 ### 1. Push your changes
 
-Run the following commands to commit and push your work:
+Add **only the files for your own resource** — not `git add .`, which sweeps up editor
+scratch files, downloaded binaries and any file you were only looking at, and will fail the
+`Branch scope` check on your pull request:
 
-    git add .
+    git add "docs/gcp/<Service>/<resource type>.json" \
+            "inputs/gcp/<Service>/<resource type>" \
+            "policies/gcp/<Service>/<resource type>"
+
+    git status          # check nothing else crept in
 
     git commit -m "message"  # e.g. initial commit
 
@@ -50,6 +56,9 @@ Your pull request must pass:
 
 - OPA checks  
 - Terraform checks  
+- Lint checks — see [policy_lint](policy-lint.md#top)  
+- **Branch scope** — your branch may only change files for its own resource type; see
+  [branch_scope](branch-scope.md#top) if it fails  
 
 Example:
 
@@ -64,7 +73,7 @@ Example:
 
 <div align="center">
 
-[⬅️ Previous: policy_lint — content-quality rules](policy-lint.md#top) &nbsp;&nbsp;&nbsp; | &nbsp;&nbsp;&nbsp;
+[⬅️ Previous: branch_scope — stay inside your own resource](branch-scope.md#top) &nbsp;&nbsp;&nbsp; | &nbsp;&nbsp;&nbsp;
 [📘 Back to Contents](policy-writing-tutorial.md#top) &nbsp;&nbsp;&nbsp;  &nbsp;&nbsp;&nbsp;
 
 </div>

--- a/scripts/linters/_tests/test_branch_scope.py
+++ b/scripts/linters/_tests/test_branch_scope.py
@@ -1,0 +1,263 @@
+"""Unit tests for branch_scope.py.
+
+These exercise the scope resolution and the per-path rule decision in isolation:
+no git repo and no real policy tree are required (``resolve_scope`` is pointed at
+a tiny docs tree built in ``tmp_path``, and the one test that covers the git
+output parser feeds it a recorded ``git diff -z --name-status`` byte string).
+"""
+
+import sys
+from pathlib import Path
+
+project_root = Path(__file__).parent.parent.parent.parent
+sys.path.insert(0, str(project_root))
+
+from scripts.linters import branch_scope as bs
+
+PLATFORM = "gcp"
+FOLDER = "Cloud Storage"
+RTYPE = "google_storage_bucket"
+
+
+def classify(status, path, folder=FOLDER, rtype=RTYPE):
+    return bs.classify(status, path, PLATFORM, folder, rtype)
+
+
+# --------------------------------------------------------------------------- #
+# parse_branch
+# --------------------------------------------------------------------------- #
+def test_parse_branch_reads_a_service_branch():
+    assert bs.parse_branch("Service/gcp/cloud_storage/google_storage_bucket") == (
+        "gcp", "cloud_storage", "google_storage_bucket")
+
+
+def test_parse_branch_ignores_a_feature_branch():
+    assert bs.parse_branch("feature/add-validator") is None
+
+
+def test_parse_branch_ignores_dev():
+    assert bs.parse_branch("dev") is None
+
+
+def test_parse_branch_rejects_the_wrong_number_of_segments():
+    assert bs.parse_branch("Service/gcp/cloud_storage") is None
+    assert bs.parse_branch("Service/gcp/cloud_storage/google_storage_bucket/extra") is None
+
+
+def test_parse_branch_rejects_an_empty_segment():
+    assert bs.parse_branch("Service/gcp//google_storage_bucket") is None
+
+
+# --------------------------------------------------------------------------- #
+# resolve_scope — the branch slug is not the directory name
+# --------------------------------------------------------------------------- #
+def _docs_tree(tmp_path, *folders):
+    for folder in folders:
+        (tmp_path / "gcp" / folder).mkdir(parents=True)
+    return str(tmp_path)
+
+
+def test_resolve_scope_maps_a_slug_to_a_capitalised_folder(tmp_path):
+    docs = _docs_tree(tmp_path, "Dataplex")
+    assert bs.resolve_scope("gcp", "dataplex", docs) == "Dataplex"
+
+
+def test_resolve_scope_maps_a_slug_across_spaces(tmp_path):
+    docs = _docs_tree(tmp_path, "Cloud Storage")
+    assert bs.resolve_scope("gcp", "cloud_storage", docs) == "Cloud Storage"
+
+
+def test_resolve_scope_maps_a_slug_across_parentheses(tmp_path):
+    # The real repo folder that motivates the slug scheme.
+    docs = _docs_tree(tmp_path, "Access Context Manager (VPC Service Controls)")
+    assert bs.resolve_scope(
+        "gcp", "access_context_manager_vpc_service_controls", docs
+    ) == "Access Context Manager (VPC Service Controls)"
+
+
+def test_resolve_scope_maps_a_slug_across_a_hyphen(tmp_path):
+    docs = _docs_tree(tmp_path, "Identity-Aware Proxy")
+    assert bs.resolve_scope("gcp", "identity_aware_proxy", docs) == "Identity-Aware Proxy"
+
+
+def test_resolve_scope_raises_for_an_unknown_slug(tmp_path):
+    docs = _docs_tree(tmp_path, "Cloud Storage")
+    try:
+        bs.resolve_scope("gcp", "no_such_service", docs)
+    except bs.ScopeError as exc:
+        assert "check_branch_name.py" in str(exc)
+    else:
+        raise AssertionError("expected ScopeError")
+
+
+# --------------------------------------------------------------------------- #
+# path_in_scope
+# --------------------------------------------------------------------------- #
+def test_own_docs_json_is_in_scope():
+    assert bs.path_in_scope(
+        "docs/gcp/Cloud Storage/google_storage_bucket.json", PLATFORM, FOLDER, RTYPE)
+
+
+def test_own_inputs_fixture_is_in_scope():
+    assert bs.path_in_scope(
+        "inputs/gcp/Cloud Storage/google_storage_bucket/location/compliant.tf",
+        PLATFORM, FOLDER, RTYPE)
+
+
+def test_own_policy_is_in_scope():
+    assert bs.path_in_scope(
+        "policies/gcp/Cloud Storage/google_storage_bucket/_vars.rego",
+        PLATFORM, FOLDER, RTYPE)
+
+
+def test_another_resource_in_the_same_service_is_out_of_scope():
+    # The commonest real violation: two contributors in one service folder.
+    assert not bs.path_in_scope(
+        "docs/gcp/Cloud Storage/google_storage_bucket_iam_binding.json",
+        PLATFORM, FOLDER, RTYPE)
+
+
+def test_a_resource_whose_name_merely_starts_with_ours_is_out_of_scope():
+    assert not bs.path_in_scope(
+        "policies/gcp/Cloud Storage/google_storage_bucket_iam_binding/role.rego",
+        PLATFORM, FOLDER, RTYPE)
+
+
+def test_another_service_is_out_of_scope():
+    assert not bs.path_in_scope(
+        "docs/gcp/BigQuery/google_bigquery_table.json", PLATFORM, FOLDER, RTYPE)
+
+
+def test_the_docs_folder_itself_is_matched_case_insensitively():
+    # A miscapitalised directory is the structural linter's error to report,
+    # not an out-of-scope one.
+    assert bs.path_in_scope(
+        "docs/gcp/cloud storage/google_storage_bucket.json", PLATFORM, FOLDER, RTYPE)
+
+
+def test_a_docs_subdirectory_is_out_of_scope():
+    # docs/<platform>/<folder>/<rtype>.json is exactly one file deep.
+    assert not bs.path_in_scope(
+        "docs/gcp/Cloud Storage/google_storage_bucket/notes.json",
+        PLATFORM, FOLDER, RTYPE)
+
+
+def test_a_bare_root_file_is_out_of_scope():
+    assert not bs.path_in_scope("opa.exe", PLATFORM, FOLDER, RTYPE)
+
+
+# --------------------------------------------------------------------------- #
+# classify
+# --------------------------------------------------------------------------- #
+def test_adding_your_own_files_is_allowed():
+    assert classify("A", "policies/gcp/Cloud Storage/google_storage_bucket/location.rego") is None
+    assert classify("M", "docs/gcp/Cloud Storage/google_storage_bucket.json") is None
+
+
+def test_adding_a_plan_cache_entry_is_allowed():
+    assert classify("A", "inputs/plan_cache/gcp/abc123.json") is None
+
+
+def test_deleting_a_plan_cache_entry_is_a_plan_cache_finding():
+    # Reported as plan-cache-modified rather than deleted-file: a wiped cache is
+    # one problem with one fix, not a thousand separate deletions.
+    assert classify("D", "inputs/plan_cache/gcp/abc123.json") == "plan-cache-modified"
+
+
+def test_modifying_a_plan_cache_entry_is_a_plan_cache_finding():
+    assert classify("M", "inputs/plan_cache/gcp/abc123.json") == "plan-cache-modified"
+
+
+def test_deleting_your_own_file_is_still_a_deletion():
+    assert classify(
+        "D", "policies/gcp/Cloud Storage/google_storage_bucket/location.rego"
+    ) == "deleted-file"
+
+
+def test_editing_the_harness_is_a_shared_harness_edit():
+    assert classify("M", "scripts/auto_test/auto_test.py") == "shared-harness-edit"
+    assert classify("M", "policies/_helpers/helpers.rego") == "shared-harness-edit"
+    assert classify("M", "templates/gcp/policy.rego") == "shared-harness-edit"
+    assert classify("M", "tests/_helpers/shared_test.rego") == "shared-harness-edit"
+
+
+def test_editing_another_resource_is_out_of_scope():
+    assert classify(
+        "M", "docs/gcp/Compute Engine/google_compute_image.json"
+    ) == "out-of-scope-file"
+
+
+def test_editing_ci_is_out_of_scope():
+    assert classify("M", ".github/workflows/policy_check_PR.yaml") == "out-of-scope-file"
+
+
+def test_stray_junk_is_out_of_scope():
+    for path in ("opa.exe", "r.png", "commits.txt", ".gitignore"):
+        assert classify("A", path) == "out-of-scope-file", path
+
+
+# --------------------------------------------------------------------------- #
+# check
+# --------------------------------------------------------------------------- #
+def test_check_is_clean_for_an_honest_branch():
+    entries = [
+        ("M", "docs/gcp/Cloud Storage/google_storage_bucket.json"),
+        ("A", "inputs/gcp/Cloud Storage/google_storage_bucket/location/compliant.tf"),
+        ("A", "policies/gcp/Cloud Storage/google_storage_bucket/location.rego"),
+        ("A", "inputs/plan_cache/gcp/abc123.json"),
+    ]
+    assert bs.check(entries, PLATFORM, FOLDER, RTYPE) == []
+
+
+def test_check_reports_each_violation_once_sorted_by_rule_then_path():
+    entries = [
+        ("A", "opa.exe"),
+        ("M", "scripts/auto_test/auto_test.py"),
+        ("A", "policies/gcp/Cloud Storage/google_storage_bucket/location.rego"),
+    ]
+    findings = bs.check(entries, PLATFORM, FOLDER, RTYPE)
+    assert [(f.rule, f.path) for f in findings] == [
+        ("out-of-scope-file", "opa.exe"),
+        ("shared-harness-edit", "scripts/auto_test/auto_test.py"),
+    ]
+
+
+def test_every_finding_carries_a_remedy_naming_the_file():
+    entries = [("M", "docs/gcp/Compute Engine/google_compute_image.json")]
+    finding = bs.check(entries, PLATFORM, FOLDER, RTYPE, base="dev")[0]
+    assert "git checkout origin/dev" in finding.message
+    assert "google_compute_image.json" in finding.message
+    assert finding.severity == "error"
+
+
+def test_every_rule_id_has_a_description_and_a_remedy():
+    assert set(bs.RULES) == set(bs.REMEDIES)
+
+
+# --------------------------------------------------------------------------- #
+# changed_entries — git output parsing
+# --------------------------------------------------------------------------- #
+def test_changed_entries_parses_statuses_spaces_and_renames(monkeypatch):
+    """A rename becomes a deletion of the old path plus an addition of the new.
+
+    Paths are NUL-separated (``-z``), which is why service folders containing
+    spaces survive intact.
+    """
+    recorded = (
+        b"M\0docs/gcp/Cloud Storage/google_storage_bucket.json\0"
+        b"A\0inputs/gcp/Cloud Storage/google_storage_bucket/location/compliant.tf\0"
+        b"D\0policies/gcp/Cloud Storage/google_storage_bucket/old.rego\0"
+        b"R096\0inputs/plan_cache/gcp/aaa.json\0inputs/plan_cache/gcp/bbb.json\0"
+    )
+    monkeypatch.setattr(bs, "_git", lambda *args: recorded)
+    monkeypatch.setattr(
+        bs.subprocess, "run",
+        lambda *a, **k: type("P", (), {"returncode": 0, "stdout": "deadbeef\n"})())
+
+    assert bs.changed_entries("origin/dev") == [
+        ("M", "docs/gcp/Cloud Storage/google_storage_bucket.json"),
+        ("A", "inputs/gcp/Cloud Storage/google_storage_bucket/location/compliant.tf"),
+        ("D", "policies/gcp/Cloud Storage/google_storage_bucket/old.rego"),
+        ("D", "inputs/plan_cache/gcp/aaa.json"),
+        ("A", "inputs/plan_cache/gcp/bbb.json"),
+    ]

--- a/scripts/linters/branch_scope.py
+++ b/scripts/linters/branch_scope.py
@@ -1,0 +1,431 @@
+#!/usr/bin/env python3
+"""
+branch_scope — a ``Service/`` branch may only change its own resource kit.
+
+Every contributor works on one resource type, on a branch named
+``Service/<platform>/<service_slug>/<resource_type>``. That branch name names
+exactly one resource, so it also names exactly the set of files the branch is
+allowed to touch::
+
+    docs/<platform>/<Service folder>/<resource_type>.json      the documentation
+    inputs/<platform>/<Service folder>/<resource_type>/**      the fixtures
+    policies/<platform>/<Service folder>/<resource_type>/**    the policies
+    inputs/plan_cache/**                                       additions only
+
+Anything else is somebody else's work or is shared by everybody, and a branch
+that changes it is either a stray `git add .` or a merge gone wrong. Two of
+those mistakes are silent and expensive:
+
+* **The shared harness.** ``scripts/**`` and ``policies/_helpers/**`` are pulled
+  from ``dev`` when the portal scans a branch, so editing them changes nothing
+  about what the branch is actually checked against — it only makes the local
+  run disagree with CI, and it makes the portal's drift check refuse to scan.
+* **The plan cache.** ``inputs/plan_cache/`` holds the committed terraform plan
+  for *every* fixture in the repo. Running the test harness in a way that clears
+  it deletes a thousand other people's cached plans, and nothing about the
+  contributor's own resource looks wrong afterwards.
+
+Neither shows up as a failing test on the branch that caused it, which is why
+this runs as its own gate on the push that introduces it.
+
+Note the service *slug* in the branch name is not the directory name: docs
+folders contain spaces and parentheses that are illegal in a git ref, so
+``docs/gcp/Cloud Run (v2 API)/`` is reached by the branch slug ``cloud_run_v2_api``.
+The mapping is shared with ``check_branch_name.py`` (see ``_service_slug.py``).
+
+Usage
+-----
+    python3 scripts/linters/branch_scope.py
+    python3 scripts/linters/branch_scope.py --base origin/dev
+    python3 scripts/linters/branch_scope.py --branch Service/gcp/dataplex/google_dataplex_task
+    python3 scripts/linters/branch_scope.py --staged     # what you are about to commit
+    python3 scripts/linters/branch_scope.py --json
+    python3 scripts/linters/branch_scope.py --list-rules
+
+Exit codes: 0 clean (or nothing to check — the branch is not a ``Service/``
+branch), 1 at least one violation, 2 a usage or environment error (not a git
+checkout, an unresolvable base ref, or a branch whose service slug does not name
+a real docs folder — that last one is a branch-name problem, and
+``check_branch_name.py`` explains it).
+"""
+
+import argparse
+import json
+import os
+import subprocess
+import sys
+from dataclasses import dataclass, asdict
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+from _service_slug import slug_to_folder  # noqa: E402
+
+RULES = {
+    "out-of-scope-file": (
+        "The file is not part of this branch's resource type. A Service/ branch may "
+        "change only its own docs JSON, inputs/ fixtures and policies/ files."),
+    "deleted-file": (
+        "The branch deletes a file. Nothing on a resource branch needs a deletion — "
+        "not even inside your own folder; rename by adding the new file."),
+    "shared-harness-edit": (
+        "The file is part of the shared test harness, helper library or templates. "
+        "It is common to every resource type and is not editable from a resource branch."),
+    "plan-cache-modified": (
+        "inputs/plan_cache/ is append-only: it holds the committed terraform plan for "
+        "every fixture in the repo, so a branch may add cache entries but never change "
+        "or delete existing ones."),
+}
+
+# Shared across every resource type, so never in one branch's scope.
+#
+# `scripts/` and `policies/_helpers/` are the two the portal pulls from `dev`
+# rather than from the branch (see Guide/Policy_writing_tutorial/policy-lint.md);
+# `tests/` and `templates/` are shared source that a resource branch has no
+# reason to touch. Everything else out of scope is reported as out-of-scope-file.
+SHARED_HARNESS_PREFIXES = (
+    "scripts/",
+    "policies/_helpers/",
+    "tests/",
+    "templates/",
+)
+
+PLAN_CACHE_PREFIX = "inputs/plan_cache/"
+
+SERVICE_PREFIX = "Service/"
+
+# Where to send a contributor for each rule.
+REMEDIES = {
+    "out-of-scope-file": (
+        "Restore it with `git checkout origin/{base} -- '{path}'`, then commit again. "
+        "If it is a file you created by accident (an editor scratch file, a downloaded "
+        "binary, a screenshot), delete it from the branch instead. Only touch "
+        "{scope_hint}."),
+    "deleted-file": (
+        "Restore it with `git checkout origin/{base} -- '{path}'`. If you meant to "
+        "rename something you added earlier on this branch, add the new name and leave "
+        "the old file's deletion out of the PR — ask a senior team member if a real "
+        "deletion is genuinely needed."),
+    "shared-harness-edit": (
+        "Restore it with `git checkout origin/{base} -- '{path}'`. If the harness or a "
+        "template really does need changing, raise it with a senior team member so it "
+        "can go in on its own feature/ branch — editing it here does not change what "
+        "you are checked against, and it stops the portal scanning your branch."),
+    "plan-cache-modified": (
+        "Restore the cache with `git checkout origin/{base} -- inputs/plan_cache` and "
+        "commit that. This usually means a local test run cleared the cache; re-run "
+        "your tests afterwards and commit only the new entries it adds for your own "
+        "fixtures."),
+}
+
+
+@dataclass(frozen=True)
+class Finding:
+    path: str
+    status: str          # git diff status letter: A, M, D, R, T
+    rule: str
+    message: str
+    severity: str = "error"
+
+
+class ScopeError(Exception):
+    """A usage or environment error — exit 2, not a finding about the branch."""
+
+
+# --------------------------------------------------------------------------- #
+# git plumbing
+# --------------------------------------------------------------------------- #
+def _git(*args):
+    """Run a git command, returning stdout as bytes. Raises ScopeError on failure."""
+    proc = subprocess.run(["git", *args], capture_output=True)
+    if proc.returncode != 0:
+        detail = (proc.stderr or b"").decode("utf-8", "replace").strip().splitlines()
+        raise ScopeError(f"`git {' '.join(args)}` failed: "
+                         f"{detail[0] if detail else 'no output'}")
+    return proc.stdout
+
+
+def current_branch():
+    """The current branch name, or None (not a repo / detached HEAD, as in CI —
+    pass --branch explicitly there)."""
+    proc = subprocess.run(["git", "rev-parse", "--abbrev-ref", "HEAD"],
+                          capture_output=True, text=True)
+    if proc.returncode != 0:
+        return None
+    branch = proc.stdout.strip()
+    return None if not branch or branch == "HEAD" else branch
+
+
+def _parse_name_status(raw):
+    """``[(status, path), ...]`` from ``git diff -z --name-status`` output.
+
+    A rename arrives as one record with two paths; it is reported as a deletion
+    of the old path plus an addition of the new one, which is what it is.
+    """
+    fields = [f.decode("utf-8", "surrogateescape") for f in raw.split(b"\0") if f != b""]
+    entries, i = [], 0
+    while i < len(fields):
+        status = fields[i]
+        letter = status[0]
+        if letter in ("R", "C"):          # R<score>\0<old>\0<new>
+            if i + 2 >= len(fields):
+                break
+            entries.append(("D", fields[i + 1]))
+            entries.append(("A", fields[i + 2]))
+            i += 3
+        else:                             # <status>\0<path>
+            if i + 1 >= len(fields):
+                break
+            entries.append((letter, fields[i + 1]))
+            i += 2
+    return entries
+
+
+def staged_entries():
+    """What this commit is about to contain: staged + unstaged changes.
+
+    The pre-commit hook runs *before* the commit exists, so a base-ref diff would
+    not yet see what is being committed. This mirrors ``run_precommit_linter.py``'s
+    changed-set for the same reason — it is how a stray ``git add .`` is caught
+    before it ever becomes a push.
+    """
+    seen, entries = set(), []
+    for args in (("diff", "-z", "--name-status", "--cached"),
+                 ("diff", "-z", "--name-status")):
+        for status, path in _parse_name_status(_git(*args)):
+            if path not in seen:
+                seen.add(path)
+                entries.append((status, path))
+    return entries
+
+
+def changed_entries(base, head="HEAD"):
+    """``[(status, path), ...]`` for what *this branch* changed against ``base``.
+
+    Uses the merge-base (the three-dot ``base...head`` diff) so that merging
+    ``dev`` into the branch never registers as the contributor's own edits — a
+    branch that is simply behind and merged up must not start failing.
+
+    ``-z`` is used rather than plain ``--name-status``: it turns off git's
+    C-style path quoting, and every service folder in this repo has a space in
+    it (``inputs/gcp/Cloud Storage/...``).
+    """
+    merge_base = subprocess.run(["git", "merge-base", head, base],
+                                capture_output=True, text=True)
+    if merge_base.returncode == 0 and merge_base.stdout.strip():
+        ref = merge_base.stdout.strip()
+    else:
+        # Shallow clone or an unrelated history: fall back to the ref itself so
+        # the check still runs (it can only over-report, never under-report).
+        ref = base
+
+    return _parse_name_status(_git("diff", "-z", "--name-status", ref, head))
+
+
+# --------------------------------------------------------------------------- #
+# Scope
+# --------------------------------------------------------------------------- #
+def parse_branch(branch):
+    """``(platform, slug, resource_type)`` for a Service/ branch, else None."""
+    if not branch or not branch.startswith(SERVICE_PREFIX):
+        return None
+    parts = branch.split("/")
+    if len(parts) != 4 or not all(parts):
+        return None
+    return parts[1], parts[2], parts[3]
+
+
+def _segments_match(actual, expected):
+    """Case-insensitive segment comparison.
+
+    The branch slug is lower-case while the folder on disk is capitalised, and a
+    contributor who miscapitalises a directory should get the structural
+    linter's precise "does not match any docs/gcp service" error, not a
+    misleading out-of-scope one from here.
+    """
+    return actual.casefold() == expected.casefold()
+
+
+def resolve_scope(platform, slug, docs_root="docs"):
+    """The docs folder name this branch owns.
+
+    Raises ScopeError when the slug does not name a real ``docs/<platform>/``
+    folder — that is a branch-name error, which ``check_branch_name.py`` reports
+    properly, so this exits 2 rather than blaming the contributor's files.
+    """
+    folder = slug_to_folder(docs_root, platform).get(slug)
+    if folder is None:
+        raise ScopeError(
+            f"service slug '{slug}' does not name any docs/{platform} service folder, "
+            f"so the branch's scope cannot be determined. Run "
+            f"`python3 scripts/linters/check_branch_name.py` for the naming rules.")
+    return folder
+
+
+def path_in_scope(path, platform, folder, resource_type):
+    """Is ``path`` part of this branch's own resource kit?"""
+    parts = path.split("/")
+    if len(parts) < 4:
+        return False
+    tree, got_platform, got_folder = parts[0], parts[1], parts[2]
+    if tree not in ("docs", "inputs", "policies"):
+        return False
+    if not _segments_match(got_platform, platform):
+        return False
+    if not _segments_match(got_folder, folder):
+        return False
+
+    if tree == "docs":
+        # docs/<platform>/<folder>/<resource_type>.json — exactly one file.
+        return len(parts) == 4 and _segments_match(parts[3], f"{resource_type}.json")
+
+    # inputs|policies/<platform>/<folder>/<resource_type>/** — anything below.
+    return len(parts) >= 5 and _segments_match(parts[3], resource_type)
+
+
+def classify(status, path, platform, folder, resource_type):
+    """The single rule ``path`` breaks, or None if it is allowed.
+
+    Order is most-specific-location first so a contributor gets the one message
+    that tells them what to do: a wiped plan cache is a plan-cache problem, not a
+    thousand separate deletions.
+    """
+    if path.startswith(PLAN_CACHE_PREFIX):
+        return None if status == "A" else "plan-cache-modified"
+    if status == "D":
+        return "deleted-file"
+    if path.startswith(SHARED_HARNESS_PREFIXES):
+        return "shared-harness-edit"
+    if path_in_scope(path, platform, folder, resource_type):
+        return None
+    return "out-of-scope-file"
+
+
+def check(entries, platform, folder, resource_type, base="dev"):
+    """``[Finding, ...]`` for a branch's changed entries, sorted by rule then path."""
+    scope_hint = (f"docs/{platform}/{folder}/{resource_type}.json, "
+                  f"inputs/{platform}/{folder}/{resource_type}/ and "
+                  f"policies/{platform}/{folder}/{resource_type}/")
+    findings = []
+    for status, path in entries:
+        rule = classify(status, path, platform, folder, resource_type)
+        if rule is None:
+            continue
+        remedy = REMEDIES[rule].format(base=base, path=path, scope_hint=scope_hint)
+        findings.append(Finding(path=path, status=status, rule=rule, message=remedy))
+    findings.sort(key=lambda f: (f.rule, f.path))
+    return findings
+
+
+# --------------------------------------------------------------------------- #
+# CLI
+# --------------------------------------------------------------------------- #
+def _print_rules():
+    width = max(len(r) for r in RULES)
+    for rule_id, description in RULES.items():
+        print(f"{rule_id.ljust(width)}  {description}")
+
+
+def _report(findings, max_per_rule):
+    """Human-readable report. Findings are grouped by rule so the explanation is
+    printed once and a wiped plan cache does not scroll the real message away."""
+    by_rule = {}
+    for finding in findings:
+        by_rule.setdefault(finding.rule, []).append(finding)
+
+    for rule_id, group in by_rule.items():
+        print(f"\n[error] {rule_id} — {RULES[rule_id]}")
+        shown = group if max_per_rule <= 0 else group[:max_per_rule]
+        for finding in shown:
+            print(f"  {rule_id} {finding.path}")
+        hidden = len(group) - len(shown)
+        if hidden:
+            print(f"  ... and {hidden} more file(s) with the same problem")
+        print(f"  -> {group[0].message}")
+
+    total = len(findings)
+    print(f"\n{total} violation(s) in {len(by_rule)} rule(s).")
+    print("Your branch may only change the files for its own resource type. "
+          "See Guide/Policy_writing_tutorial/branch-scope.md")
+
+
+def main(argv=None):
+    parser = argparse.ArgumentParser(
+        description="Check that a Service/ branch changes only its own resource's files.",
+        formatter_class=argparse.RawDescriptionHelpFormatter)
+    parser.add_argument("--base", default="origin/dev",
+                        help="base ref to diff against (default: origin/dev). The "
+                             "merge-base is used, so merging dev in is never counted "
+                             "as your own change.")
+    parser.add_argument("--branch", default=None,
+                        help="branch whose name defines the scope (default: the current "
+                             "git branch). CI checks out a detached HEAD, so pass it "
+                             "explicitly there.")
+    parser.add_argument("--head", default="HEAD",
+                        help="ref holding the changes to check (default: HEAD). Pass a "
+                             "remote ref to review someone else's branch without "
+                             "checking it out.")
+    parser.add_argument("--staged", action="store_true",
+                        help="check what this commit is about to contain (staged + "
+                             "unstaged changes) instead of the branch's diff against "
+                             "--base. Used by the pre-commit hook, which runs before "
+                             "the commit exists.")
+    parser.add_argument("--docs", default="docs", help="docs root (default: docs).")
+    parser.add_argument("--json", action="store_true", dest="as_json",
+                        help="print the findings as a JSON array")
+    parser.add_argument("--max-per-rule", type=int, default=10,
+                        help="how many paths to list per rule before summarising "
+                             "(default: 10; 0 for all)")
+    parser.add_argument("--list-rules", action="store_true",
+                        help="print every rule id and its description, then exit")
+    args = parser.parse_args(argv)
+
+    if args.list_rules:
+        _print_rules()
+        return 0
+
+    branch = args.branch if args.branch is not None else current_branch()
+    if branch is None:
+        print("[ERROR] could not determine the current git branch (not a repo, or "
+              "detached HEAD). Pass --branch <name> explicitly.", file=sys.stderr)
+        return 2
+
+    parsed = parse_branch(branch)
+    if parsed is None:
+        # feature/ branches and dev are out of this check's remit entirely.
+        if not args.as_json:
+            print(f"[*] '{branch}' is not a Service/<platform>/<service>/<resource> "
+                  f"branch — nothing to scope-check.")
+        else:
+            print("[]")
+        return 0
+
+    platform, slug, resource_type = parsed
+    try:
+        folder = resolve_scope(platform, slug, args.docs)
+        entries = (staged_entries() if args.staged
+                   else changed_entries(args.base, args.head))
+    except ScopeError as exc:
+        print(f"[ERROR] branch_scope could not run: {exc}", file=sys.stderr)
+        return 2
+
+    base_label = args.base.split("/")[-1] if "/" in args.base else args.base
+    findings = check(entries, platform, folder, resource_type, base=base_label)
+
+    if args.as_json:
+        print(json.dumps([asdict(f) for f in findings], indent=2))
+    elif findings:
+        print(f"[FAIL] {branch} changes files outside its own resource type.")
+        print(f"       This branch owns: docs/{platform}/{folder}/{resource_type}.json, "
+              f"inputs/{platform}/{folder}/{resource_type}/, "
+              f"policies/{platform}/{folder}/{resource_type}/")
+        _report(findings, args.max_per_rule)
+    else:
+        print(f"[OK] {branch} changes only its own resource "
+              f"({platform}/{folder}/{resource_type}); "
+              f"{len(entries)} changed file(s) checked "
+              f"({'staged + unstaged' if args.staged else 'against ' + args.base}).")
+
+    return 1 if findings else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/linters/readme-linters.md
+++ b/scripts/linters/readme-linters.md
@@ -5,13 +5,19 @@ cross-consistency across three trees — `docs/`, `inputs/`, `policies/` —
 treating `docs/` as the source of truth that `inputs/` and `policies/` must
 reconcile to. It uses only the Python standard library (no extra installs).
 
-There are three supporting scripts:
+There are four supporting scripts:
 
 - `run_precommit_linter.py` — runs the linter but fails only on **your** changed
   files (so you are never blocked by the repo-wide backlog). It also runs
   `policy_lint.py` (below) over every resource type your changed files belong
   to, on the same "own only what you changed" basis.
 - `check_branch_name.py` — enforces the branch naming convention.
+- `branch_scope.py` — enforces that a `Service/<platform>/<service_slug>/<resource_type>`
+  branch changes **only** that resource's files (`docs/` JSON, `inputs/`,
+  `policies/`), plus additions to `inputs/plan_cache/`. It catches the two
+  silent mistakes — editing the shared harness and wiping the plan cache —
+  neither of which fails any test on the branch that caused it. Rules are
+  documented in `Guide/Policy_writing_tutorial/branch-scope.md`.
 - `policy_lint.py` — deterministic *content*-quality rules over a policy kit's
   declared `conditions`/`variables` (hard-coded literals, trivial messages,
   fixture drift, ...). It answers whether the policy is any good, not just
@@ -90,7 +96,18 @@ to, and fails on an error-severity finding only when the specific `.rego` file
 python scripts/linters/run_precommit_linter.py            # staged + unstaged (pre-commit)
 python scripts/linters/run_precommit_linter.py --base origin/dev   # everything vs dev (CI)
 python scripts/linters/run_precommit_linter.py --all      # whole tree, fail on any error
+
+python scripts/linters/branch_scope.py --staged           # what you are about to commit
+python scripts/linters/branch_scope.py --base origin/dev  # the whole branch vs dev (CI)
 ```
+
+**CI (`.github/workflows/branch-scope.yml`):** a `branch_scope` job runs
+`branch_scope.py --branch <head ref> --base origin/<base>` on every pull request
+from a `Service/` branch. It is a **separate workflow with no `paths:` filter**
+on purpose: `policy_check_PR.yaml` only runs when `docs/`, `inputs/` or
+`policies/` changed, so a branch whose only change is to `scripts/` or to a
+stray committed binary would never trigger it — and those are exactly the
+changes the scope check exists to catch.
 
 **CI (`.github/workflows/policy_check_PR.yaml`):** a `lint` job runs
 (1) `linter.py --tree all --no-content-checks` as a hard whole-tree structural


### PR DESCRIPTION
A `Service/<platform>/<service>/<resource_type>` branch may only change the files belonging to **that one resource type**, plus additions to `inputs/plan_cache`. Everything else fails, and deletions are never allowed — not even inside your own folder.

Branches that are not `Service/*` are unaffected: the job is skipped entirely.

## Why

Nothing currently stops one branch editing another contributor's resource type, deleting shared fixtures, or changing the shared harness (`scripts/`, `policies/_helpers/`) — and editing the harness silently blocks that contributor's own progress, because the scan overlays `dev`'s copy and refuses to run when the branch has diverged.

Swept across **all 229 live `Service/*` branches**: **206 pass, 23 fail, no false positives** (every failure inspected by hand). What the 23 are actually doing:

- two branches deleted **~1,015 `inputs/plan_cache` files** each — the shared plan cache
- one added **545 files** of a vendored `tools/pde-gate` tree
- one built an entirely different resource type and edited `.github/workflows/policy_check_PR.yaml`
- one deleted **8 of its own files** — two complete arguments of finished work
- **eight branches edited another contributor's docs JSON**, two of them swapping directly (`google_compute_snapshot` editing `..._region_commitment.json` while that branch edited `..._snapshot.json`); the rest are near-name confusions like `target_https_proxy` editing `target_http_proxy.json`
- stray committed junk: `opa.exe`, `r.png`, `commits.txt`, `templates/gcp/policy.rego`

## How it decides

The diff is **three-dot** from the merge-base with the base branch, so merging `dev` in to catch up never registers as your change. This is the whole check, not a detail: measured two-dot, **all 229 branches "fail"**, blaming 206 honest ones for up to 96 files each.

Service-folder names are resolved with the repo's existing `slug_to_folder()` — `docs/gcp` has 159 folders with spaces and brackets (`Access Context Manager (VPC Service Controls)` → `access_context_manager_vpc_service_controls`), so a naive lowercase mapping would fail nearly every honest PR.

## What's here

- `scripts/linters/branch_scope.py` — runnable locally, `--list-rules`, `--json`, `--head` to check a branch without checking it out. Findings are grouped per rule with one remedy line, so a wiped plan cache reads as one problem with one fix rather than 1,013 lines. Same exit-code semantics as `policy_lint.py`.
- `.github/workflows/branch-scope.yml` — its own workflow with no `paths:` filter, because a branch whose only change is to `scripts/` would never trigger `policy_check_PR.yaml`, and that is precisely the silent case this catches.
- `Guide/Policy_writing_tutorial/branch-scope.md` — the rules, per-rule anchors, in the same voice as the policy-lint page.
- `scripts/linters/_tests/test_branch_scope.py` — 33 tests; full linter suite 173 passing.
- A `--staged` pre-commit hook, and a fix to `raising-pull-request.md`, which currently instructs `git add .` — the direct cause of most findings above.

## Note for reviewers

The 23 branches above will get a red check on their next push. That is intended: the rule is only meaningful if it fails.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015uFmZRNFNqoTccW58Kbs4b
