### PR TITLE
Clean up the mechanical lint backlog on dev (501 files)

### DIFF
--- a/policies/gcp/API Hub/google_apihub_api_hub_instance/config.cmek_key_name.rego
+++ b/policies/gcp/API Hub/google_apihub_api_hub_instance/config.cmek_key_name.rego
@@ -20,4 +20,4 @@ summary := helpers.get_multi_summary(conditions, vars.variables)
 message := summary.message
 
 
-details := helpers.get_multi_summary(conditions, vars.variables).details
+details := summary.details

--- a/policies/gcp/API Hub/google_apihub_api_hub_instance/config.disable_search.rego
+++ b/policies/gcp/API Hub/google_apihub_api_hub_instance/config.disable_search.rego
@@ -15,6 +15,8 @@ conditions := [
     }
     ]
 ]
-message := helpers.get_multi_summary(conditions, vars.variables).message
+result := helpers.get_multi_summary(conditions, vars.variables)
 
-details := helpers.get_multi_summary(conditions, vars.variables).details
+message := result.message
+
+details := result.details

--- a/policies/gcp/API Hub/google_apihub_api_hub_instance/config.encryption_type.rego
+++ b/policies/gcp/API Hub/google_apihub_api_hub_instance/config.encryption_type.rego
@@ -18,4 +18,4 @@ conditions := [
 
 summary := helpers.get_multi_summary(conditions, vars.variables)
 message := summary.message
-details := helpers.get_multi_summary(conditions, vars.variables).details
+details := summary.details

--- a/policies/gcp/API Hub/google_apihub_api_hub_instance/location.rego
+++ b/policies/gcp/API Hub/google_apihub_api_hub_instance/location.rego
@@ -18,4 +18,4 @@ conditions := [
 
 summary := helpers.get_multi_summary(conditions, vars.variables)
 message := summary.message
-details := helpers.get_multi_summary(conditions, vars.variables).details
+details := summary.details

--- a/policies/gcp/API Hub/google_apihub_curation/endpoint.application_integration_endpoint_details.trigger_id.rego
+++ b/policies/gcp/API Hub/google_apihub_curation/endpoint.application_integration_endpoint_details.trigger_id.rego
@@ -38,4 +38,4 @@ conditions := [
 
 summary := helpers.get_multi_summary(conditions, vars.variables)
 message := summary.message
-details := helpers.get_multi_summary(conditions, vars.variables).details
+details := summary.details

--- a/policies/gcp/API Hub/google_apihub_curation/endpoint.application_integration_endpoint_details.uri.rego
+++ b/policies/gcp/API Hub/google_apihub_curation/endpoint.application_integration_endpoint_details.uri.rego
@@ -20,4 +20,4 @@ summary := helpers.get_multi_summary(conditions, vars.variables)
 message := summary.message
 
 
-details := helpers.get_multi_summary(conditions, vars.variables).details
+details := summary.details

--- a/policies/gcp/API Hub/google_apihub_plugin/config_template.auth_config_template.service_account.service_account.rego
+++ b/policies/gcp/API Hub/google_apihub_plugin/config_template.auth_config_template.service_account.service_account.rego
@@ -18,4 +18,4 @@ conditions := [
 
 summary := helpers.get_multi_summary(conditions, vars.variables)
 message := summary.message
-details := helpers.get_multi_summary(conditions, vars.variables).details
+details := summary.details

--- a/policies/gcp/API Hub/google_apihub_plugin/config_template.auth_config_template.supported_auth_types.rego
+++ b/policies/gcp/API Hub/google_apihub_plugin/config_template.auth_config_template.supported_auth_types.rego
@@ -18,4 +18,4 @@ conditions := [
 
 summary := helpers.get_multi_summary(conditions, vars.variables)
 message := summary.message
-details := helpers.get_multi_summary(conditions, vars.variables).details
+details := summary.details

--- a/policies/gcp/API Hub/google_apihub_plugin_instance/auth_config.auth_type.rego
+++ b/policies/gcp/API Hub/google_apihub_plugin_instance/auth_config.auth_type.rego
@@ -18,4 +18,4 @@ conditions := [
 
 summary := helpers.get_multi_summary(conditions, vars.variables)
 message := summary.message
-details := helpers.get_multi_summary(conditions, vars.variables).details
+details := summary.details

--- a/policies/gcp/API Hub/google_apihub_plugin_instance/disable.rego
+++ b/policies/gcp/API Hub/google_apihub_plugin_instance/disable.rego
@@ -18,4 +18,4 @@ conditions := [
 
 summary := helpers.get_multi_summary(conditions, vars.variables)
 message := summary.message
-details := helpers.get_multi_summary(conditions, vars.variables).details
+details := summary.details

--- a/policies/gcp/Access Approval/google_folder_access_approval_settings/enrolled_services.cloud_product.rego
+++ b/policies/gcp/Access Approval/google_folder_access_approval_settings/enrolled_services.cloud_product.rego
@@ -16,5 +16,7 @@ conditions := [[
 	},
 ]]
 
-message := helpers.get_multi_summary(conditions, vars.variables).message
-details := helpers.get_multi_summary(conditions, vars.variables).details
+result := helpers.get_multi_summary(conditions, vars.variables)
+
+message := result.message
+details := result.details

--- a/policies/gcp/Access Approval/google_folder_access_approval_settings/enrolled_services.enrollment_level.rego
+++ b/policies/gcp/Access Approval/google_folder_access_approval_settings/enrolled_services.enrollment_level.rego
@@ -16,5 +16,7 @@ conditions := [[
 	},
 ]]
 
-message := helpers.get_multi_summary(conditions, vars.variables).message
-details := helpers.get_multi_summary(conditions, vars.variables).details
+result := helpers.get_multi_summary(conditions, vars.variables)
+
+message := result.message
+details := result.details

--- a/policies/gcp/Access Approval/google_organization_access_approval_settings/enrolled_services.cloud_product.rego
+++ b/policies/gcp/Access Approval/google_organization_access_approval_settings/enrolled_services.cloud_product.rego
@@ -16,5 +16,7 @@ conditions := [[
 	},
 ]]
 
-message := helpers.get_multi_summary(conditions, vars.variables).message
-details := helpers.get_multi_summary(conditions, vars.variables).details
+result := helpers.get_multi_summary(conditions, vars.variables)
+
+message := result.message
+details := result.details

--- a/policies/gcp/Access Approval/google_project_access_approval_settings/enrolled_services.cloud_product.rego
+++ b/policies/gcp/Access Approval/google_project_access_approval_settings/enrolled_services.cloud_product.rego
@@ -16,5 +16,7 @@ conditions := [[
 	},
 ]]
 
-message := helpers.get_multi_summary(conditions, vars.variables).message
-details := helpers.get_multi_summary(conditions, vars.variables).details
+result := helpers.get_multi_summary(conditions, vars.variables)
+
+message := result.message
+details := result.details

--- a/policies/gcp/AlloyDB/google_alloydb_backup/encryption_config.kms_key_name.rego
+++ b/policies/gcp/AlloyDB/google_alloydb_backup/encryption_config.kms_key_name.rego
@@ -19,5 +19,7 @@ conditions := [[
   },
 ]]
 
-message := helpers.get_multi_summary(conditions, vars.variables).message
-details := helpers.get_multi_summary(conditions, vars.variables).details
+result := helpers.get_multi_summary(conditions, vars.variables)
+
+message := result.message
+details := result.details

--- a/policies/gcp/AlloyDB/google_alloydb_cluster/automated_backup_policy.time_based_retention.retention_period.rego
+++ b/policies/gcp/AlloyDB/google_alloydb_cluster/automated_backup_policy.time_based_retention.retention_period.rego
@@ -18,5 +18,7 @@ conditions := [
   ],
 ]
 
-message := helpers.get_multi_summary(conditions, vars.variables).message
-details := helpers.get_multi_summary(conditions, vars.variables).details
+result := helpers.get_multi_summary(conditions, vars.variables)
+
+message := result.message
+details := result.details

--- a/policies/gcp/AlloyDB/google_alloydb_cluster/continuous_backup_config.enabled.rego
+++ b/policies/gcp/AlloyDB/google_alloydb_cluster/continuous_backup_config.enabled.rego
@@ -16,5 +16,7 @@ conditions := [[
   },
 ]]
 
-message := helpers.get_multi_summary(conditions, vars.variables).message
-details := helpers.get_multi_summary(conditions, vars.variables).details
+result := helpers.get_multi_summary(conditions, vars.variables)
+
+message := result.message
+details := result.details

--- a/policies/gcp/AlloyDB/google_alloydb_cluster/deletion_policy.rego
+++ b/policies/gcp/AlloyDB/google_alloydb_cluster/deletion_policy.rego
@@ -16,5 +16,7 @@ conditions := [[
   },
 ]]
 
-message := helpers.get_multi_summary(conditions, vars.variables).message
-details := helpers.get_multi_summary(conditions, vars.variables).details
+result := helpers.get_multi_summary(conditions, vars.variables)
+
+message := result.message
+details := result.details

--- a/policies/gcp/AlloyDB/google_alloydb_instance/client_connection_config.ssl_config.ssl_mode.rego
+++ b/policies/gcp/AlloyDB/google_alloydb_instance/client_connection_config.ssl_config.ssl_mode.rego
@@ -16,6 +16,8 @@ conditions := [[
 	},
 ]]
 
-message := helpers.get_multi_summary(conditions, vars.variables).message
+result := helpers.get_multi_summary(conditions, vars.variables)
 
-details := helpers.get_multi_summary(conditions, vars.variables).details
+message := result.message
+
+details := result.details

--- a/policies/gcp/AlloyDB/google_alloydb_user/user_id.rego
+++ b/policies/gcp/AlloyDB/google_alloydb_user/user_id.rego
@@ -21,5 +21,7 @@ conditions := [
   ],
 ]
 
-message := helpers.get_multi_summary(conditions, vars.variables).message
-details := helpers.get_multi_summary(conditions, vars.variables).details
+result := helpers.get_multi_summary(conditions, vars.variables)
+
+message := result.message
+details := result.details

--- a/policies/gcp/AlloyDB/google_alloydb_user/user_type.rego
+++ b/policies/gcp/AlloyDB/google_alloydb_user/user_type.rego
@@ -21,5 +21,7 @@ conditions := [
   ],
 ]
 
-message := helpers.get_multi_summary(conditions, vars.variables).message
-details := helpers.get_multi_summary(conditions, vars.variables).details
+result := helpers.get_multi_summary(conditions, vars.variables)
+
+message := result.message
+details := result.details

--- a/policies/gcp/Anthos On-Prem/google_gkeonprem_bare_metal_admin_cluster/control_plane.control_plane_node_pool_config.node_pool_config.node_configs.node_ip.rego
+++ b/policies/gcp/Anthos On-Prem/google_gkeonprem_bare_metal_admin_cluster/control_plane.control_plane_node_pool_config.node_pool_config.node_configs.node_ip.rego
@@ -16,6 +16,8 @@ import data.terraform.gcp.security.anthos_on_prem.google_gkeonprem_bare_metal_ad
     ]
 ]
 
- message := helpers.get_multi_summary(conditions, vars.variables).message
+ result := helpers.get_multi_summary(conditions, vars.variables)
 
- details := helpers.get_multi_summary(conditions, vars.variables).details
+ message := result.message
+
+ details := result.details

--- a/policies/gcp/Anthos On-Prem/google_gkeonprem_bare_metal_admin_cluster/load_balancer.port_config.control_plane_load_balancer_port.rego
+++ b/policies/gcp/Anthos On-Prem/google_gkeonprem_bare_metal_admin_cluster/load_balancer.port_config.control_plane_load_balancer_port.rego
@@ -16,6 +16,8 @@ import data.terraform.gcp.security.anthos_on_prem.google_gkeonprem_bare_metal_ad
     ]
 ]
 
- message := helpers.get_multi_summary(conditions, vars.variables).message
+ result := helpers.get_multi_summary(conditions, vars.variables)
 
- details := helpers.get_multi_summary(conditions, vars.variables).details
+ message := result.message
+
+ details := result.details

--- a/policies/gcp/Anthos On-Prem/google_gkeonprem_bare_metal_admin_cluster/location.rego
+++ b/policies/gcp/Anthos On-Prem/google_gkeonprem_bare_metal_admin_cluster/location.rego
@@ -27,6 +27,8 @@ import data.terraform.gcp.security.anthos_on_prem.google_gkeonprem_bare_metal_ad
 
  ]
 
- message := helpers.get_multi_summary(conditions, vars.variables).message
+ result := helpers.get_multi_summary(conditions, vars.variables)
 
- details := helpers.get_multi_summary(conditions, vars.variables).details
+ message := result.message
+
+ details := result.details

--- a/policies/gcp/Anthos On-Prem/google_gkeonprem_bare_metal_admin_cluster/security_config.authorization.admin_users.username.rego
+++ b/policies/gcp/Anthos On-Prem/google_gkeonprem_bare_metal_admin_cluster/security_config.authorization.admin_users.username.rego
@@ -15,6 +15,8 @@ import data.terraform.gcp.security.anthos_on_prem.google_gkeonprem_bare_metal_ad
     ]
  ]
 
- message := helpers.get_multi_summary(conditions, vars.variables).message
+ result := helpers.get_multi_summary(conditions, vars.variables)
 
- details := helpers.get_multi_summary(conditions, vars.variables).details
+ message := result.message
+
+ details := result.details

--- a/policies/gcp/Anthos On-Prem/google_gkeonprem_bare_metal_cluster/load_balancer.vip_config.control_plane_vip.rego
+++ b/policies/gcp/Anthos On-Prem/google_gkeonprem_bare_metal_cluster/load_balancer.vip_config.control_plane_vip.rego
@@ -16,6 +16,8 @@ import data.terraform.gcp.security.anthos_on_prem.google_gkeonprem_bare_metal_cl
     ]
 ]
 
- message := helpers.get_multi_summary(conditions, vars.variables).message
+ result := helpers.get_multi_summary(conditions, vars.variables)
 
- details := helpers.get_multi_summary(conditions, vars.variables).details
+ message := result.message
+
+ details := result.details

--- a/policies/gcp/Anthos On-Prem/google_gkeonprem_bare_metal_cluster/location.rego
+++ b/policies/gcp/Anthos On-Prem/google_gkeonprem_bare_metal_cluster/location.rego
@@ -53,6 +53,8 @@ import data.terraform.gcp.security.anthos_on_prem.google_gkeonprem_bare_metal_cl
 
  ]
 
- message := helpers.get_multi_summary(conditions, vars.variables).message
+ result := helpers.get_multi_summary(conditions, vars.variables)
 
- details := helpers.get_multi_summary(conditions, vars.variables).details
+ message := result.message
+
+ details := result.details

--- a/policies/gcp/Anthos On-Prem/google_gkeonprem_bare_metal_node_pool/location.rego
+++ b/policies/gcp/Anthos On-Prem/google_gkeonprem_bare_metal_node_pool/location.rego
@@ -40,6 +40,8 @@ import data.terraform.gcp.security.anthos_on_prem.google_gkeonprem_bare_metal_no
 
  ]
 
- message := helpers.get_multi_summary(conditions, vars.variables).message
+ result := helpers.get_multi_summary(conditions, vars.variables)
 
- details := helpers.get_multi_summary(conditions, vars.variables).details
+ message := result.message
+
+ details := result.details

--- a/policies/gcp/Anthos On-Prem/google_gkeonprem_vmware_admin_cluster/authorization.viewer_users.username.rego
+++ b/policies/gcp/Anthos On-Prem/google_gkeonprem_vmware_admin_cluster/authorization.viewer_users.username.rego
@@ -16,6 +16,8 @@ import data.terraform.gcp.security.anthos_on_prem.google_gkeonprem_vmware_admin_
     ]
 ]
 
- message := helpers.get_multi_summary(conditions, vars.variables).message
+ result := helpers.get_multi_summary(conditions, vars.variables)
 
- details := helpers.get_multi_summary(conditions, vars.variables).details
+ message := result.message
+
+ details := result.details

--- a/policies/gcp/Anthos On-Prem/google_gkeonprem_vmware_cluster/load_balancer.vip_config.control_plane_vip.rego
+++ b/policies/gcp/Anthos On-Prem/google_gkeonprem_vmware_cluster/load_balancer.vip_config.control_plane_vip.rego
@@ -16,6 +16,8 @@ import data.terraform.gcp.security.anthos_on_prem.google_gkeonprem_vmware_cluste
     ]
 ]
 
- message := helpers.get_multi_summary(conditions, vars.variables).message
+ result := helpers.get_multi_summary(conditions, vars.variables)
 
- details := helpers.get_multi_summary(conditions, vars.variables).details
+ message := result.message
+
+ details := result.details

--- a/policies/gcp/Anthos On-Prem/google_gkeonprem_vmware_cluster/network_config.service_address_cidr_blocks.rego
+++ b/policies/gcp/Anthos On-Prem/google_gkeonprem_vmware_cluster/network_config.service_address_cidr_blocks.rego
@@ -17,6 +17,8 @@ import data.terraform.gcp.security.anthos_on_prem.google_gkeonprem_vmware_cluste
 ]
 
 
- message := helpers.get_multi_summary(conditions, vars.variables).message
+ result := helpers.get_multi_summary(conditions, vars.variables)
 
- details := helpers.get_multi_summary(conditions, vars.variables).details
+ message := result.message
+
+ details := result.details

--- a/policies/gcp/Anthos On-Prem/google_gkeonprem_vmware_node_pool/config.image_type.rego
+++ b/policies/gcp/Anthos On-Prem/google_gkeonprem_vmware_node_pool/config.image_type.rego
@@ -17,6 +17,8 @@ import data.terraform.gcp.security.anthos_on_prem.google_gkeonprem_vmware_node_p
 
  ]
 
- message := helpers.get_multi_summary(conditions, vars.variables).message
+ result := helpers.get_multi_summary(conditions, vars.variables)
 
- details := helpers.get_multi_summary(conditions, vars.variables).details
+ message := result.message
+
+ details := result.details

--- a/policies/gcp/Anthos On-Prem/google_gkeonprem_vmware_node_pool/node_pool_autoscaling.min_replicas.rego
+++ b/policies/gcp/Anthos On-Prem/google_gkeonprem_vmware_node_pool/node_pool_autoscaling.min_replicas.rego
@@ -16,6 +16,8 @@ import data.terraform.gcp.security.anthos_on_prem.google_gkeonprem_vmware_node_p
     ]
 ]
 
- message := helpers.get_multi_summary(conditions, vars.variables).message
+ result := helpers.get_multi_summary(conditions, vars.variables)
 
- details := helpers.get_multi_summary(conditions, vars.variables).details
+ message := result.message
+
+ details := result.details

--- a/policies/gcp/Apigee/google_apigee_addons_config/addons_config.advanced_api_ops_config.enabled.rego
+++ b/policies/gcp/Apigee/google_apigee_addons_config/addons_config.advanced_api_ops_config.enabled.rego
@@ -21,5 +21,7 @@ conditions := [
     ]
 ]
 
-message := helpers.get_multi_summary(conditions, vars.variables).message
-details := helpers.get_multi_summary(conditions, vars.variables).details
+result := helpers.get_multi_summary(conditions, vars.variables)
+
+message := result.message
+details := result.details

--- a/policies/gcp/Apigee/google_apigee_addons_config/addons_config.api_security_config.enabled.rego
+++ b/policies/gcp/Apigee/google_apigee_addons_config/addons_config.api_security_config.enabled.rego
@@ -21,5 +21,7 @@ conditions := [
     ]
 ]
 
-message := helpers.get_multi_summary(conditions, vars.variables).message
-details := helpers.get_multi_summary(conditions, vars.variables).details
+result := helpers.get_multi_summary(conditions, vars.variables)
+
+message := result.message
+details := result.details

--- a/policies/gcp/Apigee/google_apigee_addons_config/addons_config.monetization_config.enabled.rego
+++ b/policies/gcp/Apigee/google_apigee_addons_config/addons_config.monetization_config.enabled.rego
@@ -21,5 +21,7 @@ conditions := [
     ]
 ]
 
-message := helpers.get_multi_summary(conditions, vars.variables).message
-details := helpers.get_multi_summary(conditions, vars.variables).details
+result := helpers.get_multi_summary(conditions, vars.variables)
+
+message := result.message
+details := result.details

--- a/policies/gcp/Apigee/google_apigee_api/config_bundle.rego
+++ b/policies/gcp/Apigee/google_apigee_api/config_bundle.rego
@@ -21,5 +21,7 @@ conditions := [
     ]
 ]
 
-message := helpers.get_multi_summary(conditions, vars.variables).message
-details := helpers.get_multi_summary(conditions, vars.variables).details
+result := helpers.get_multi_summary(conditions, vars.variables)
+
+message := result.message
+details := result.details

--- a/policies/gcp/Apigee/google_apigee_api_deployment/proxy_id.rego
+++ b/policies/gcp/Apigee/google_apigee_api_deployment/proxy_id.rego
@@ -21,5 +21,7 @@ conditions := [
     ]
 ]
 
-message := helpers.get_multi_summary(conditions, vars.variables).message
-details := helpers.get_multi_summary(conditions, vars.variables).details
+result := helpers.get_multi_summary(conditions, vars.variables)
+
+message := result.message
+details := result.details

--- a/policies/gcp/Apigee/google_apigee_api_product/api_resources.rego
+++ b/policies/gcp/Apigee/google_apigee_api_product/api_resources.rego
@@ -21,5 +21,7 @@ conditions := [
     ]
 ]
 
-message := helpers.get_multi_summary(conditions, vars.variables).message
-details := helpers.get_multi_summary(conditions, vars.variables).details
+result := helpers.get_multi_summary(conditions, vars.variables)
+
+message := result.message
+details := result.details

--- a/policies/gcp/Apigee/google_apigee_api_product/approval_type.rego
+++ b/policies/gcp/Apigee/google_apigee_api_product/approval_type.rego
@@ -21,5 +21,7 @@ conditions := [
     ]
 ]
 
-message := helpers.get_multi_summary(conditions, vars.variables).message
-details := helpers.get_multi_summary(conditions, vars.variables).details
+result := helpers.get_multi_summary(conditions, vars.variables)
+
+message := result.message
+details := result.details

--- a/policies/gcp/Apigee/google_apigee_api_product/proxies.rego
+++ b/policies/gcp/Apigee/google_apigee_api_product/proxies.rego
@@ -21,5 +21,7 @@ conditions := [
     ]
 ]
 
-message := helpers.get_multi_summary(conditions, vars.variables).message
-details := helpers.get_multi_summary(conditions, vars.variables).details
+result := helpers.get_multi_summary(conditions, vars.variables)
+
+message := result.message
+details := result.details

--- a/policies/gcp/Apigee/google_apigee_api_product/scopes.rego
+++ b/policies/gcp/Apigee/google_apigee_api_product/scopes.rego
@@ -21,5 +21,7 @@ conditions := [
     ]
 ]
 
-message := helpers.get_multi_summary(conditions, vars.variables).message
-details := helpers.get_multi_summary(conditions, vars.variables).details
+result := helpers.get_multi_summary(conditions, vars.variables)
+
+message := result.message
+details := result.details

--- a/policies/gcp/Apigee/google_apigee_developer_app/callback_url.rego
+++ b/policies/gcp/Apigee/google_apigee_developer_app/callback_url.rego
@@ -21,5 +21,7 @@ conditions := [
     ]
 ]
 
-message := helpers.get_multi_summary(conditions, vars.variables).message
-details := helpers.get_multi_summary(conditions, vars.variables).details
+result := helpers.get_multi_summary(conditions, vars.variables)
+
+message := result.message
+details := result.details

--- a/policies/gcp/Apigee/google_apigee_dns_zone/dns_zone_id.rego
+++ b/policies/gcp/Apigee/google_apigee_dns_zone/dns_zone_id.rego
@@ -21,5 +21,7 @@ conditions := [
     ]
 ]
 
-message := helpers.get_multi_summary(conditions, vars.variables).message
-details := helpers.get_multi_summary(conditions, vars.variables).details
+result := helpers.get_multi_summary(conditions, vars.variables)
+
+message := result.message
+details := result.details

--- a/policies/gcp/Apigee/google_apigee_dns_zone/domain.rego
+++ b/policies/gcp/Apigee/google_apigee_dns_zone/domain.rego
@@ -21,5 +21,7 @@ conditions := [
     ]
 ]
 
-message := helpers.get_multi_summary(conditions, vars.variables).message
-details := helpers.get_multi_summary(conditions, vars.variables).details
+result := helpers.get_multi_summary(conditions, vars.variables)
+
+message := result.message
+details := result.details

--- a/policies/gcp/Apikeys/google_apikeys_key/restrictions.api_targets.methods.rego
+++ b/policies/gcp/Apikeys/google_apikeys_key/restrictions.api_targets.methods.rego
@@ -21,5 +21,7 @@ conditions := [
     ]
 ]
 
-message := helpers.get_multi_summary(conditions, vars.variables).message
-details := helpers.get_multi_summary(conditions, vars.variables).details
+result := helpers.get_multi_summary(conditions, vars.variables)
+
+message := result.message
+details := result.details

--- a/policies/gcp/Apikeys/google_apikeys_key/restrictions.api_targets.service.rego
+++ b/policies/gcp/Apikeys/google_apikeys_key/restrictions.api_targets.service.rego
@@ -45,5 +45,7 @@ conditions := [
     ]
 ]
 
-message := helpers.get_multi_summary(conditions, vars.variables).message
-details := helpers.get_multi_summary(conditions, vars.variables).details
+result := helpers.get_multi_summary(conditions, vars.variables)
+
+message := result.message
+details := result.details

--- a/policies/gcp/Apikeys/google_apikeys_key/restrictions.browser_key_restrictions.allowed_referrers.rego
+++ b/policies/gcp/Apikeys/google_apikeys_key/restrictions.browser_key_restrictions.allowed_referrers.rego
@@ -21,5 +21,7 @@ conditions := [
     ]
 ]
 
-message := helpers.get_multi_summary(conditions, vars.variables).message
-details := helpers.get_multi_summary(conditions, vars.variables).details
+result := helpers.get_multi_summary(conditions, vars.variables)
+
+message := result.message
+details := result.details

--- a/policies/gcp/Apikeys/google_apikeys_key/restrictions.server_key_restrictions.allowed_ips.rego
+++ b/policies/gcp/Apikeys/google_apikeys_key/restrictions.server_key_restrictions.allowed_ips.rego
@@ -21,5 +21,7 @@ conditions := [
     ]
 ]
 
-message := helpers.get_multi_summary(conditions, vars.variables).message
-details := helpers.get_multi_summary(conditions, vars.variables).details
+result := helpers.get_multi_summary(conditions, vars.variables)
+
+message := result.message
+details := result.details

--- a/policies/gcp/App Engine/google_app_engine_application/database_type.rego
+++ b/policies/gcp/App Engine/google_app_engine_application/database_type.rego
@@ -18,5 +18,7 @@ conditions := [
   ]
 ]
 
-message := helpers.get_multi_summary(conditions, vars.variables).message
-details := helpers.get_multi_summary(conditions, vars.variables).details
+result := helpers.get_multi_summary(conditions, vars.variables)
+
+message := result.message
+details := result.details

--- a/policies/gcp/App Engine/google_app_engine_application/location_id.rego
+++ b/policies/gcp/App Engine/google_app_engine_application/location_id.rego
@@ -17,5 +17,7 @@ conditions := [
 ]
 
 
-message := helpers.get_multi_summary(conditions, vars.variables).message
-details := helpers.get_multi_summary(conditions, vars.variables).details
+result := helpers.get_multi_summary(conditions, vars.variables)
+
+message := result.message
+details := result.details

--- a/policies/gcp/App Engine/google_app_engine_application/project.rego
+++ b/policies/gcp/App Engine/google_app_engine_application/project.rego
@@ -18,5 +18,7 @@ conditions := [
   ]
 ]
 
-message := helpers.get_multi_summary(conditions, vars.variables).message
-details := helpers.get_multi_summary(conditions, vars.variables).details
+result := helpers.get_multi_summary(conditions, vars.variables)
+
+message := result.message
+details := result.details

--- a/policies/gcp/App Engine/google_app_engine_application/serving_status.rego
+++ b/policies/gcp/App Engine/google_app_engine_application/serving_status.rego
@@ -18,5 +18,7 @@ conditions := [
   ]
 ]
 
-message := helpers.get_multi_summary(conditions, vars.variables).message
-details := helpers.get_multi_summary(conditions, vars.variables).details
+result := helpers.get_multi_summary(conditions, vars.variables)
+
+message := result.message
+details := result.details

--- a/policies/gcp/App Engine/google_app_engine_application/ssl_policy.rego
+++ b/policies/gcp/App Engine/google_app_engine_application/ssl_policy.rego
@@ -18,5 +18,7 @@ conditions := [
   ]
 ]
 
-message := helpers.get_multi_summary(conditions, vars.variables).message
-details := helpers.get_multi_summary(conditions, vars.variables).details
+result := helpers.get_multi_summary(conditions, vars.variables)
+
+message := result.message
+details := result.details

--- a/policies/gcp/App Engine/google_app_engine_domain_mapping/domain_name.rego
+++ b/policies/gcp/App Engine/google_app_engine_domain_mapping/domain_name.rego
@@ -18,5 +18,7 @@ conditions := [
   ]
 ]
 
-message := helpers.get_multi_summary(conditions, vars.variables).message
-details := helpers.get_multi_summary(conditions, vars.variables).details
+result := helpers.get_multi_summary(conditions, vars.variables)
+
+message := result.message
+details := result.details

--- a/policies/gcp/App Engine/google_app_engine_domain_mapping/override_strategy.rego
+++ b/policies/gcp/App Engine/google_app_engine_domain_mapping/override_strategy.rego
@@ -18,5 +18,7 @@ conditions := [
   ]
 ]
 
-message := helpers.get_multi_summary(conditions, vars.variables).message
-details := helpers.get_multi_summary(conditions, vars.variables).details
+result := helpers.get_multi_summary(conditions, vars.variables)
+
+message := result.message
+details := result.details

--- a/policies/gcp/App Engine/google_app_engine_firewall_rule/action.rego
+++ b/policies/gcp/App Engine/google_app_engine_firewall_rule/action.rego
@@ -18,5 +18,7 @@ conditions := [
   ]
 ]
 
-message := helpers.get_multi_summary(conditions, vars.variables).message
-details := helpers.get_multi_summary(conditions, vars.variables).details
+result := helpers.get_multi_summary(conditions, vars.variables)
+
+message := result.message
+details := result.details

--- a/policies/gcp/App Engine/google_app_engine_firewall_rule/priority.rego
+++ b/policies/gcp/App Engine/google_app_engine_firewall_rule/priority.rego
@@ -18,5 +18,7 @@ conditions := [
   ]
 ]
 
-message := helpers.get_multi_summary(conditions, vars.variables).message
-details := helpers.get_multi_summary(conditions, vars.variables).details
+result := helpers.get_multi_summary(conditions, vars.variables)
+
+message := result.message
+details := result.details

--- a/policies/gcp/App Engine/google_app_engine_firewall_rule/source_range.rego
+++ b/policies/gcp/App Engine/google_app_engine_firewall_rule/source_range.rego
@@ -18,5 +18,7 @@ conditions := [
   ]
 ]
 
-message := helpers.get_multi_summary(conditions, vars.variables).message
-details := helpers.get_multi_summary(conditions, vars.variables).details
+result := helpers.get_multi_summary(conditions, vars.variables)
+
+message := result.message
+details := result.details

--- a/policies/gcp/App Engine/google_app_engine_flexible_app_version/runtime.rego
+++ b/policies/gcp/App Engine/google_app_engine_flexible_app_version/runtime.rego
@@ -18,5 +18,7 @@ conditions := [
     ]
 ]
 
-message := helpers.get_multi_summary(conditions, vars.variables).message
-details := helpers.get_multi_summary(conditions, vars.variables).details
+result := helpers.get_multi_summary(conditions, vars.variables)
+
+message := result.message
+details := result.details

--- a/policies/gcp/App Engine/google_app_engine_flexible_app_version/service.rego
+++ b/policies/gcp/App Engine/google_app_engine_flexible_app_version/service.rego
@@ -18,5 +18,7 @@ conditions := [
     ]
 ]
 
-message := helpers.get_multi_summary(conditions, vars.variables).message
-details := helpers.get_multi_summary(conditions, vars.variables).details
+result := helpers.get_multi_summary(conditions, vars.variables)
+
+message := result.message
+details := result.details

--- a/policies/gcp/App Engine/google_app_engine_service_network_settings/service.rego
+++ b/policies/gcp/App Engine/google_app_engine_service_network_settings/service.rego
@@ -18,5 +18,7 @@ conditions := [
     ]
 ]
 
-message := helpers.get_multi_summary(conditions, vars.variables).message
-details := helpers.get_multi_summary(conditions, vars.variables).details
+result := helpers.get_multi_summary(conditions, vars.variables)
+
+message := result.message
+details := result.details

--- a/policies/gcp/App Engine/google_app_engine_service_split_traffic/migrate_traffic.rego
+++ b/policies/gcp/App Engine/google_app_engine_service_split_traffic/migrate_traffic.rego
@@ -18,5 +18,7 @@ conditions := [
     ]
 ]
 
-message := helpers.get_multi_summary(conditions, vars.variables).message
-details := helpers.get_multi_summary(conditions, vars.variables).details
+result := helpers.get_multi_summary(conditions, vars.variables)
+
+message := result.message
+details := result.details

--- a/policies/gcp/App Engine/google_app_engine_service_split_traffic/service.rego
+++ b/policies/gcp/App Engine/google_app_engine_service_split_traffic/service.rego
@@ -18,5 +18,7 @@ conditions := [
     ]
 ]
 
-message := helpers.get_multi_summary(conditions, vars.variables).message
-details := helpers.get_multi_summary(conditions, vars.variables).details
+result := helpers.get_multi_summary(conditions, vars.variables)
+
+message := result.message
+details := result.details

--- a/policies/gcp/App Engine/google_app_engine_standard_app_version/instance_class.rego
+++ b/policies/gcp/App Engine/google_app_engine_standard_app_version/instance_class.rego
@@ -32,5 +32,7 @@ conditions := [
     ]
 ]
 
-message := helpers.get_multi_summary(conditions, vars.variables).message
-details := helpers.get_multi_summary(conditions, vars.variables).details
+result := helpers.get_multi_summary(conditions, vars.variables)
+
+message := result.message
+details := result.details

--- a/policies/gcp/App Engine/google_app_engine_standard_app_version/runtime.rego
+++ b/policies/gcp/App Engine/google_app_engine_standard_app_version/runtime.rego
@@ -18,5 +18,7 @@ conditions := [
     ]
 ]
 
-message := helpers.get_multi_summary(conditions, vars.variables).message
-details := helpers.get_multi_summary(conditions, vars.variables).details
+result := helpers.get_multi_summary(conditions, vars.variables)
+
+message := result.message
+details := result.details

--- a/policies/gcp/App Engine/google_app_engine_standard_app_version/service.rego
+++ b/policies/gcp/App Engine/google_app_engine_standard_app_version/service.rego
@@ -18,5 +18,7 @@ conditions := [
     ]
 ]
 
-message := helpers.get_multi_summary(conditions, vars.variables).message
-details := helpers.get_multi_summary(conditions, vars.variables).details
+result := helpers.get_multi_summary(conditions, vars.variables)
+
+message := result.message
+details := result.details

--- a/policies/gcp/Application Integration/google_integrations_auth_config/location.rego
+++ b/policies/gcp/Application Integration/google_integrations_auth_config/location.rego
@@ -16,6 +16,8 @@ conditions := [
     ]
 ]
 
-message := helpers.get_multi_summary(conditions, vars.variables).message
+result := helpers.get_multi_summary(conditions, vars.variables)
 
-details := helpers.get_multi_summary(conditions, vars.variables).details
+message := result.message
+
+details := result.details

--- a/policies/gcp/Application Integration/google_integrations_auth_config/visibility.rego
+++ b/policies/gcp/Application Integration/google_integrations_auth_config/visibility.rego
@@ -22,7 +22,9 @@ conditions := [
 ]
 
 # Summary message of policy compliance
-message := helpers.get_multi_summary(conditions, vars.variables).message
+result := helpers.get_multi_summary(conditions, vars.variables)
+
+message := result.message
 
 # Detailed compliance summary for debugging
-details := helpers.get_multi_summary(conditions, vars.variables).details
+details := result.details

--- a/policies/gcp/Application Integration/google_integrations_client/location.rego
+++ b/policies/gcp/Application Integration/google_integrations_client/location.rego
@@ -16,6 +16,8 @@ conditions := [
     ]
 ]
 
-message := helpers.get_multi_summary(conditions, vars.variables).message
+result := helpers.get_multi_summary(conditions, vars.variables)
 
-details := helpers.get_multi_summary(conditions, vars.variables).details
+message := result.message
+
+details := result.details

--- a/policies/gcp/Backup for GKE/google_gke_backup_backup_channel/destination_project.rego
+++ b/policies/gcp/Backup for GKE/google_gke_backup_backup_channel/destination_project.rego
@@ -17,5 +17,7 @@ conditions := [
   ]
 ]
 
-message := helpers.get_multi_summary(conditions, vars.variables).message
-details := helpers.get_multi_summary(conditions, vars.variables).details
+result := helpers.get_multi_summary(conditions, vars.variables)
+
+message := result.message
+details := result.details

--- a/policies/gcp/Backup for GKE/google_gke_backup_backup_channel/labels.rego
+++ b/policies/gcp/Backup for GKE/google_gke_backup_backup_channel/labels.rego
@@ -47,5 +47,7 @@ conditions := [
   ]
 ]
 
-message := helpers.get_multi_summary(conditions, vars.variables).message
-details := helpers.get_multi_summary(conditions, vars.variables).details
+result := helpers.get_multi_summary(conditions, vars.variables)
+
+message := result.message
+details := result.details

--- a/policies/gcp/Backup for GKE/google_gke_backup_backup_channel/location.rego
+++ b/policies/gcp/Backup for GKE/google_gke_backup_backup_channel/location.rego
@@ -29,5 +29,7 @@ conditions := [
   ]
 ]
 
-message := helpers.get_multi_summary(conditions, vars.variables).message
-details := helpers.get_multi_summary(conditions, vars.variables).details
+result := helpers.get_multi_summary(conditions, vars.variables)
+
+message := result.message
+details := result.details

--- a/policies/gcp/Backup for GKE/google_gke_backup_backup_plan/backup_config.all_namespaces.rego
+++ b/policies/gcp/Backup for GKE/google_gke_backup_backup_plan/backup_config.all_namespaces.rego
@@ -17,5 +17,7 @@ conditions := [
   ]
 ]
 
-message := helpers.get_multi_summary(conditions, vars.variables).message
-details := helpers.get_multi_summary(conditions, vars.variables).details
+result := helpers.get_multi_summary(conditions, vars.variables)
+
+message := result.message
+details := result.details

--- a/policies/gcp/Backup for GKE/google_gke_backup_backup_plan/backup_config.encryption_key.gcp_kms_encryption_key.rego
+++ b/policies/gcp/Backup for GKE/google_gke_backup_backup_plan/backup_config.encryption_key.gcp_kms_encryption_key.rego
@@ -17,5 +17,7 @@ conditions := [
   ]
 ]
 
-message := helpers.get_multi_summary(conditions, vars.variables).message
-details := helpers.get_multi_summary(conditions, vars.variables).details
+result := helpers.get_multi_summary(conditions, vars.variables)
+
+message := result.message
+details := result.details

--- a/policies/gcp/Backup for GKE/google_gke_backup_backup_plan/backup_config.include_secrets.rego
+++ b/policies/gcp/Backup for GKE/google_gke_backup_backup_plan/backup_config.include_secrets.rego
@@ -17,5 +17,7 @@ conditions := [
   ]
 ]
 
-message := helpers.get_multi_summary(conditions, vars.variables).message
-details := helpers.get_multi_summary(conditions, vars.variables).details
+result := helpers.get_multi_summary(conditions, vars.variables)
+
+message := result.message
+details := result.details

--- a/policies/gcp/Backup for GKE/google_gke_backup_backup_plan/backup_config.include_volume_data.rego
+++ b/policies/gcp/Backup for GKE/google_gke_backup_backup_plan/backup_config.include_volume_data.rego
@@ -29,5 +29,7 @@ conditions := [
   ]
 ]
 
-message := helpers.get_multi_summary(conditions, vars.variables).message
-details := helpers.get_multi_summary(conditions, vars.variables).details
+result := helpers.get_multi_summary(conditions, vars.variables)
+
+message := result.message
+details := result.details

--- a/policies/gcp/Backup for GKE/google_gke_backup_backup_plan/backup_config.permissive_mode.rego
+++ b/policies/gcp/Backup for GKE/google_gke_backup_backup_plan/backup_config.permissive_mode.rego
@@ -17,5 +17,7 @@ conditions := [
   ]
 ]
 
-message := helpers.get_multi_summary(conditions, vars.variables).message
-details := helpers.get_multi_summary(conditions, vars.variables).details
+result := helpers.get_multi_summary(conditions, vars.variables)
+
+message := result.message
+details := result.details

--- a/policies/gcp/Backup for GKE/google_gke_backup_backup_plan/backup_schedule.cron_schedule.rego
+++ b/policies/gcp/Backup for GKE/google_gke_backup_backup_plan/backup_schedule.cron_schedule.rego
@@ -17,5 +17,7 @@ conditions := [
   ]
 ]
 
-message := helpers.get_multi_summary(conditions, vars.variables).message
-details := helpers.get_multi_summary(conditions, vars.variables).details
+result := helpers.get_multi_summary(conditions, vars.variables)
+
+message := result.message
+details := result.details

--- a/policies/gcp/Backup for GKE/google_gke_backup_backup_plan/deactivated.rego
+++ b/policies/gcp/Backup for GKE/google_gke_backup_backup_plan/deactivated.rego
@@ -17,5 +17,7 @@ conditions := [
   ]
 ]
 
-message := helpers.get_multi_summary(conditions, vars.variables).message
-details := helpers.get_multi_summary(conditions, vars.variables).details
+result := helpers.get_multi_summary(conditions, vars.variables)
+
+message := result.message
+details := result.details

--- a/policies/gcp/Backup for GKE/google_gke_backup_backup_plan/labels.rego
+++ b/policies/gcp/Backup for GKE/google_gke_backup_backup_plan/labels.rego
@@ -41,6 +41,8 @@ conditions := [
   ]
 ]
 
-message := helpers.get_multi_summary(conditions, vars.variables).message
-details := helpers.get_multi_summary(conditions, vars.variables).details
+result := helpers.get_multi_summary(conditions, vars.variables)
+
+message := result.message
+details := result.details
 

--- a/policies/gcp/Backup for GKE/google_gke_backup_backup_plan/location.rego
+++ b/policies/gcp/Backup for GKE/google_gke_backup_backup_plan/location.rego
@@ -22,5 +22,7 @@ conditions := [
     ]
 ]
 
-message := helpers.get_multi_summary(conditions, vars.variables).message
-details := helpers.get_multi_summary(conditions, vars.variables).details
+result := helpers.get_multi_summary(conditions, vars.variables)
+
+message := result.message
+details := result.details

--- a/policies/gcp/Backup for GKE/google_gke_backup_backup_plan/retention_policy.backup_delete_lock_days.rego
+++ b/policies/gcp/Backup for GKE/google_gke_backup_backup_plan/retention_policy.backup_delete_lock_days.rego
@@ -17,5 +17,7 @@ conditions := [
   ]
 ]
 
-message := helpers.get_multi_summary(conditions, vars.variables).message
-details := helpers.get_multi_summary(conditions, vars.variables).details
+result := helpers.get_multi_summary(conditions, vars.variables)
+
+message := result.message
+details := result.details

--- a/policies/gcp/Backup for GKE/google_gke_backup_backup_plan/retention_policy.backup_retain_days.rego
+++ b/policies/gcp/Backup for GKE/google_gke_backup_backup_plan/retention_policy.backup_retain_days.rego
@@ -17,5 +17,7 @@ conditions := [
   ]
 ]
 
-message := helpers.get_multi_summary(conditions, vars.variables).message
-details := helpers.get_multi_summary(conditions, vars.variables).details
+result := helpers.get_multi_summary(conditions, vars.variables)
+
+message := result.message
+details := result.details

--- a/policies/gcp/Backup for GKE/google_gke_backup_restore_channel/destination_project.rego
+++ b/policies/gcp/Backup for GKE/google_gke_backup_restore_channel/destination_project.rego
@@ -17,5 +17,7 @@ conditions := [
   ]
 ]
 
-message := helpers.get_multi_summary(conditions, vars.variables).message
-details := helpers.get_multi_summary(conditions, vars.variables).details
+result := helpers.get_multi_summary(conditions, vars.variables)
+
+message := result.message
+details := result.details

--- a/policies/gcp/Backup for GKE/google_gke_backup_restore_channel/labels.rego
+++ b/policies/gcp/Backup for GKE/google_gke_backup_restore_channel/labels.rego
@@ -35,5 +35,7 @@ conditions := [
   ]
 ]
 
-message := helpers.get_multi_summary(conditions, vars.variables).message
-details := helpers.get_multi_summary(conditions, vars.variables).details
+result := helpers.get_multi_summary(conditions, vars.variables)
+
+message := result.message
+details := result.details

--- a/policies/gcp/Backup for GKE/google_gke_backup_restore_channel/location.rego
+++ b/policies/gcp/Backup for GKE/google_gke_backup_restore_channel/location.rego
@@ -29,5 +29,7 @@ conditions := [
   ]
 ]
 
-message := helpers.get_multi_summary(conditions, vars.variables).message
-details := helpers.get_multi_summary(conditions, vars.variables).details
+result := helpers.get_multi_summary(conditions, vars.variables)
+
+message := result.message
+details := result.details

--- a/policies/gcp/Backup for GKE/google_gke_backup_restore_plan/cluster.rego
+++ b/policies/gcp/Backup for GKE/google_gke_backup_restore_plan/cluster.rego
@@ -17,5 +17,7 @@ conditions := [
   ]
 ]
 
-message := helpers.get_multi_summary(conditions, vars.variables).message
-details := helpers.get_multi_summary(conditions, vars.variables).details
+result := helpers.get_multi_summary(conditions, vars.variables)
+
+message := result.message
+details := result.details

--- a/policies/gcp/Backup for GKE/google_gke_backup_restore_plan/restore_config.all_namespaces.rego
+++ b/policies/gcp/Backup for GKE/google_gke_backup_restore_plan/restore_config.all_namespaces.rego
@@ -17,5 +17,7 @@ conditions := [
   ]
 ]
 
-message := helpers.get_multi_summary(conditions, vars.variables).message
-details := helpers.get_multi_summary(conditions, vars.variables).details
+result := helpers.get_multi_summary(conditions, vars.variables)
+
+message := result.message
+details := result.details

--- a/policies/gcp/Backup for GKE/google_gke_backup_restore_plan/restore_config.cluster_resource_conflict_policy.rego
+++ b/policies/gcp/Backup for GKE/google_gke_backup_restore_plan/restore_config.cluster_resource_conflict_policy.rego
@@ -17,5 +17,7 @@ conditions := [
   ]
 ]
 
-message := helpers.get_multi_summary(conditions, vars.variables).message
-details := helpers.get_multi_summary(conditions, vars.variables).details
+result := helpers.get_multi_summary(conditions, vars.variables)
+
+message := result.message
+details := result.details

--- a/policies/gcp/Backup for GKE/google_gke_backup_restore_plan/restore_config.cluster_resource_restore_scope.all_group_kinds.rego
+++ b/policies/gcp/Backup for GKE/google_gke_backup_restore_plan/restore_config.cluster_resource_restore_scope.all_group_kinds.rego
@@ -17,5 +17,7 @@ conditions := [
   ]
 ]
 
-message := helpers.get_multi_summary(conditions, vars.variables).message
-details := helpers.get_multi_summary(conditions, vars.variables).details
+result := helpers.get_multi_summary(conditions, vars.variables)
+
+message := result.message
+details := result.details

--- a/policies/gcp/Backup for GKE/google_gke_backup_restore_plan/restore_config.namespaced_resource_restore_mode.rego
+++ b/policies/gcp/Backup for GKE/google_gke_backup_restore_plan/restore_config.namespaced_resource_restore_mode.rego
@@ -17,5 +17,7 @@ conditions := [
   ]
 ]
 
-message := helpers.get_multi_summary(conditions, vars.variables).message
-details := helpers.get_multi_summary(conditions, vars.variables).details
+result := helpers.get_multi_summary(conditions, vars.variables)
+
+message := result.message
+details := result.details

--- a/policies/gcp/BeyondCorp/google_beyondcorp_app_connection/type.rego
+++ b/policies/gcp/BeyondCorp/google_beyondcorp_app_connection/type.rego
@@ -19,6 +19,8 @@ conditions := [
 ]
 
 
-message := helpers.get_multi_summary(conditions, vars.variables).message
+result := helpers.get_multi_summary(conditions, vars.variables)
 
-details := helpers.get_multi_summary(conditions, vars.variables).details
+message := result.message
+
+details := result.details

--- a/policies/gcp/BeyondCorp/google_beyondcorp_security_gateway_iam_binding/members.rego
+++ b/policies/gcp/BeyondCorp/google_beyondcorp_security_gateway_iam_binding/members.rego
@@ -21,5 +21,5 @@ conditions := [
 
 summary := helpers.get_multi_summary(conditions, vars.variables)
 
-message := helpers.get_multi_summary(conditions, vars.variables).message
-details := helpers.get_multi_summary(conditions, vars.variables).details
+message := summary.message
+details := summary.details

--- a/policies/gcp/BeyondCorp/google_beyondcorp_security_gateway_iam_member/member.rego
+++ b/policies/gcp/BeyondCorp/google_beyondcorp_security_gateway_iam_member/member.rego
@@ -21,5 +21,5 @@ conditions := [
 
 summary := helpers.get_multi_summary(conditions, vars.variables)
 
-message := helpers.get_multi_summary(conditions, vars.variables).message
-details := helpers.get_multi_summary(conditions, vars.variables).details
+message := summary.message
+details := summary.details

--- a/policies/gcp/BigQuery Analytics Hub/google_bigquery_analytics_hub_data_exchange/discovery_type.rego
+++ b/policies/gcp/BigQuery Analytics Hub/google_bigquery_analytics_hub_data_exchange/discovery_type.rego
@@ -19,5 +19,7 @@ conditions := [[
 	},
 ]]
 
-message := helpers.get_multi_summary(conditions, vars.variables).message
-details := helpers.get_multi_summary(conditions, vars.variables).details
+result := helpers.get_multi_summary(conditions, vars.variables)
+
+message := result.message
+details := result.details

--- a/policies/gcp/BigQuery Analytics Hub/google_bigquery_analytics_hub_data_exchange/location.rego
+++ b/policies/gcp/BigQuery Analytics Hub/google_bigquery_analytics_hub_data_exchange/location.rego
@@ -16,5 +16,7 @@ conditions := [[
 	},
 ]]
 
-message := helpers.get_multi_summary(conditions, vars.variables).message
-details := helpers.get_multi_summary(conditions, vars.variables).details
+result := helpers.get_multi_summary(conditions, vars.variables)
+
+message := result.message
+details := result.details

--- a/policies/gcp/BigQuery Analytics Hub/google_bigquery_analytics_hub_listing/restricted_export_config.enabled.rego
+++ b/policies/gcp/BigQuery Analytics Hub/google_bigquery_analytics_hub_listing/restricted_export_config.enabled.rego
@@ -25,5 +25,7 @@ conditions := [[
 	},
 ]]
 
-message := helpers.get_multi_summary(conditions, vars.variables).message
-details := helpers.get_multi_summary(conditions, vars.variables).details
+result := helpers.get_multi_summary(conditions, vars.variables)
+
+message := result.message
+details := result.details

--- a/policies/gcp/BigQuery Analytics Hub/google_bigquery_analytics_hub_listing_subscription/destination_dataset.labels.rego
+++ b/policies/gcp/BigQuery Analytics Hub/google_bigquery_analytics_hub_listing_subscription/destination_dataset.labels.rego
@@ -19,5 +19,7 @@ conditions := [[
 	},
 ]]
 
-message := helpers.get_multi_summary(conditions, vars.variables).message
-details := helpers.get_multi_summary(conditions, vars.variables).details
+result := helpers.get_multi_summary(conditions, vars.variables)
+
+message := result.message
+details := result.details

--- a/policies/gcp/BigQuery Data Policy/google_bigquery_datapolicy_data_policy/data_policy_type.rego
+++ b/policies/gcp/BigQuery Data Policy/google_bigquery_datapolicy_data_policy/data_policy_type.rego
@@ -15,5 +15,7 @@ conditions := [
     ]
 ]
 
-message := helpers.get_multi_summary(conditions, vars.variables).message
-details := helpers.get_multi_summary(conditions, vars.variables).details
+result := helpers.get_multi_summary(conditions, vars.variables)
+
+message := result.message
+details := result.details

--- a/policies/gcp/BigQuery Data Policy/google_bigquery_datapolicy_data_policy/location.rego
+++ b/policies/gcp/BigQuery Data Policy/google_bigquery_datapolicy_data_policy/location.rego
@@ -15,5 +15,7 @@ conditions := [
     ]
 ]
 
-message := helpers.get_multi_summary(conditions, vars.variables).message
-details := helpers.get_multi_summary(conditions, vars.variables).details
+result := helpers.get_multi_summary(conditions, vars.variables)
+
+message := result.message
+details := result.details

--- a/policies/gcp/BigQuery Data Policy/google_bigquery_datapolicy_data_policy_iam_member/location.rego
+++ b/policies/gcp/BigQuery Data Policy/google_bigquery_datapolicy_data_policy_iam_member/location.rego
@@ -15,5 +15,7 @@ conditions := [
     ]
 ]
 
-message := helpers.get_multi_summary(conditions, vars.variables).message
-details := helpers.get_multi_summary(conditions, vars.variables).details
+result := helpers.get_multi_summary(conditions, vars.variables)
+
+message := result.message
+details := result.details

--- a/policies/gcp/BigQuery Data Policy/google_bigquery_datapolicy_data_policy_iam_member/member.rego
+++ b/policies/gcp/BigQuery Data Policy/google_bigquery_datapolicy_data_policy_iam_member/member.rego
@@ -35,5 +35,7 @@ conditions := [
     ]
 ]
 
-message := helpers.get_multi_summary(conditions, vars.variables).message
-details := helpers.get_multi_summary(conditions, vars.variables).details
+result := helpers.get_multi_summary(conditions, vars.variables)
+
+message := result.message
+details := result.details

--- a/policies/gcp/BigQuery Data Transfer/google_bigquery_data_transfer_config/destination_dataset_id.rego
+++ b/policies/gcp/BigQuery Data Transfer/google_bigquery_data_transfer_config/destination_dataset_id.rego
@@ -19,5 +19,7 @@ conditions := [
   ]
 ]
 
-message := helpers.get_multi_summary(conditions, vars.variables).message
-details := helpers.get_multi_summary(conditions, vars.variables).details
+result := helpers.get_multi_summary(conditions, vars.variables)
+
+message := result.message
+details := result.details

--- a/policies/gcp/BigQuery Data Transfer/google_bigquery_data_transfer_config/encryption_configuration.kms_key_name.rego
+++ b/policies/gcp/BigQuery Data Transfer/google_bigquery_data_transfer_config/encryption_configuration.kms_key_name.rego
@@ -19,5 +19,7 @@ conditions := [
   ]
 ]
 
-message := helpers.get_multi_summary(conditions, vars.variables).message
-details := helpers.get_multi_summary(conditions, vars.variables).details
+result := helpers.get_multi_summary(conditions, vars.variables)
+
+message := result.message
+details := result.details

--- a/policies/gcp/BigQuery Data Transfer/google_bigquery_data_transfer_config/location.rego
+++ b/policies/gcp/BigQuery Data Transfer/google_bigquery_data_transfer_config/location.rego
@@ -15,5 +15,7 @@ conditions := [[
   }
 ]]
 
-message := helpers.get_multi_summary(conditions, vars.variables).message
-details := helpers.get_multi_summary(conditions, vars.variables).details
+result := helpers.get_multi_summary(conditions, vars.variables)
+
+message := result.message
+details := result.details

--- a/policies/gcp/BigQuery Reservation/google_bigquery_bi_reservation/location.rego
+++ b/policies/gcp/BigQuery Reservation/google_bigquery_bi_reservation/location.rego
@@ -20,5 +20,7 @@ conditions := [
   ]
 ]
 
-message := data.terraform.helpers.get_multi_summary(conditions, vars.variables).message
-details := data.terraform.helpers.get_multi_summary(conditions, vars.variables).details
+result := data.terraform.helpers.get_multi_summary(conditions, vars.variables)
+
+message := result.message
+details := result.details

--- a/policies/gcp/BigQuery Reservation/google_bigquery_capacity_commitment/location.rego
+++ b/policies/gcp/BigQuery Reservation/google_bigquery_capacity_commitment/location.rego
@@ -21,5 +21,7 @@ conditions := [
   ]
 ]
 
-message := data.terraform.helpers.get_multi_summary(conditions, vars.variables).message
-details := data.terraform.helpers.get_multi_summary(conditions, vars.variables).details
+result := data.terraform.helpers.get_multi_summary(conditions, vars.variables)
+
+message := result.message
+details := result.details

--- a/policies/gcp/BigQuery Reservation/google_bigquery_reservation/autoscale.max_slots.rego
+++ b/policies/gcp/BigQuery Reservation/google_bigquery_reservation/autoscale.max_slots.rego
@@ -21,5 +21,7 @@ conditions := [
   ]
 ]
 
-message := data.terraform.helpers.get_multi_summary(conditions, vars.variables).message
-details := data.terraform.helpers.get_multi_summary(conditions, vars.variables).details
+result := data.terraform.helpers.get_multi_summary(conditions, vars.variables)
+
+message := result.message
+details := result.details

--- a/policies/gcp/BigQuery Reservation/google_bigquery_reservation/concurrency.rego
+++ b/policies/gcp/BigQuery Reservation/google_bigquery_reservation/concurrency.rego
@@ -20,5 +20,7 @@ conditions := [
   ]
 ]
 
-message := data.terraform.helpers.get_multi_summary(conditions, vars.variables).message
-details := data.terraform.helpers.get_multi_summary(conditions, vars.variables).details
+result := data.terraform.helpers.get_multi_summary(conditions, vars.variables)
+
+message := result.message
+details := result.details

--- a/policies/gcp/BigQuery Reservation/google_bigquery_reservation/edition.rego
+++ b/policies/gcp/BigQuery Reservation/google_bigquery_reservation/edition.rego
@@ -20,5 +20,7 @@ conditions := [
   ]
 ]
 
-message := data.terraform.helpers.get_multi_summary(conditions, vars.variables).message
-details := data.terraform.helpers.get_multi_summary(conditions, vars.variables).details
+result := data.terraform.helpers.get_multi_summary(conditions, vars.variables)
+
+message := result.message
+details := result.details

--- a/policies/gcp/BigQuery Reservation/google_bigquery_reservation/ignore_idle_slots.rego
+++ b/policies/gcp/BigQuery Reservation/google_bigquery_reservation/ignore_idle_slots.rego
@@ -20,5 +20,7 @@ conditions := [
   ]
 ]
 
-message := data.terraform.helpers.get_multi_summary(conditions, vars.variables).message
-details := data.terraform.helpers.get_multi_summary(conditions, vars.variables).details
+result := data.terraform.helpers.get_multi_summary(conditions, vars.variables)
+
+message := result.message
+details := result.details

--- a/policies/gcp/BigQuery Reservation/google_bigquery_reservation/location.rego
+++ b/policies/gcp/BigQuery Reservation/google_bigquery_reservation/location.rego
@@ -20,5 +20,7 @@ conditions := [
   ]
 ]
 
-message := data.terraform.helpers.get_multi_summary(conditions, vars.variables).message
-details := data.terraform.helpers.get_multi_summary(conditions, vars.variables).details
+result := data.terraform.helpers.get_multi_summary(conditions, vars.variables)
+
+message := result.message
+details := result.details

--- a/policies/gcp/BigQuery Reservation/google_bigquery_reservation_assignment/job_type.rego
+++ b/policies/gcp/BigQuery Reservation/google_bigquery_reservation_assignment/job_type.rego
@@ -20,5 +20,7 @@ conditions := [
   ]
 ]
 
-message := data.terraform.helpers.get_multi_summary(conditions, vars.variables).message
-details := data.terraform.helpers.get_multi_summary(conditions, vars.variables).details
+result := data.terraform.helpers.get_multi_summary(conditions, vars.variables)
+
+message := result.message
+details := result.details

--- a/policies/gcp/BigQuery Reservation/google_bigquery_reservation_assignment/location.rego
+++ b/policies/gcp/BigQuery Reservation/google_bigquery_reservation_assignment/location.rego
@@ -20,5 +20,7 @@ conditions := [
   ]
 ]
 
-message := data.terraform.helpers.get_multi_summary(conditions, vars.variables).message
-details := data.terraform.helpers.get_multi_summary(conditions, vars.variables).details
+result := data.terraform.helpers.get_multi_summary(conditions, vars.variables)
+
+message := result.message
+details := result.details

--- a/policies/gcp/BigQuery/google_bigquery_dataset/access.domain.rego
+++ b/policies/gcp/BigQuery/google_bigquery_dataset/access.domain.rego
@@ -15,5 +15,7 @@ conditions := [
     ]
 ]
 
-message := helpers.get_multi_summary(conditions, vars.variables).message
-details := helpers.get_multi_summary(conditions, vars.variables).details
+result := helpers.get_multi_summary(conditions, vars.variables)
+
+message := result.message
+details := result.details

--- a/policies/gcp/BigQuery/google_bigquery_dataset/access.group_by_email.rego
+++ b/policies/gcp/BigQuery/google_bigquery_dataset/access.group_by_email.rego
@@ -15,5 +15,7 @@ conditions := [
     ]
 ]
 
-message := helpers.get_multi_summary(conditions, vars.variables).message
-details := helpers.get_multi_summary(conditions, vars.variables).details
+result := helpers.get_multi_summary(conditions, vars.variables)
+
+message := result.message
+details := result.details

--- a/policies/gcp/BigQuery/google_bigquery_dataset/access.user_by_email.rego
+++ b/policies/gcp/BigQuery/google_bigquery_dataset/access.user_by_email.rego
@@ -15,5 +15,7 @@ conditions := [
     ]
 ]
 
-message := helpers.get_multi_summary(conditions, vars.variables).message
-details := helpers.get_multi_summary(conditions, vars.variables).details
+result := helpers.get_multi_summary(conditions, vars.variables)
+
+message := result.message
+details := result.details

--- a/policies/gcp/BigQuery/google_bigquery_dataset/default_encryption_configuration.kms_key_name.rego
+++ b/policies/gcp/BigQuery/google_bigquery_dataset/default_encryption_configuration.kms_key_name.rego
@@ -15,5 +15,7 @@ conditions := [
     ]
 ]
 
-message := helpers.get_multi_summary(conditions, vars.variables).message
-details := helpers.get_multi_summary(conditions, vars.variables).details
+result := helpers.get_multi_summary(conditions, vars.variables)
+
+message := result.message
+details := result.details

--- a/policies/gcp/BigQuery/google_bigquery_dataset/location.rego
+++ b/policies/gcp/BigQuery/google_bigquery_dataset/location.rego
@@ -15,5 +15,7 @@ conditions := [
     ]
 ]
 
-message := helpers.get_multi_summary(conditions, vars.variables).message
-details := helpers.get_multi_summary(conditions, vars.variables).details
+result := helpers.get_multi_summary(conditions, vars.variables)
+
+message := result.message
+details := result.details

--- a/policies/gcp/BigQuery/google_bigquery_dataset_access/domain.rego
+++ b/policies/gcp/BigQuery/google_bigquery_dataset_access/domain.rego
@@ -15,5 +15,7 @@ conditions := [
     ]
 ]
 
-message := helpers.get_multi_summary(conditions, vars.variables).message
-details := helpers.get_multi_summary(conditions, vars.variables).details
+result := helpers.get_multi_summary(conditions, vars.variables)
+
+message := result.message
+details := result.details

--- a/policies/gcp/BigQuery/google_bigquery_dataset_access/group_by_email.rego
+++ b/policies/gcp/BigQuery/google_bigquery_dataset_access/group_by_email.rego
@@ -15,5 +15,7 @@ conditions := [
     ]
 ]
 
-message := helpers.get_multi_summary(conditions, vars.variables).message
-details := helpers.get_multi_summary(conditions, vars.variables).details
+result := helpers.get_multi_summary(conditions, vars.variables)
+
+message := result.message
+details := result.details

--- a/policies/gcp/BigQuery/google_bigquery_dataset_access/role.rego
+++ b/policies/gcp/BigQuery/google_bigquery_dataset_access/role.rego
@@ -15,5 +15,7 @@ conditions := [
     ]
 ]
 
-message := helpers.get_multi_summary(conditions, vars.variables).message
-details := helpers.get_multi_summary(conditions, vars.variables).details
+result := helpers.get_multi_summary(conditions, vars.variables)
+
+message := result.message
+details := result.details

--- a/policies/gcp/BigQuery/google_bigquery_dataset_access/special_group.rego
+++ b/policies/gcp/BigQuery/google_bigquery_dataset_access/special_group.rego
@@ -15,5 +15,7 @@ conditions := [
     ]
 ]
 
-message := helpers.get_multi_summary(conditions, vars.variables).message
-details := helpers.get_multi_summary(conditions, vars.variables).details
+result := helpers.get_multi_summary(conditions, vars.variables)
+
+message := result.message
+details := result.details

--- a/policies/gcp/BigQuery/google_bigquery_dataset_access/user_by_email.rego
+++ b/policies/gcp/BigQuery/google_bigquery_dataset_access/user_by_email.rego
@@ -15,5 +15,7 @@ conditions := [
     ]
 ]
 
-message := helpers.get_multi_summary(conditions, vars.variables).message
-details := helpers.get_multi_summary(conditions, vars.variables).details
+result := helpers.get_multi_summary(conditions, vars.variables)
+
+message := result.message
+details := result.details

--- a/policies/gcp/BigQuery/google_bigquery_job/load.max_bad_records.rego
+++ b/policies/gcp/BigQuery/google_bigquery_job/load.max_bad_records.rego
@@ -15,5 +15,7 @@ conditions := [
     ]
 ]
 
-message := helpers.get_multi_summary(conditions, vars.variables).message
-details := helpers.get_multi_summary(conditions, vars.variables).details
+result := helpers.get_multi_summary(conditions, vars.variables)
+
+message := result.message
+details := result.details

--- a/policies/gcp/BigQuery/google_bigquery_job/load.source_uris.rego
+++ b/policies/gcp/BigQuery/google_bigquery_job/load.source_uris.rego
@@ -15,5 +15,7 @@ conditions := [
     ]
 ]
 
-message := helpers.get_multi_summary(conditions, vars.variables).message
-details := helpers.get_multi_summary(conditions, vars.variables).details
+result := helpers.get_multi_summary(conditions, vars.variables)
+
+message := result.message
+details := result.details

--- a/policies/gcp/BigQuery/google_bigquery_job/location.rego
+++ b/policies/gcp/BigQuery/google_bigquery_job/location.rego
@@ -15,5 +15,7 @@ conditions := [
     ]
 ]
 
-message := helpers.get_multi_summary(conditions, vars.variables).message
-details := helpers.get_multi_summary(conditions, vars.variables).details
+result := helpers.get_multi_summary(conditions, vars.variables)
+
+message := result.message
+details := result.details

--- a/policies/gcp/BigQuery/google_bigquery_job/query.connection_properties.key.rego
+++ b/policies/gcp/BigQuery/google_bigquery_job/query.connection_properties.key.rego
@@ -15,5 +15,7 @@ conditions := [
     ]
 ]
 
-message := helpers.get_multi_summary(conditions, vars.variables).message
-details := helpers.get_multi_summary(conditions, vars.variables).details
+result := helpers.get_multi_summary(conditions, vars.variables)
+
+message := result.message
+details := result.details

--- a/policies/gcp/BigQuery/google_bigquery_job/query.connection_properties.value.rego
+++ b/policies/gcp/BigQuery/google_bigquery_job/query.connection_properties.value.rego
@@ -15,5 +15,7 @@ conditions := [
     ]
 ]
 
-message := helpers.get_multi_summary(conditions, vars.variables).message
-details := helpers.get_multi_summary(conditions, vars.variables).details
+result := helpers.get_multi_summary(conditions, vars.variables)
+
+message := result.message
+details := result.details

--- a/policies/gcp/BigQuery/google_bigquery_job/query.maximum_bytes_billed.rego
+++ b/policies/gcp/BigQuery/google_bigquery_job/query.maximum_bytes_billed.rego
@@ -15,5 +15,7 @@ conditions := [
     ]
 ]
 
-message := helpers.get_multi_summary(conditions, vars.variables).message
-details := helpers.get_multi_summary(conditions, vars.variables).details
+result := helpers.get_multi_summary(conditions, vars.variables)
+
+message := result.message
+details := result.details

--- a/policies/gcp/BigQuery/google_bigquery_row_access_policy/filter_predicate.rego
+++ b/policies/gcp/BigQuery/google_bigquery_row_access_policy/filter_predicate.rego
@@ -15,5 +15,7 @@ conditions := [
     ]
 ]
 
-message := helpers.get_multi_summary(conditions, vars.variables).message
-details := helpers.get_multi_summary(conditions, vars.variables).details
+result := helpers.get_multi_summary(conditions, vars.variables)
+
+message := result.message
+details := result.details

--- a/policies/gcp/BigQuery/google_bigquery_row_access_policy/grantees.rego
+++ b/policies/gcp/BigQuery/google_bigquery_row_access_policy/grantees.rego
@@ -15,5 +15,7 @@ conditions := [
     ]
 ]
 
-message := helpers.get_multi_summary(conditions, vars.variables).message
-details := helpers.get_multi_summary(conditions, vars.variables).details
+result := helpers.get_multi_summary(conditions, vars.variables)
+
+message := result.message
+details := result.details

--- a/policies/gcp/BigQuery/google_bigquery_row_access_policy/table_id.rego
+++ b/policies/gcp/BigQuery/google_bigquery_row_access_policy/table_id.rego
@@ -15,5 +15,7 @@ conditions := [
     ]
 ]
 
-message := helpers.get_multi_summary(conditions, vars.variables).message
-details := helpers.get_multi_summary(conditions, vars.variables).details
+result := helpers.get_multi_summary(conditions, vars.variables)
+
+message := result.message
+details := result.details

--- a/policies/gcp/BigQuery/google_bigquery_table/deletion_protection.rego
+++ b/policies/gcp/BigQuery/google_bigquery_table/deletion_protection.rego
@@ -15,5 +15,7 @@ conditions := [
     ]
 ]
 
-message := helpers.get_multi_summary(conditions, vars.variables).message
-details := helpers.get_multi_summary(conditions, vars.variables).details
+result := helpers.get_multi_summary(conditions, vars.variables)
+
+message := result.message
+details := result.details

--- a/policies/gcp/BigQuery/google_bigquery_table/encryption_configuration.kms_key_name.rego
+++ b/policies/gcp/BigQuery/google_bigquery_table/encryption_configuration.kms_key_name.rego
@@ -15,5 +15,7 @@ conditions := [
     ]
 ]
 
-message := helpers.get_multi_summary(conditions, vars.variables).message
-details := helpers.get_multi_summary(conditions, vars.variables).details
+result := helpers.get_multi_summary(conditions, vars.variables)
+
+message := result.message
+details := result.details

--- a/policies/gcp/BigQuery/google_bigquery_table/expiration_time.rego
+++ b/policies/gcp/BigQuery/google_bigquery_table/expiration_time.rego
@@ -15,5 +15,7 @@ conditions := [
     ]
 ]
 
-message := helpers.get_multi_summary(conditions, vars.variables).message
-details := helpers.get_multi_summary(conditions, vars.variables).details
+result := helpers.get_multi_summary(conditions, vars.variables)
+
+message := result.message
+details := result.details

--- a/policies/gcp/BigQuery/google_bigquery_table/external_data_configuration.connection_id.rego
+++ b/policies/gcp/BigQuery/google_bigquery_table/external_data_configuration.connection_id.rego
@@ -15,5 +15,7 @@ conditions := [
     ]
 ]
 
-message := helpers.get_multi_summary(conditions, vars.variables).message
-details := helpers.get_multi_summary(conditions, vars.variables).details
+result := helpers.get_multi_summary(conditions, vars.variables)
+
+message := result.message
+details := result.details

--- a/policies/gcp/BigQuery/google_bigquery_table/require_partition_filter.rego
+++ b/policies/gcp/BigQuery/google_bigquery_table/require_partition_filter.rego
@@ -15,5 +15,7 @@ conditions := [
     ]
 ]
 
-message := helpers.get_multi_summary(conditions, vars.variables).message
-details := helpers.get_multi_summary(conditions, vars.variables).details
+result := helpers.get_multi_summary(conditions, vars.variables)
+
+message := result.message
+details := result.details

--- a/policies/gcp/Biglake/google_biglake_catalog/location.rego
+++ b/policies/gcp/Biglake/google_biglake_catalog/location.rego
@@ -20,5 +20,7 @@ conditions := [
   ]
 ]
 
-message := helpers.get_multi_summary(conditions, vars.variables).message
-details := helpers.get_multi_summary(conditions, vars.variables).details
+result := helpers.get_multi_summary(conditions, vars.variables)
+
+message := result.message
+details := result.details

--- a/policies/gcp/Biglake/google_biglake_database/hive_options.location_uri.rego
+++ b/policies/gcp/Biglake/google_biglake_database/hive_options.location_uri.rego
@@ -20,5 +20,7 @@ conditions := [
   ]
 ]
 
-message := helpers.get_multi_summary(conditions, vars.variables).message
-details := helpers.get_multi_summary(conditions, vars.variables).details
+result := helpers.get_multi_summary(conditions, vars.variables)
+
+message := result.message
+details := result.details

--- a/policies/gcp/Biglake/google_biglake_database/type.rego
+++ b/policies/gcp/Biglake/google_biglake_database/type.rego
@@ -20,5 +20,7 @@ conditions := [
   ]
 ]
 
-message := helpers.get_multi_summary(conditions, vars.variables).message
-details := helpers.get_multi_summary(conditions, vars.variables).details
+result := helpers.get_multi_summary(conditions, vars.variables)
+
+message := result.message
+details := result.details

--- a/policies/gcp/Biglake/google_biglake_table/hive_options.storage_descriptor.location_uri.rego
+++ b/policies/gcp/Biglake/google_biglake_table/hive_options.storage_descriptor.location_uri.rego
@@ -19,5 +19,7 @@ conditions := [
   ]
 ]
 
-message := helpers.get_multi_summary(conditions, vars.variables).message
-details := helpers.get_multi_summary(conditions, vars.variables).details
+result := helpers.get_multi_summary(conditions, vars.variables)
+
+message := result.message
+details := result.details

--- a/policies/gcp/Biglake/google_biglake_table/type.rego
+++ b/policies/gcp/Biglake/google_biglake_table/type.rego
@@ -23,5 +23,7 @@ conditions := [
   ]
 ]
 
-message := helpers.get_multi_summary(conditions, vars.variables).message
-details := helpers.get_multi_summary(conditions, vars.variables).details
+result := helpers.get_multi_summary(conditions, vars.variables)
+
+message := result.message
+details := result.details

--- a/policies/gcp/Binary Authorization/google_binary_authorization_attestor/attestation_authority_note.public_keys.id.rego
+++ b/policies/gcp/Binary Authorization/google_binary_authorization_attestor/attestation_authority_note.public_keys.id.rego
@@ -21,5 +21,7 @@ conditions := [
 ]
 
 # Generate policy message and details
-message := helpers.get_multi_summary(conditions, vars.variables).message
-details := helpers.get_multi_summary(conditions, vars.variables).details
+result := helpers.get_multi_summary(conditions, vars.variables)
+
+message := result.message
+details := result.details

--- a/policies/gcp/Binary Authorization/google_binary_authorization_attestor/attestation_authority_note.public_keys.pkix_public_key.signature_algorithm.rego
+++ b/policies/gcp/Binary Authorization/google_binary_authorization_attestor/attestation_authority_note.public_keys.pkix_public_key.signature_algorithm.rego
@@ -21,7 +21,9 @@ conditions := [
 ]
 
 # Summary message for compliance
-message := helpers.get_multi_summary(conditions, vars.variables).message
+result := helpers.get_multi_summary(conditions, vars.variables)
+
+message := result.message
 
 # Detailed compliance info for debugging
-details := helpers.get_multi_summary(conditions, vars.variables).details
+details := result.details

--- a/policies/gcp/Binary Authorization/google_binary_authorization_attestor_iam_member/attestor.rego
+++ b/policies/gcp/Binary Authorization/google_binary_authorization_attestor_iam_member/attestor.rego
@@ -25,7 +25,9 @@ conditions := [
 ]
 
 # Summary message for compliance
-message := helpers.get_multi_summary(conditions, vars.variables).message
+result := helpers.get_multi_summary(conditions, vars.variables)
+
+message := result.message
 
 # Detailed compliance info for debugging
-details := helpers.get_multi_summary(conditions, vars.variables).details
+details := result.details

--- a/policies/gcp/Binary Authorization/google_binary_authorization_attestor_iam_member/member.rego
+++ b/policies/gcp/Binary Authorization/google_binary_authorization_attestor_iam_member/member.rego
@@ -22,5 +22,7 @@ conditions := [
   ]
 ]
 
-message := helpers.get_multi_summary(conditions, vars.variables).message
-details := helpers.get_multi_summary(conditions, vars.variables).details
+result := helpers.get_multi_summary(conditions, vars.variables)
+
+message := result.message
+details := result.details

--- a/policies/gcp/Binary Authorization/google_binary_authorization_attestor_iam_member/role.rego
+++ b/policies/gcp/Binary Authorization/google_binary_authorization_attestor_iam_member/role.rego
@@ -21,5 +21,7 @@ conditions := [
   ]
 ]
 
-message := helpers.get_multi_summary(conditions, vars.variables).message
-details := helpers.get_multi_summary(conditions, vars.variables).details
+result := helpers.get_multi_summary(conditions, vars.variables)
+
+message := result.message
+details := result.details

--- a/policies/gcp/Binary Authorization/google_binary_authorization_policy/default_admission_rule.enforcement_mode.rego
+++ b/policies/gcp/Binary Authorization/google_binary_authorization_policy/default_admission_rule.enforcement_mode.rego
@@ -20,5 +20,7 @@ conditions := [
   ]
 ]
 
-message := helpers.get_multi_summary(conditions, vars.variables).message
-details := helpers.get_multi_summary(conditions, vars.variables).details
+result := helpers.get_multi_summary(conditions, vars.variables)
+
+message := result.message
+details := result.details

--- a/policies/gcp/Binary Authorization/google_binary_authorization_policy/default_admission_rule.require_attestations_by.rego
+++ b/policies/gcp/Binary Authorization/google_binary_authorization_policy/default_admission_rule.require_attestations_by.rego
@@ -20,5 +20,7 @@ conditions := [
   ]
 ]
 
-message := helpers.get_multi_summary(conditions, vars.variables).message
-details := helpers.get_multi_summary(conditions, vars.variables).details
+result := helpers.get_multi_summary(conditions, vars.variables)
+
+message := result.message
+details := result.details

--- a/policies/gcp/Certificate Manager/google_certificate_manager_certificate_issuance_config/key_algorithm.rego
+++ b/policies/gcp/Certificate Manager/google_certificate_manager_certificate_issuance_config/key_algorithm.rego
@@ -20,5 +20,7 @@ conditions := [
     ]
 ]
 
-message := helpers.get_multi_summary(conditions, vars.variables).message
-details := helpers.get_multi_summary(conditions, vars.variables).details
+result := helpers.get_multi_summary(conditions, vars.variables)
+
+message := result.message
+details := result.details

--- a/policies/gcp/Certificate Manager/google_certificate_manager_certificate_issuance_config/lifetime.rego
+++ b/policies/gcp/Certificate Manager/google_certificate_manager_certificate_issuance_config/lifetime.rego
@@ -20,5 +20,7 @@ conditions := [
     ]
 ]
 
-message := helpers.get_multi_summary(conditions, vars.variables).message
-details := helpers.get_multi_summary(conditions, vars.variables).details
+result := helpers.get_multi_summary(conditions, vars.variables)
+
+message := result.message
+details := result.details

--- a/policies/gcp/Certificate Manager/google_certificate_manager_certificate_issuance_config/rotation_window_percentage.rego
+++ b/policies/gcp/Certificate Manager/google_certificate_manager_certificate_issuance_config/rotation_window_percentage.rego
@@ -20,5 +20,7 @@ conditions := [
     ]
 ]
 
-message := helpers.get_multi_summary(conditions, vars.variables).message
-details := helpers.get_multi_summary(conditions, vars.variables).details
+result := helpers.get_multi_summary(conditions, vars.variables)
+
+message := result.message
+details := result.details

--- a/policies/gcp/Certificate Manager/google_certificate_manager_dns_authorization/type.rego
+++ b/policies/gcp/Certificate Manager/google_certificate_manager_dns_authorization/type.rego
@@ -20,5 +20,7 @@ conditions := [
     ]
 ]
 
-message := helpers.get_multi_summary(conditions, vars.variables).message
-details := helpers.get_multi_summary(conditions, vars.variables).details
+result := helpers.get_multi_summary(conditions, vars.variables)
+
+message := result.message
+details := result.details

--- a/policies/gcp/Chronicle/google_chronicle_data_access_label/location.rego
+++ b/policies/gcp/Chronicle/google_chronicle_data_access_label/location.rego
@@ -23,7 +23,9 @@ conditions := [
 ]
 
 # Summary message for compliance
-message := helpers.get_multi_summary(conditions, vars.variables).message
+result := helpers.get_multi_summary(conditions, vars.variables)
+
+message := result.message
 
 # Detailed compliance info for debugging
-details := helpers.get_multi_summary(conditions, vars.variables).details
+details := result.details

--- a/policies/gcp/Chronicle/google_chronicle_data_access_label/udm_query.rego
+++ b/policies/gcp/Chronicle/google_chronicle_data_access_label/udm_query.rego
@@ -23,7 +23,9 @@ conditions := [
   ],
 ]
 
-message := helpers.get_multi_summary(conditions, vars.variables).message
+result := helpers.get_multi_summary(conditions, vars.variables)
+
+message := result.message
 
 # Detailed report of each condition and situation
-details := helpers.get_multi_summary(conditions, vars.variables).details
+details := result.details

--- a/policies/gcp/Chronicle/google_chronicle_data_access_scope/allow_all.rego
+++ b/policies/gcp/Chronicle/google_chronicle_data_access_scope/allow_all.rego
@@ -41,5 +41,7 @@ conditions := [
   ]
 ]
 
-message := helpers.get_multi_summary(conditions, vars.variables).message
-details := helpers.get_multi_summary(conditions, vars.variables).details
+result := helpers.get_multi_summary(conditions, vars.variables)
+
+message := result.message
+details := result.details

--- a/policies/gcp/Chronicle/google_chronicle_data_access_scope/location.rego
+++ b/policies/gcp/Chronicle/google_chronicle_data_access_scope/location.rego
@@ -23,7 +23,9 @@ conditions := [
 ]
 
 # Summary message for compliance
-message := helpers.get_multi_summary(conditions, vars.variables).message
+result := helpers.get_multi_summary(conditions, vars.variables)
+
+message := result.message
 
 # Detailed compliance info for debugging
-details := helpers.get_multi_summary(conditions, vars.variables).details
+details := result.details

--- a/policies/gcp/Chronicle/google_chronicle_reference_list/location.rego
+++ b/policies/gcp/Chronicle/google_chronicle_reference_list/location.rego
@@ -23,7 +23,9 @@ conditions := [
 ]
 
 # Summary message for compliance
-message := helpers.get_multi_summary(conditions, vars.variables).message
+result := helpers.get_multi_summary(conditions, vars.variables)
+
+message := result.message
 
 # Detailed compliance info for debugging
-details := helpers.get_multi_summary(conditions, vars.variables).details
+details := result.details

--- a/policies/gcp/Chronicle/google_chronicle_retrohunt/location.rego
+++ b/policies/gcp/Chronicle/google_chronicle_retrohunt/location.rego
@@ -23,7 +23,9 @@ conditions := [
 ]
 
 # Summary message for compliance
-message := helpers.get_multi_summary(conditions, vars.variables).message
+result := helpers.get_multi_summary(conditions, vars.variables)
+
+message := result.message
 
 # Detailed compliance info for debugging
-details := helpers.get_multi_summary(conditions, vars.variables).details
+details := result.details

--- a/policies/gcp/Chronicle/google_chronicle_rule/location.rego
+++ b/policies/gcp/Chronicle/google_chronicle_rule/location.rego
@@ -23,7 +23,9 @@ conditions := [
 ]
 
 # Summary message for compliance
-message := helpers.get_multi_summary(conditions, vars.variables).message
+result := helpers.get_multi_summary(conditions, vars.variables)
+
+message := result.message
 
 # Detailed compliance info for debugging
-details := helpers.get_multi_summary(conditions, vars.variables).details
+details := result.details

--- a/policies/gcp/Chronicle/google_chronicle_rule/scope.rego
+++ b/policies/gcp/Chronicle/google_chronicle_rule/scope.rego
@@ -40,6 +40,8 @@ conditions := [
   ]
 ]
 
-message := helpers.get_multi_summary(conditions, vars.variables).message
+result := helpers.get_multi_summary(conditions, vars.variables)
 
-details := helpers.get_multi_summary(conditions, vars.variables).details
+message := result.message
+
+details := result.details

--- a/policies/gcp/Chronicle/google_chronicle_rule_deployment/alerting.rego
+++ b/policies/gcp/Chronicle/google_chronicle_rule_deployment/alerting.rego
@@ -21,7 +21,9 @@ conditions := [
 ]
 
 # Message output when policy is evaluated
-message := helpers.get_multi_summary(conditions, vars.variables).message
+result := helpers.get_multi_summary(conditions, vars.variables)
+
+message := result.message
 
 # Detailed condition evaluation output
-details := helpers.get_multi_summary(conditions, vars.variables).details
+details := result.details

--- a/policies/gcp/Chronicle/google_chronicle_rule_deployment/enabled.rego
+++ b/policies/gcp/Chronicle/google_chronicle_rule_deployment/enabled.rego
@@ -22,7 +22,9 @@ conditions := [
 ]
 
 # General message summarizing policy compliance
-message := helpers.get_multi_summary(conditions, vars.variables).message
+result := helpers.get_multi_summary(conditions, vars.variables)
+
+message := result.message
 
 # Detailed summary for debugging
-details := helpers.get_multi_summary(conditions, vars.variables).details
+details := result.details

--- a/policies/gcp/Chronicle/google_chronicle_rule_deployment/location.rego
+++ b/policies/gcp/Chronicle/google_chronicle_rule_deployment/location.rego
@@ -23,7 +23,9 @@ conditions := [
 ]
 
 # Summary message for compliance
-message := helpers.get_multi_summary(conditions, vars.variables).message
+result := helpers.get_multi_summary(conditions, vars.variables)
+
+message := result.message
 
 # Detailed compliance info for debugging
-details := helpers.get_multi_summary(conditions, vars.variables).details
+details := result.details

--- a/policies/gcp/Chronicle/google_chronicle_watchlist/location.rego
+++ b/policies/gcp/Chronicle/google_chronicle_watchlist/location.rego
@@ -23,7 +23,9 @@ conditions := [
 ]
 
 # Summary message for compliance
-message := helpers.get_multi_summary(conditions, vars.variables).message
+result := helpers.get_multi_summary(conditions, vars.variables)
+
+message := result.message
 
 # Detailed compliance info for debugging
-details := helpers.get_multi_summary(conditions, vars.variables).details
+details := result.details

--- a/policies/gcp/Chronicle/google_chronicle_watchlist/multiplying_factor.rego
+++ b/policies/gcp/Chronicle/google_chronicle_watchlist/multiplying_factor.rego
@@ -21,5 +21,7 @@ conditions := [
     ]
 ]
 
-message := helpers.get_multi_summary(conditions, vars.variables).message
-details := helpers.get_multi_summary(conditions, vars.variables).details
+result := helpers.get_multi_summary(conditions, vars.variables)
+
+message := result.message
+details := result.details

--- a/policies/gcp/Cloud Deploy/google_clouddeploy_automation/service_account.rego
+++ b/policies/gcp/Cloud Deploy/google_clouddeploy_automation/service_account.rego
@@ -16,6 +16,8 @@ conditions := [
 ]
 
 
-message := helpers.get_multi_summary(conditions, vars.variables).message
+result := helpers.get_multi_summary(conditions, vars.variables)
 
-details := helpers.get_multi_summary(conditions, vars.variables).details
+message := result.message
+
+details := result.details

--- a/policies/gcp/Cloud Deploy/google_clouddeploy_automation/suspended.rego
+++ b/policies/gcp/Cloud Deploy/google_clouddeploy_automation/suspended.rego
@@ -15,6 +15,8 @@ conditions := [
     ]
 ]
 
-message := helpers.get_multi_summary(conditions, vars.variables).message
+result := helpers.get_multi_summary(conditions, vars.variables)
 
-details := helpers.get_multi_summary(conditions, vars.variables).details
+message := result.message
+
+details := result.details

--- a/policies/gcp/Cloud Deploy/google_clouddeploy_custom_target_type_iam_binding/members.rego
+++ b/policies/gcp/Cloud Deploy/google_clouddeploy_custom_target_type_iam_binding/members.rego
@@ -15,6 +15,8 @@ conditions := [
     ]
 ]
 
-message := helpers.get_multi_summary(conditions, vars.variables).message
+result := helpers.get_multi_summary(conditions, vars.variables)
 
-details := helpers.get_multi_summary(conditions, vars.variables).details
+message := result.message
+
+details := result.details

--- a/policies/gcp/Cloud Deploy/google_clouddeploy_custom_target_type_iam_binding/role.rego
+++ b/policies/gcp/Cloud Deploy/google_clouddeploy_custom_target_type_iam_binding/role.rego
@@ -15,6 +15,8 @@ conditions := [
   ]
 ]
 
-message := helpers.get_multi_summary(conditions, vars.variables).message
+result := helpers.get_multi_summary(conditions, vars.variables)
 
-details := helpers.get_multi_summary(conditions, vars.variables).details
+message := result.message
+
+details := result.details

--- a/policies/gcp/Cloud Deploy/google_clouddeploy_custom_target_type_iam_member/member.rego
+++ b/policies/gcp/Cloud Deploy/google_clouddeploy_custom_target_type_iam_member/member.rego
@@ -15,5 +15,7 @@ conditions := [
     ]
 ]
 
-message := helpers.get_multi_summary(conditions, vars.variables).message
-details := helpers.get_multi_summary(conditions, vars.variables).details
+result := helpers.get_multi_summary(conditions, vars.variables)
+
+message := result.message
+details := result.details

--- a/policies/gcp/Cloud Deploy/google_clouddeploy_custom_target_type_iam_member/role.rego
+++ b/policies/gcp/Cloud Deploy/google_clouddeploy_custom_target_type_iam_member/role.rego
@@ -15,6 +15,8 @@ conditions := [
   ]
 ]
 
-message := helpers.get_multi_summary(conditions, vars.variables).message
+result := helpers.get_multi_summary(conditions, vars.variables)
 
-details := helpers.get_multi_summary(conditions, vars.variables).details
+message := result.message
+
+details := result.details

--- a/policies/gcp/Cloud Deploy/google_clouddeploy_custom_target_type_iam_policy/policy_data.rego
+++ b/policies/gcp/Cloud Deploy/google_clouddeploy_custom_target_type_iam_policy/policy_data.rego
@@ -15,6 +15,8 @@ conditions := [
   ]
 ]
 
-message := helpers.get_multi_summary(conditions, vars.variables).message
+result := helpers.get_multi_summary(conditions, vars.variables)
 
-details := helpers.get_multi_summary(conditions, vars.variables).details
+message := result.message
+
+details := result.details

--- a/policies/gcp/Cloud Deploy/google_clouddeploy_delivery_pipeline/serial_pipeline.stages.target_id.rego
+++ b/policies/gcp/Cloud Deploy/google_clouddeploy_delivery_pipeline/serial_pipeline.stages.target_id.rego
@@ -15,6 +15,8 @@ conditions := [
     ]
 ]
 
-message := helpers.get_multi_summary(conditions, vars.variables).message
+result := helpers.get_multi_summary(conditions, vars.variables)
 
-details := helpers.get_multi_summary(conditions, vars.variables).details
+message := result.message
+
+details := result.details

--- a/policies/gcp/Cloud Deploy/google_clouddeploy_delivery_pipeline/suspended.rego
+++ b/policies/gcp/Cloud Deploy/google_clouddeploy_delivery_pipeline/suspended.rego
@@ -15,6 +15,8 @@ conditions := [
     ]
 ]
 
-message := helpers.get_multi_summary(conditions, vars.variables).message
+result := helpers.get_multi_summary(conditions, vars.variables)
 
-details := helpers.get_multi_summary(conditions, vars.variables).details
+message := result.message
+
+details := result.details

--- a/policies/gcp/Cloud Deploy/google_clouddeploy_delivery_pipeline_iam_binding/members.rego
+++ b/policies/gcp/Cloud Deploy/google_clouddeploy_delivery_pipeline_iam_binding/members.rego
@@ -15,5 +15,7 @@ conditions := [
     ]
 ]
 
-message := helpers.get_multi_summary(conditions, vars.variables).message
-details := helpers.get_multi_summary(conditions, vars.variables).details
+result := helpers.get_multi_summary(conditions, vars.variables)
+
+message := result.message
+details := result.details

--- a/policies/gcp/Cloud Deploy/google_clouddeploy_delivery_pipeline_iam_binding/role.rego
+++ b/policies/gcp/Cloud Deploy/google_clouddeploy_delivery_pipeline_iam_binding/role.rego
@@ -15,6 +15,8 @@ conditions := [
   ]
 ]
 
-message := helpers.get_multi_summary(conditions, vars.variables).message
+result := helpers.get_multi_summary(conditions, vars.variables)
 
-details := helpers.get_multi_summary(conditions, vars.variables).details
+message := result.message
+
+details := result.details

--- a/policies/gcp/Cloud Deploy/google_clouddeploy_delivery_pipeline_iam_member/member.rego
+++ b/policies/gcp/Cloud Deploy/google_clouddeploy_delivery_pipeline_iam_member/member.rego
@@ -15,5 +15,7 @@ conditions := [
     ]
 ]
 
-message := helpers.get_multi_summary(conditions, vars.variables).message
-details := helpers.get_multi_summary(conditions, vars.variables).details
+result := helpers.get_multi_summary(conditions, vars.variables)
+
+message := result.message
+details := result.details

--- a/policies/gcp/Cloud Deploy/google_clouddeploy_delivery_pipeline_iam_member/role.rego
+++ b/policies/gcp/Cloud Deploy/google_clouddeploy_delivery_pipeline_iam_member/role.rego
@@ -15,6 +15,8 @@ conditions := [
   ]
 ]
     
-message := helpers.get_multi_summary(conditions, vars.variables).message
+result := helpers.get_multi_summary(conditions, vars.variables)
 
-details := helpers.get_multi_summary(conditions, vars.variables).details
+message := result.message
+
+details := result.details

--- a/policies/gcp/Cloud Deploy/google_clouddeploy_delivery_pipeline_iam_policy/policy_data.rego
+++ b/policies/gcp/Cloud Deploy/google_clouddeploy_delivery_pipeline_iam_policy/policy_data.rego
@@ -15,6 +15,8 @@ conditions := [
   ]
 ]
 
-message := helpers.get_multi_summary(conditions, vars.variables).message
+result := helpers.get_multi_summary(conditions, vars.variables)
 
-details := helpers.get_multi_summary(conditions, vars.variables).details
+message := result.message
+
+details := result.details

--- a/policies/gcp/Cloud Deploy/google_clouddeploy_deploy_policy/suspended.rego
+++ b/policies/gcp/Cloud Deploy/google_clouddeploy_deploy_policy/suspended.rego
@@ -16,6 +16,8 @@ conditions := [
     ]
 ]
 
-message := helpers.get_multi_summary(conditions, vars.variables).message
+result := helpers.get_multi_summary(conditions, vars.variables)
 
-details := helpers.get_multi_summary(conditions, vars.variables).details
+message := result.message
+
+details := result.details

--- a/policies/gcp/Cloud Deploy/google_clouddeploy_target/gke.internal_ip.rego
+++ b/policies/gcp/Cloud Deploy/google_clouddeploy_target/gke.internal_ip.rego
@@ -15,5 +15,7 @@ conditions := [
     ]
 ]
 
-message := helpers.get_multi_summary(conditions, vars.variables).message
-details := helpers.get_multi_summary(conditions, vars.variables).details
+result := helpers.get_multi_summary(conditions, vars.variables)
+
+message := result.message
+details := result.details

--- a/policies/gcp/Cloud Deploy/google_clouddeploy_target/require_approval.rego
+++ b/policies/gcp/Cloud Deploy/google_clouddeploy_target/require_approval.rego
@@ -15,6 +15,8 @@ conditions := [
     ]
 ]
 
-message := helpers.get_multi_summary(conditions, vars.variables).message
+result := helpers.get_multi_summary(conditions, vars.variables)
 
-details := helpers.get_multi_summary(conditions, vars.variables).details
+message := result.message
+
+details := result.details

--- a/policies/gcp/Cloud Deploy/google_clouddeploy_target/run.location.rego
+++ b/policies/gcp/Cloud Deploy/google_clouddeploy_target/run.location.rego
@@ -21,6 +21,8 @@ conditions := [
     ]
 ]
 
-message := helpers.get_multi_summary(conditions, vars.variables).message
+result := helpers.get_multi_summary(conditions, vars.variables)
 
-details := helpers.get_multi_summary(conditions, vars.variables).details
+message := result.message
+
+details := result.details

--- a/policies/gcp/Cloud Deploy/google_clouddeploy_target_iam_binding/members.rego
+++ b/policies/gcp/Cloud Deploy/google_clouddeploy_target_iam_binding/members.rego
@@ -15,5 +15,7 @@ conditions := [
     ]
 ]
 
-message := helpers.get_multi_summary(conditions, vars.variables).message
-details := helpers.get_multi_summary(conditions, vars.variables).details
+result := helpers.get_multi_summary(conditions, vars.variables)
+
+message := result.message
+details := result.details

--- a/policies/gcp/Cloud Deploy/google_clouddeploy_target_iam_binding/role.rego
+++ b/policies/gcp/Cloud Deploy/google_clouddeploy_target_iam_binding/role.rego
@@ -15,6 +15,8 @@ conditions := [
   ]
 ]
 
-message := helpers.get_multi_summary(conditions, vars.variables).message
+result := helpers.get_multi_summary(conditions, vars.variables)
 
-details := helpers.get_multi_summary(conditions, vars.variables).details
+message := result.message
+
+details := result.details

--- a/policies/gcp/Cloud Deploy/google_clouddeploy_target_iam_member/member.rego
+++ b/policies/gcp/Cloud Deploy/google_clouddeploy_target_iam_member/member.rego
@@ -15,5 +15,7 @@ conditions := [
     ]
 ]
 
-message := helpers.get_multi_summary(conditions, vars.variables).message
-details := helpers.get_multi_summary(conditions, vars.variables).details
+result := helpers.get_multi_summary(conditions, vars.variables)
+
+message := result.message
+details := result.details

--- a/policies/gcp/Cloud Deploy/google_clouddeploy_target_iam_member/role.rego
+++ b/policies/gcp/Cloud Deploy/google_clouddeploy_target_iam_member/role.rego
@@ -15,6 +15,8 @@ conditions := [
   ]
 ]
 
-message := helpers.get_multi_summary(conditions, vars.variables).message
+result := helpers.get_multi_summary(conditions, vars.variables)
 
-details := helpers.get_multi_summary(conditions, vars.variables).details
+message := result.message
+
+details := result.details

--- a/policies/gcp/Cloud Deploy/google_clouddeploy_target_iam_policy/policy_data.rego
+++ b/policies/gcp/Cloud Deploy/google_clouddeploy_target_iam_policy/policy_data.rego
@@ -15,6 +15,8 @@ conditions := [
   ]
 ]
 
-message := helpers.get_multi_summary(conditions, vars.variables).message
+result := helpers.get_multi_summary(conditions, vars.variables)
 
-details := helpers.get_multi_summary(conditions, vars.variables).details
+message := result.message
+
+details := result.details

--- a/policies/gcp/Cloud Deployment Manager/google_deployment_manager_deployment/create_policy.rego
+++ b/policies/gcp/Cloud Deployment Manager/google_deployment_manager_deployment/create_policy.rego
@@ -19,4 +19,4 @@ conditions := [
 summary := helpers.get_multi_summary(conditions, vars.variables)
 message := summary.message
 
-details := helpers.get_multi_summary(conditions, vars.variables).details
+details := summary.details

--- a/policies/gcp/Cloud Deployment Manager/google_deployment_manager_deployment/delete_policy.rego
+++ b/policies/gcp/Cloud Deployment Manager/google_deployment_manager_deployment/delete_policy.rego
@@ -19,4 +19,4 @@ conditions := [
 summary := helpers.get_multi_summary(conditions, vars.variables)
 message := summary.message
 
-details := helpers.get_multi_summary(conditions, vars.variables).details
+details := summary.details

--- a/policies/gcp/Cloud Deployment Manager/google_deployment_manager_deployment/preview.rego
+++ b/policies/gcp/Cloud Deployment Manager/google_deployment_manager_deployment/preview.rego
@@ -19,4 +19,4 @@ conditions := [
 summary := helpers.get_multi_summary(conditions, vars.variables)
 message := summary.message
 
-details := helpers.get_multi_summary(conditions, vars.variables).details
+details := summary.details

--- a/policies/gcp/Cloud Functions (2nd gen)/google_cloudfunctions2_function/build_config.environment_variables.rego
+++ b/policies/gcp/Cloud Functions (2nd gen)/google_cloudfunctions2_function/build_config.environment_variables.rego
@@ -20,5 +20,7 @@ conditions := [
 ]
 
 # Generate message and details
-message := helpers.get_multi_summary(conditions, vars.variables).message
-details := helpers.get_multi_summary(conditions, vars.variables).details
+result := helpers.get_multi_summary(conditions, vars.variables)
+
+message := result.message
+details := result.details

--- a/policies/gcp/Cloud Functions (2nd gen)/google_cloudfunctions2_function/location.rego
+++ b/policies/gcp/Cloud Functions (2nd gen)/google_cloudfunctions2_function/location.rego
@@ -21,5 +21,7 @@ conditions := [
   ]
 ]
 
-message := helpers.get_multi_summary(conditions, vars.variables).message
-details := helpers.get_multi_summary(conditions, vars.variables).details
+result := helpers.get_multi_summary(conditions, vars.variables)
+
+message := result.message
+details := result.details

--- a/policies/gcp/Cloud Functions (2nd gen)/google_cloudfunctions2_function/service_config.ingress_settings.rego
+++ b/policies/gcp/Cloud Functions (2nd gen)/google_cloudfunctions2_function/service_config.ingress_settings.rego
@@ -20,5 +20,7 @@ conditions := [
   ]
 ]
 
-message := helpers.get_multi_summary(conditions, vars.variables).message
-details := helpers.get_multi_summary(conditions, vars.variables).details
+result := helpers.get_multi_summary(conditions, vars.variables)
+
+message := result.message
+details := result.details

--- a/policies/gcp/Cloud Functions (2nd gen)/google_cloudfunctions2_function/service_config.timeout_seconds.rego
+++ b/policies/gcp/Cloud Functions (2nd gen)/google_cloudfunctions2_function/service_config.timeout_seconds.rego
@@ -16,5 +16,7 @@ conditions := [
   ]
 ]
 
-message := helpers.get_multi_summary(conditions, vars.variables).message
-details := helpers.get_multi_summary(conditions, vars.variables).details
+result := helpers.get_multi_summary(conditions, vars.variables)
+
+message := result.message
+details := result.details

--- a/policies/gcp/Cloud Functions (2nd gen)/google_cloudfunctions2_function/service_config.vpc_connector.rego
+++ b/policies/gcp/Cloud Functions (2nd gen)/google_cloudfunctions2_function/service_config.vpc_connector.rego
@@ -22,5 +22,7 @@ conditions := [
   ]
 ]
 
-message := helpers.get_multi_summary(conditions, vars.variables).message
-details := helpers.get_multi_summary(conditions, vars.variables).details
+result := helpers.get_multi_summary(conditions, vars.variables)
+
+message := result.message
+details := result.details

--- a/policies/gcp/Cloud Healthcare/google_healthcare_consent_store/default_consent_ttl.rego
+++ b/policies/gcp/Cloud Healthcare/google_healthcare_consent_store/default_consent_ttl.rego
@@ -21,6 +21,8 @@ conditions := [
   ]
 ]
 
-message := helpers.get_multi_summary(conditions, vars.variables).message
+result := helpers.get_multi_summary(conditions, vars.variables)
 
-details := helpers.get_multi_summary(conditions, vars.variables).details
+message := result.message
+
+details := result.details

--- a/policies/gcp/Cloud Healthcare/google_healthcare_consent_store/enable_consent_create_on_update.rego
+++ b/policies/gcp/Cloud Healthcare/google_healthcare_consent_store/enable_consent_create_on_update.rego
@@ -21,6 +21,8 @@ conditions := [
   ]
 ]
 
-message := helpers.get_multi_summary(conditions, vars.variables).message
+result := helpers.get_multi_summary(conditions, vars.variables)
 
-details := helpers.get_multi_summary(conditions, vars.variables).details
+message := result.message
+
+details := result.details

--- a/policies/gcp/Cloud Healthcare/google_healthcare_consent_store/labels.rego
+++ b/policies/gcp/Cloud Healthcare/google_healthcare_consent_store/labels.rego
@@ -34,6 +34,8 @@ conditions := [
   ]
 ]
 
-message := helpers.get_multi_summary(conditions, vars.variables).message
+result := helpers.get_multi_summary(conditions, vars.variables)
 
-details := helpers.get_multi_summary(conditions, vars.variables).details
+message := result.message
+
+details := result.details

--- a/policies/gcp/Cloud Healthcare/google_healthcare_consent_store_iam_member/member.rego
+++ b/policies/gcp/Cloud Healthcare/google_healthcare_consent_store_iam_member/member.rego
@@ -21,6 +21,8 @@ conditions := [
   ]
 ]
 
-message := helpers.get_multi_summary(conditions, vars.variables).message
+result := helpers.get_multi_summary(conditions, vars.variables)
 
-details := helpers.get_multi_summary(conditions, vars.variables).details
+message := result.message
+
+details := result.details

--- a/policies/gcp/Cloud Healthcare/google_healthcare_consent_store_iam_member/role.rego
+++ b/policies/gcp/Cloud Healthcare/google_healthcare_consent_store_iam_member/role.rego
@@ -21,6 +21,8 @@ conditions := [
   ]
 ]
 
-message := helpers.get_multi_summary(conditions, vars.variables).message
+result := helpers.get_multi_summary(conditions, vars.variables)
 
-details := helpers.get_multi_summary(conditions, vars.variables).details
+message := result.message
+
+details := result.details

--- a/policies/gcp/Cloud Healthcare/google_healthcare_dataset/encryption_spec.kms_key_name.rego
+++ b/policies/gcp/Cloud Healthcare/google_healthcare_dataset/encryption_spec.kms_key_name.rego
@@ -21,6 +21,8 @@ conditions := [
   ]
 ]
 
-message := helpers.get_multi_summary(conditions, vars.variables).message
+result := helpers.get_multi_summary(conditions, vars.variables)
 
-details := helpers.get_multi_summary(conditions, vars.variables).details
+message := result.message
+
+details := result.details

--- a/policies/gcp/Cloud Healthcare/google_healthcare_dataset/location.rego
+++ b/policies/gcp/Cloud Healthcare/google_healthcare_dataset/location.rego
@@ -20,6 +20,8 @@ conditions := [
   ]
 ]
 
-message := helpers.get_multi_summary(conditions, vars.variables).message
+result := helpers.get_multi_summary(conditions, vars.variables)
 
-details := helpers.get_multi_summary(conditions, vars.variables).details
+message := result.message
+
+details := result.details

--- a/policies/gcp/Cloud Healthcare/google_healthcare_dataset_iam_member/member.rego
+++ b/policies/gcp/Cloud Healthcare/google_healthcare_dataset_iam_member/member.rego
@@ -21,6 +21,8 @@ conditions := [
   ]
 ]
 
-message := helpers.get_multi_summary(conditions, vars.variables).message
+result := helpers.get_multi_summary(conditions, vars.variables)
 
-details := helpers.get_multi_summary(conditions, vars.variables).details
+message := result.message
+
+details := result.details

--- a/policies/gcp/Cloud Healthcare/google_healthcare_dataset_iam_member/role.rego
+++ b/policies/gcp/Cloud Healthcare/google_healthcare_dataset_iam_member/role.rego
@@ -21,6 +21,8 @@ conditions := [
   ]
 ]
 
-message := helpers.get_multi_summary(conditions, vars.variables).message
+result := helpers.get_multi_summary(conditions, vars.variables)
 
-details := helpers.get_multi_summary(conditions, vars.variables).details
+message := result.message
+
+details := result.details

--- a/policies/gcp/Cloud Healthcare/google_healthcare_dicom_store/labels.rego
+++ b/policies/gcp/Cloud Healthcare/google_healthcare_dicom_store/labels.rego
@@ -34,6 +34,8 @@ conditions := [
   ]
 ]
 
-message := helpers.get_multi_summary(conditions, vars.variables).message
+result := helpers.get_multi_summary(conditions, vars.variables)
 
-details := helpers.get_multi_summary(conditions, vars.variables).details
+message := result.message
+
+details := result.details

--- a/policies/gcp/Cloud Healthcare/google_healthcare_dicom_store/notification_config.pubsub_topic.rego
+++ b/policies/gcp/Cloud Healthcare/google_healthcare_dicom_store/notification_config.pubsub_topic.rego
@@ -21,6 +21,8 @@ conditions := [
   ]
 ]
 
-message := helpers.get_multi_summary(conditions, vars.variables).message
+result := helpers.get_multi_summary(conditions, vars.variables)
 
-details := helpers.get_multi_summary(conditions, vars.variables).details
+message := result.message
+
+details := result.details

--- a/policies/gcp/Cloud Healthcare/google_healthcare_dicom_store_iam_member/member.rego
+++ b/policies/gcp/Cloud Healthcare/google_healthcare_dicom_store_iam_member/member.rego
@@ -21,6 +21,8 @@ conditions := [
   ]
 ]
 
-message := helpers.get_multi_summary(conditions, vars.variables).message
+result := helpers.get_multi_summary(conditions, vars.variables)
 
-details := helpers.get_multi_summary(conditions, vars.variables).details
+message := result.message
+
+details := result.details

--- a/policies/gcp/Cloud Healthcare/google_healthcare_dicom_store_iam_member/role.rego
+++ b/policies/gcp/Cloud Healthcare/google_healthcare_dicom_store_iam_member/role.rego
@@ -21,6 +21,8 @@ conditions := [
   ]
 ]
 
-message := helpers.get_multi_summary(conditions, vars.variables).message
+result := helpers.get_multi_summary(conditions, vars.variables)
 
-details := helpers.get_multi_summary(conditions, vars.variables).details
+message := result.message
+
+details := result.details

--- a/policies/gcp/Cloud Healthcare/google_healthcare_fhir_store/disable_resource_versioning.rego
+++ b/policies/gcp/Cloud Healthcare/google_healthcare_fhir_store/disable_resource_versioning.rego
@@ -21,6 +21,8 @@ conditions := [
   ]
 ]
 
-message := helpers.get_multi_summary(conditions, vars.variables).message
+result := helpers.get_multi_summary(conditions, vars.variables)
 
-details := helpers.get_multi_summary(conditions, vars.variables).details
+message := result.message
+
+details := result.details

--- a/policies/gcp/Cloud Healthcare/google_healthcare_fhir_store/enable_update_create.rego
+++ b/policies/gcp/Cloud Healthcare/google_healthcare_fhir_store/enable_update_create.rego
@@ -21,6 +21,8 @@ conditions := [
   ]
 ]
 
-message := helpers.get_multi_summary(conditions, vars.variables).message
+result := helpers.get_multi_summary(conditions, vars.variables)
 
-details := helpers.get_multi_summary(conditions, vars.variables).details
+message := result.message
+
+details := result.details

--- a/policies/gcp/Cloud Healthcare/google_healthcare_fhir_store/labels.rego
+++ b/policies/gcp/Cloud Healthcare/google_healthcare_fhir_store/labels.rego
@@ -34,6 +34,8 @@ conditions := [
   ]
 ]
 
-message := helpers.get_multi_summary(conditions, vars.variables).message
+result := helpers.get_multi_summary(conditions, vars.variables)
 
-details := helpers.get_multi_summary(conditions, vars.variables).details
+message := result.message
+
+details := result.details

--- a/policies/gcp/Cloud Healthcare/google_healthcare_fhir_store/version.rego
+++ b/policies/gcp/Cloud Healthcare/google_healthcare_fhir_store/version.rego
@@ -21,6 +21,8 @@ conditions := [
   ]
 ]
 
-message := helpers.get_multi_summary(conditions, vars.variables).message
+result := helpers.get_multi_summary(conditions, vars.variables)
 
-details := helpers.get_multi_summary(conditions, vars.variables).details
+message := result.message
+
+details := result.details

--- a/policies/gcp/Cloud Healthcare/google_healthcare_fhir_store_iam_member/member.rego
+++ b/policies/gcp/Cloud Healthcare/google_healthcare_fhir_store_iam_member/member.rego
@@ -21,6 +21,8 @@ conditions := [
   ]
 ]
 
-message := helpers.get_multi_summary(conditions, vars.variables).message
+result := helpers.get_multi_summary(conditions, vars.variables)
 
-details := helpers.get_multi_summary(conditions, vars.variables).details
+message := result.message
+
+details := result.details

--- a/policies/gcp/Cloud Healthcare/google_healthcare_fhir_store_iam_member/role.rego
+++ b/policies/gcp/Cloud Healthcare/google_healthcare_fhir_store_iam_member/role.rego
@@ -21,6 +21,8 @@ conditions := [
   ]
 ]
 
-message := helpers.get_multi_summary(conditions, vars.variables).message
+result := helpers.get_multi_summary(conditions, vars.variables)
 
-details := helpers.get_multi_summary(conditions, vars.variables).details
+message := result.message
+
+details := result.details

--- a/policies/gcp/Cloud Healthcare/google_healthcare_hl7_v2_store/labels.rego
+++ b/policies/gcp/Cloud Healthcare/google_healthcare_hl7_v2_store/labels.rego
@@ -34,6 +34,8 @@ conditions := [
   ]
 ]
 
-message := helpers.get_multi_summary(conditions, vars.variables).message
+result := helpers.get_multi_summary(conditions, vars.variables)
 
-details := helpers.get_multi_summary(conditions, vars.variables).details
+message := result.message
+
+details := result.details

--- a/policies/gcp/Cloud Healthcare/google_healthcare_hl7_v2_store/notification_configs.pubsub_topic.rego
+++ b/policies/gcp/Cloud Healthcare/google_healthcare_hl7_v2_store/notification_configs.pubsub_topic.rego
@@ -21,6 +21,8 @@ conditions := [
   ]
 ]
 
-message := helpers.get_multi_summary(conditions, vars.variables).message
+result := helpers.get_multi_summary(conditions, vars.variables)
 
-details := helpers.get_multi_summary(conditions, vars.variables).details
+message := result.message
+
+details := result.details

--- a/policies/gcp/Cloud Healthcare/google_healthcare_hl7_v2_store/reject_duplicate_message.rego
+++ b/policies/gcp/Cloud Healthcare/google_healthcare_hl7_v2_store/reject_duplicate_message.rego
@@ -21,6 +21,8 @@ conditions := [
   ]
 ]
 
-message := helpers.get_multi_summary(conditions, vars.variables).message
+result := helpers.get_multi_summary(conditions, vars.variables)
 
-details := helpers.get_multi_summary(conditions, vars.variables).details
+message := result.message
+
+details := result.details

--- a/policies/gcp/Cloud Healthcare/google_healthcare_hl7_v2_store_iam_member/member.rego
+++ b/policies/gcp/Cloud Healthcare/google_healthcare_hl7_v2_store_iam_member/member.rego
@@ -21,6 +21,8 @@ conditions := [
   ]
 ]
 
-message := helpers.get_multi_summary(conditions, vars.variables).message
+result := helpers.get_multi_summary(conditions, vars.variables)
 
-details := helpers.get_multi_summary(conditions, vars.variables).details
+message := result.message
+
+details := result.details

--- a/policies/gcp/Cloud Healthcare/google_healthcare_hl7_v2_store_iam_member/role.rego
+++ b/policies/gcp/Cloud Healthcare/google_healthcare_hl7_v2_store_iam_member/role.rego
@@ -21,6 +21,8 @@ conditions := [
   ]
 ]
 
-message := helpers.get_multi_summary(conditions, vars.variables).message
+result := helpers.get_multi_summary(conditions, vars.variables)
 
-details := helpers.get_multi_summary(conditions, vars.variables).details
+message := result.message
+
+details := result.details

--- a/policies/gcp/Cloud Healthcare/google_healthcare_pipeline_job/disable_lineage.rego
+++ b/policies/gcp/Cloud Healthcare/google_healthcare_pipeline_job/disable_lineage.rego
@@ -21,6 +21,8 @@ conditions := [
   ]
 ]
 
-message := helpers.get_multi_summary(conditions, vars.variables).message
+result := helpers.get_multi_summary(conditions, vars.variables)
 
-details := helpers.get_multi_summary(conditions, vars.variables).details
+message := result.message
+
+details := result.details

--- a/policies/gcp/Cloud Healthcare/google_healthcare_pipeline_job/labels.rego
+++ b/policies/gcp/Cloud Healthcare/google_healthcare_pipeline_job/labels.rego
@@ -34,6 +34,8 @@ conditions := [
   ]
 ]
 
-message := helpers.get_multi_summary(conditions, vars.variables).message
+result := helpers.get_multi_summary(conditions, vars.variables)
 
-details := helpers.get_multi_summary(conditions, vars.variables).details
+message := result.message
+
+details := result.details

--- a/policies/gcp/Cloud Healthcare/google_healthcare_workspace/labels.rego
+++ b/policies/gcp/Cloud Healthcare/google_healthcare_workspace/labels.rego
@@ -34,6 +34,8 @@ conditions := [
   ]
 ]
 
-message := helpers.get_multi_summary(conditions, vars.variables).message
+result := helpers.get_multi_summary(conditions, vars.variables)
 
-details := helpers.get_multi_summary(conditions, vars.variables).details
+message := result.message
+
+details := result.details

--- a/policies/gcp/Cloud Key Management Service/google_kms_crypto_key/destroy_scheduled_duration.rego
+++ b/policies/gcp/Cloud Key Management Service/google_kms_crypto_key/destroy_scheduled_duration.rego
@@ -17,5 +17,7 @@ conditions :=[
     ]
 ]
 
-message := helpers.get_multi_summary(conditions, vars.variables).message
-details := helpers.get_multi_summary(conditions, vars.variables).details
+result := helpers.get_multi_summary(conditions, vars.variables)
+
+message := result.message
+details := result.details

--- a/policies/gcp/Cloud Key Management Service/google_kms_crypto_key_version/state.rego
+++ b/policies/gcp/Cloud Key Management Service/google_kms_crypto_key_version/state.rego
@@ -20,6 +20,8 @@ conditions :=[
 
 ]
 
-message := helpers.get_multi_summary(conditions, vars.variables).message
-details := helpers.get_multi_summary(conditions, vars.variables).details
+result := helpers.get_multi_summary(conditions, vars.variables)
+
+message := result.message
+details := result.details
 

--- a/policies/gcp/Cloud Key Management Service/google_kms_key_ring/location.rego
+++ b/policies/gcp/Cloud Key Management Service/google_kms_key_ring/location.rego
@@ -15,5 +15,7 @@ conditions :=[
     ]
 ]
 
-message := helpers.get_multi_summary(conditions, vars.variables).message
-details := helpers.get_multi_summary(conditions, vars.variables).details
+result := helpers.get_multi_summary(conditions, vars.variables)
+
+message := result.message
+details := result.details

--- a/policies/gcp/Cloud Key Management Service/google_kms_key_ring_import_job/import_method.rego
+++ b/policies/gcp/Cloud Key Management Service/google_kms_key_ring_import_job/import_method.rego
@@ -41,5 +41,7 @@ conditions := [
 ]
 
 
-message := helpers.get_multi_summary(conditions, vars.variables).message
-details := helpers.get_multi_summary(conditions, vars.variables).details
+result := helpers.get_multi_summary(conditions, vars.variables)
+
+message := result.message
+details := result.details

--- a/policies/gcp/Cloud Key Management Service/google_kms_key_ring_import_job/protection_level.rego
+++ b/policies/gcp/Cloud Key Management Service/google_kms_key_ring_import_job/protection_level.rego
@@ -18,5 +18,7 @@ conditions := [
     ]
 ]
 
-message := helpers.get_multi_summary(conditions, vars.variables).message
-details := helpers.get_multi_summary(conditions, vars.variables).details
+result := helpers.get_multi_summary(conditions, vars.variables)
+
+message := result.message
+details := result.details

--- a/policies/gcp/Cloud Platform/google_folder/deletion_protection.rego
+++ b/policies/gcp/Cloud Platform/google_folder/deletion_protection.rego
@@ -18,5 +18,7 @@ conditions := [
 
 ]
 
-message := helpers.get_multi_summary(conditions, vars.variables).message
-details := helpers.get_multi_summary(conditions, vars.variables).details
+result := helpers.get_multi_summary(conditions, vars.variables)
+
+message := result.message
+details := result.details

--- a/policies/gcp/Cloud Platform/google_folder_iam_binding/role.rego
+++ b/policies/gcp/Cloud Platform/google_folder_iam_binding/role.rego
@@ -30,5 +30,7 @@ conditions := [
   ]
 ]
 
-message := helpers.get_multi_summary(conditions, vars.variables).message
-details := helpers.get_multi_summary(conditions, vars.variables).details
+result := helpers.get_multi_summary(conditions, vars.variables)
+
+message := result.message
+details := result.details

--- a/policies/gcp/Cloud Platform/google_folder_iam_member/role.rego
+++ b/policies/gcp/Cloud Platform/google_folder_iam_member/role.rego
@@ -17,6 +17,8 @@ conditions := [
 ]
 ]
 
-message := helpers.get_multi_summary(conditions, vars.variables).message
-details := helpers.get_multi_summary(conditions, vars.variables).details
+result := helpers.get_multi_summary(conditions, vars.variables)
+
+message := result.message
+details := result.details
 

--- a/policies/gcp/Cloud Platform/google_folder_iam_policy/policy_data.rego
+++ b/policies/gcp/Cloud Platform/google_folder_iam_policy/policy_data.rego
@@ -18,6 +18,8 @@ conditions := [
 ]
 
 
-message := helpers.get_multi_summary(conditions, vars.variables).message
-details := helpers.get_multi_summary(conditions, vars.variables).details
+result := helpers.get_multi_summary(conditions, vars.variables)
+
+message := result.message
+details := result.details
 

--- a/policies/gcp/Cloud Platform/google_folder_organization_policy/constraint.rego
+++ b/policies/gcp/Cloud Platform/google_folder_organization_policy/constraint.rego
@@ -44,5 +44,7 @@ conditions := [
 
 ]
 
-message := helpers.get_multi_summary(conditions, vars.variables).message
-details := helpers.get_multi_summary(conditions, vars.variables).details
+result := helpers.get_multi_summary(conditions, vars.variables)
+
+message := result.message
+details := result.details

--- a/policies/gcp/Cloud Platform/google_organization_iam_custom_role/stage.rego
+++ b/policies/gcp/Cloud Platform/google_organization_iam_custom_role/stage.rego
@@ -29,6 +29,8 @@ conditions := [
 
 ]
 
-message := helpers.get_multi_summary(conditions, vars.variables).message
-details := helpers.get_multi_summary(conditions, vars.variables).details
+result := helpers.get_multi_summary(conditions, vars.variables)
+
+message := result.message
+details := result.details
 

--- a/policies/gcp/Cloud Platform/google_project/auto_create_network.rego
+++ b/policies/gcp/Cloud Platform/google_project/auto_create_network.rego
@@ -21,6 +21,8 @@ conditions := [
 ]
  
 
-message := helpers.get_multi_summary(conditions, vars.variables).message
-details := helpers.get_multi_summary(conditions, vars.variables).details
+result := helpers.get_multi_summary(conditions, vars.variables)
+
+message := result.message
+details := result.details
 

--- a/policies/gcp/Cloud Platform/google_project/billing_account.rego
+++ b/policies/gcp/Cloud Platform/google_project/billing_account.rego
@@ -20,6 +20,8 @@ conditions := [
 ]
  
 
-message := helpers.get_multi_summary(conditions, vars.variables).message
-details := helpers.get_multi_summary(conditions, vars.variables).details
+result := helpers.get_multi_summary(conditions, vars.variables)
+
+message := result.message
+details := result.details
 

--- a/policies/gcp/Cloud Platform/google_project/deletion_policy.rego
+++ b/policies/gcp/Cloud Platform/google_project/deletion_policy.rego
@@ -20,6 +20,8 @@ conditions := [
 ]
  
 
-message := helpers.get_multi_summary(conditions, vars.variables).message
-details := helpers.get_multi_summary(conditions, vars.variables).details
+result := helpers.get_multi_summary(conditions, vars.variables)
+
+message := result.message
+details := result.details
 

--- a/policies/gcp/Cloud Platform/google_project/labels.rego
+++ b/policies/gcp/Cloud Platform/google_project/labels.rego
@@ -19,5 +19,7 @@ conditions := [
   ]
 ]
 
-message := helpers.get_multi_summary(conditions, vars.variables).message
-details := helpers.get_multi_summary(conditions, vars.variables).details
+result := helpers.get_multi_summary(conditions, vars.variables)
+
+message := result.message
+details := result.details

--- a/policies/gcp/Cloud Platform/google_project/project_id.rego
+++ b/policies/gcp/Cloud Platform/google_project/project_id.rego
@@ -18,6 +18,8 @@ conditions := [
 ]
  
 
-message := helpers.get_multi_summary(conditions, vars.variables).message
-details := helpers.get_multi_summary(conditions, vars.variables).details
+result := helpers.get_multi_summary(conditions, vars.variables)
+
+message := result.message
+details := result.details
 

--- a/policies/gcp/Cloud Platform/google_project/tags.rego
+++ b/policies/gcp/Cloud Platform/google_project/tags.rego
@@ -19,6 +19,8 @@ conditions := [
   ]
 ]
  
-message := helpers.get_multi_summary(conditions, vars.variables).message
-details := helpers.get_multi_summary(conditions, vars.variables).details
+result := helpers.get_multi_summary(conditions, vars.variables)
+
+message := result.message
+details := result.details
 

--- a/policies/gcp/Cloud Platform/google_project_service/service.rego
+++ b/policies/gcp/Cloud Platform/google_project_service/service.rego
@@ -19,6 +19,8 @@ conditions := [
    ]
 ]
  
-message := helpers.get_multi_summary(conditions, vars.variables).message
-details := helpers.get_multi_summary(conditions, vars.variables).details
+result := helpers.get_multi_summary(conditions, vars.variables)
+
+message := result.message
+details := result.details
 

--- a/policies/gcp/Cloud Platform/google_service_account/account_id.rego
+++ b/policies/gcp/Cloud Platform/google_service_account/account_id.rego
@@ -17,6 +17,8 @@ conditions := [
   ]
 ]
  
-message := helpers.get_multi_summary(conditions, vars.variables).message
-details := helpers.get_multi_summary(conditions, vars.variables).details
+result := helpers.get_multi_summary(conditions, vars.variables)
+
+message := result.message
+details := result.details
 

--- a/policies/gcp/Cloud Platform/google_service_account/description.rego
+++ b/policies/gcp/Cloud Platform/google_service_account/description.rego
@@ -17,6 +17,8 @@ conditions := [
   ]
 ]
 
-message := helpers.get_multi_summary(conditions, vars.variables).message
-details := helpers.get_multi_summary(conditions, vars.variables).details
+result := helpers.get_multi_summary(conditions, vars.variables)
+
+message := result.message
+details := result.details
 

--- a/policies/gcp/Cloud Platform/google_service_account/disabled.rego
+++ b/policies/gcp/Cloud Platform/google_service_account/disabled.rego
@@ -15,6 +15,8 @@ conditions := [
   ]
 ]
  
-message := helpers.get_multi_summary(conditions, vars.variables).message
-details := helpers.get_multi_summary(conditions, vars.variables).details
+result := helpers.get_multi_summary(conditions, vars.variables)
+
+message := result.message
+details := result.details
 

--- a/policies/gcp/Cloud Platform/google_service_account/display_name.rego
+++ b/policies/gcp/Cloud Platform/google_service_account/display_name.rego
@@ -15,6 +15,8 @@ conditions := [
   ]
 ]
  
-message := helpers.get_multi_summary(conditions, vars.variables).message
-details := helpers.get_multi_summary(conditions, vars.variables).details
+result := helpers.get_multi_summary(conditions, vars.variables)
+
+message := result.message
+details := result.details
 

--- a/policies/gcp/Cloud Pub__Sub/google_pubsub_schema/type.rego
+++ b/policies/gcp/Cloud Pub__Sub/google_pubsub_schema/type.rego
@@ -21,5 +21,5 @@ conditions := [
 ]
 
 result = helpers.get_multi_summary(conditions, vars.variables)
-message = result.message
-details = result.details
+message := result.message
+details := result.details

--- a/policies/gcp/Cloud Pub__Sub/google_pubsub_subscription/enable_exactly_once_delivery.rego
+++ b/policies/gcp/Cloud Pub__Sub/google_pubsub_subscription/enable_exactly_once_delivery.rego
@@ -21,5 +21,5 @@ conditions := [
 ]
 
 result = helpers.get_multi_summary(conditions, vars.variables)
-message = result.message
-details = result.details
+message := result.message
+details := result.details

--- a/policies/gcp/Cloud Pub__Sub/google_pubsub_subscription_iam_binding/members.rego
+++ b/policies/gcp/Cloud Pub__Sub/google_pubsub_subscription_iam_binding/members.rego
@@ -21,5 +21,5 @@ conditions := [
 ]
 
 result = helpers.get_multi_summary(conditions, vars.variables)
-message = result.message
-details = result.details
+message := result.message
+details := result.details

--- a/policies/gcp/Cloud Pub__Sub/google_pubsub_topic/kms_key_name.rego
+++ b/policies/gcp/Cloud Pub__Sub/google_pubsub_topic/kms_key_name.rego
@@ -21,5 +21,5 @@ conditions := [
 ]
 
 result = helpers.get_multi_summary(conditions, vars.variables)
-message = result.message
-details = result.details
+message := result.message
+details := result.details

--- a/policies/gcp/Cloud Pub__Sub/google_pubsub_topic_iam_binding/members.rego
+++ b/policies/gcp/Cloud Pub__Sub/google_pubsub_topic_iam_binding/members.rego
@@ -21,5 +21,5 @@ conditions := [
 ]
 
 result = helpers.get_multi_summary(conditions, vars.variables)
-message = result.message
-details = result.details
+message := result.message
+details := result.details

--- a/policies/gcp/Cloud Quotas/google_cloud_quotas_quota_preference/contact_email.rego
+++ b/policies/gcp/Cloud Quotas/google_cloud_quotas_quota_preference/contact_email.rego
@@ -24,5 +24,7 @@ conditions := [
     ]
 ]
 
-message := helpers.get_multi_summary(conditions, vars.variables).message
-details := helpers.get_multi_summary(conditions, vars.variables).details
+result := helpers.get_multi_summary(conditions, vars.variables)
+
+message := result.message
+details := result.details

--- a/policies/gcp/Cloud Quotas/google_cloud_quotas_quota_preference/dimensions.rego
+++ b/policies/gcp/Cloud Quotas/google_cloud_quotas_quota_preference/dimensions.rego
@@ -24,5 +24,7 @@ conditions := [
     ]
 ]
 
-message := helpers.get_multi_summary(conditions, vars.variables).message
-details := helpers.get_multi_summary(conditions, vars.variables).details
+result := helpers.get_multi_summary(conditions, vars.variables)
+
+message := result.message
+details := result.details

--- a/policies/gcp/Cloud Quotas/google_cloud_quotas_quota_preference/ignore_safety_checks.rego
+++ b/policies/gcp/Cloud Quotas/google_cloud_quotas_quota_preference/ignore_safety_checks.rego
@@ -24,5 +24,7 @@ conditions := [
     ]
 ]
 
-message := helpers.get_multi_summary(conditions, vars.variables).message
-details := helpers.get_multi_summary(conditions, vars.variables).details
+result := helpers.get_multi_summary(conditions, vars.variables)
+
+message := result.message
+details := result.details

--- a/policies/gcp/Cloud Quotas/google_cloud_quotas_quota_preference/justification.rego
+++ b/policies/gcp/Cloud Quotas/google_cloud_quotas_quota_preference/justification.rego
@@ -23,5 +23,7 @@ conditions := [
     ]
 ]
 
-message := helpers.get_multi_summary(conditions, vars.variables).message
-details := helpers.get_multi_summary(conditions, vars.variables).details
+result := helpers.get_multi_summary(conditions, vars.variables)
+
+message := result.message
+details := result.details

--- a/policies/gcp/Cloud Quotas/google_cloud_quotas_quota_preference/parent.rego
+++ b/policies/gcp/Cloud Quotas/google_cloud_quotas_quota_preference/parent.rego
@@ -24,5 +24,7 @@ conditions := [
     ]
 ]
 
-message := helpers.get_multi_summary(conditions, vars.variables).message
-details := helpers.get_multi_summary(conditions, vars.variables).details
+result := helpers.get_multi_summary(conditions, vars.variables)
+
+message := result.message
+details := result.details

--- a/policies/gcp/Cloud Quotas/google_cloud_quotas_quota_preference/quota_config.preferred_value.rego
+++ b/policies/gcp/Cloud Quotas/google_cloud_quotas_quota_preference/quota_config.preferred_value.rego
@@ -21,5 +21,7 @@ conditions := [
     ]
 ]
 
-message := helpers.get_multi_summary(conditions, vars.variables).message
-details := helpers.get_multi_summary(conditions, vars.variables).details
+result := helpers.get_multi_summary(conditions, vars.variables)
+
+message := result.message
+details := result.details

--- a/policies/gcp/Cloud Quotas/google_cloud_quotas_quota_preference/quota_id.rego
+++ b/policies/gcp/Cloud Quotas/google_cloud_quotas_quota_preference/quota_id.rego
@@ -23,5 +23,7 @@ conditions := [
     ]
 ]
 
-message := helpers.get_multi_summary(conditions, vars.variables).message
-details := helpers.get_multi_summary(conditions, vars.variables).details
+result := helpers.get_multi_summary(conditions, vars.variables)
+
+message := result.message
+details := result.details

--- a/policies/gcp/Cloud Quotas/google_cloud_quotas_quota_preference/service.rego
+++ b/policies/gcp/Cloud Quotas/google_cloud_quotas_quota_preference/service.rego
@@ -22,5 +22,7 @@ conditions := [
     ]
 ]
 
-message := helpers.get_multi_summary(conditions, vars.variables).message
-details := helpers.get_multi_summary(conditions, vars.variables).details
+result := helpers.get_multi_summary(conditions, vars.variables)
+
+message := result.message
+details := result.details

--- a/policies/gcp/Cloud Spanner/google_spanner_backup_schedule/encryption_config.encryption_type.rego
+++ b/policies/gcp/Cloud Spanner/google_spanner_backup_schedule/encryption_config.encryption_type.rego
@@ -22,5 +22,5 @@ conditions := [
 
 summary := helpers.get_multi_summary(conditions, vars.variables)
 
-message := helpers.get_multi_summary(conditions, vars.variables).message
-details := helpers.get_multi_summary(conditions, vars.variables).details
+message := summary.message
+details := summary.details

--- a/policies/gcp/Cloud Spanner/google_spanner_database/enable_drop_protection.rego
+++ b/policies/gcp/Cloud Spanner/google_spanner_database/enable_drop_protection.rego
@@ -22,5 +22,5 @@ conditions := [
 
 summary := helpers.get_multi_summary(conditions, vars.variables)
 
-message := helpers.get_multi_summary(conditions, vars.variables).message
-details := helpers.get_multi_summary(conditions, vars.variables).details
+message := summary.message
+details := summary.details

--- a/policies/gcp/Cloud Spanner/google_spanner_database_iam_binding/members.rego
+++ b/policies/gcp/Cloud Spanner/google_spanner_database_iam_binding/members.rego
@@ -21,5 +21,5 @@ conditions := [
 ]
 
 summary := helpers.get_multi_summary(conditions, vars.variables)
-message := helpers.get_multi_summary(conditions, vars.variables).message
-details := helpers.get_multi_summary(conditions, vars.variables).details
+message := summary.message
+details := summary.details

--- a/policies/gcp/Cloud Spanner/google_spanner_database_iam_member/member.rego
+++ b/policies/gcp/Cloud Spanner/google_spanner_database_iam_member/member.rego
@@ -21,5 +21,5 @@ conditions := [
 ]
 
 summary := helpers.get_multi_summary(conditions, vars.variables)
-message := helpers.get_multi_summary(conditions, vars.variables).message
-details := helpers.get_multi_summary(conditions, vars.variables).details
+message := summary.message
+details := summary.details

--- a/policies/gcp/Cloud Spanner/google_spanner_database_iam_policy/policy_data.rego
+++ b/policies/gcp/Cloud Spanner/google_spanner_database_iam_policy/policy_data.rego
@@ -18,5 +18,5 @@ conditions := [
   ]
 ]
 summary := helpers.get_multi_summary(conditions, vars.variables)
-message := helpers.get_multi_summary(conditions, vars.variables).message
-details := helpers.get_multi_summary(conditions, vars.variables).details
+message := summary.message
+details := summary.details

--- a/policies/gcp/Cloud Spanner/google_spanner_instance/config.rego
+++ b/policies/gcp/Cloud Spanner/google_spanner_instance/config.rego
@@ -21,5 +21,5 @@ conditions := [
 ]
 
 summary := helpers.get_multi_summary(conditions, vars.variables)
-message := helpers.get_multi_summary(conditions, vars.variables).message
-details := helpers.get_multi_summary(conditions, vars.variables).details
+message := summary.message
+details := summary.details

--- a/policies/gcp/Cloud Spanner/google_spanner_instance/default_backup_schedule_type.rego
+++ b/policies/gcp/Cloud Spanner/google_spanner_instance/default_backup_schedule_type.rego
@@ -21,5 +21,5 @@ conditions := [
 ]
 
 summary := helpers.get_multi_summary(conditions, vars.variables)
-message := helpers.get_multi_summary(conditions, vars.variables).message
-details := helpers.get_multi_summary(conditions, vars.variables).details
+message := summary.message
+details := summary.details

--- a/policies/gcp/Cloud Spanner/google_spanner_instance/force_destroy.rego
+++ b/policies/gcp/Cloud Spanner/google_spanner_instance/force_destroy.rego
@@ -20,7 +20,7 @@ conditions := [
   ]
 ]
 
-summary := helpers.get_multi_summary(conditions, vars.variables)
+summary := result
 
 result := helpers.get_multi_summary(conditions, vars.variables)
 message := result.message

--- a/policies/gcp/Cloud Spanner/google_spanner_instance_iam_binding/members.rego
+++ b/policies/gcp/Cloud Spanner/google_spanner_instance_iam_binding/members.rego
@@ -22,5 +22,5 @@ conditions := [
 
 summary := helpers.get_multi_summary(conditions, vars.variables)
 
-message := helpers.get_multi_summary(conditions, vars.variables).message
-details := helpers.get_multi_summary(conditions, vars.variables).details
+message := summary.message
+details := summary.details

--- a/policies/gcp/Cloud Spanner/google_spanner_instance_iam_member/member.rego
+++ b/policies/gcp/Cloud Spanner/google_spanner_instance_iam_member/member.rego
@@ -22,5 +22,5 @@ conditions := [
 
 summary := helpers.get_multi_summary(conditions, vars.variables)
 
-message := helpers.get_multi_summary(conditions, vars.variables).message
-details := helpers.get_multi_summary(conditions, vars.variables).details
+message := summary.message
+details := summary.details

--- a/policies/gcp/Cloud Spanner/google_spanner_instance_iam_policy/policy_data.rego
+++ b/policies/gcp/Cloud Spanner/google_spanner_instance_iam_policy/policy_data.rego
@@ -18,5 +18,5 @@ conditions := [
   ]
 ]
 summary := helpers.get_multi_summary(conditions, vars.variables)
-message := helpers.get_multi_summary(conditions, vars.variables).message
-details := helpers.get_multi_summary(conditions, vars.variables).details
+message := summary.message
+details := summary.details

--- a/policies/gcp/Cloud Storage Batch Operations/google_storage_batch_operations_job/bucket_list.buckets.prefix_list.included_object_prefixes.rego
+++ b/policies/gcp/Cloud Storage Batch Operations/google_storage_batch_operations_job/bucket_list.buckets.prefix_list.included_object_prefixes.rego
@@ -19,5 +19,7 @@ conditions := [[
     }
 ]]
 
-message := helpers.get_multi_summary(conditions, vars.variables).message
-details := helpers.get_multi_summary(conditions, vars.variables).details
+result := helpers.get_multi_summary(conditions, vars.variables)
+
+message := result.message
+details := result.details

--- a/policies/gcp/Cloud Storage Batch Operations/google_storage_batch_operations_job/delete_object.permanent_object_deletion_enabled.rego
+++ b/policies/gcp/Cloud Storage Batch Operations/google_storage_batch_operations_job/delete_object.permanent_object_deletion_enabled.rego
@@ -19,5 +19,7 @@ conditions := [[
         }
 ]]
 
-message := helpers.get_multi_summary(conditions, vars.variables).message
-details := helpers.get_multi_summary(conditions, vars.variables).details
+result := helpers.get_multi_summary(conditions, vars.variables)
+
+message := result.message
+details := result.details

--- a/policies/gcp/Cloud Storage Batch Operations/google_storage_batch_operations_job/put_object_hold.event_based_hold.rego
+++ b/policies/gcp/Cloud Storage Batch Operations/google_storage_batch_operations_job/put_object_hold.event_based_hold.rego
@@ -20,5 +20,7 @@ conditions := [[
         }
 ]]
 
-message := helpers.get_multi_summary(conditions, vars.variables).message
-details := helpers.get_multi_summary(conditions, vars.variables).details
+result := helpers.get_multi_summary(conditions, vars.variables)
+
+message := result.message
+details := result.details

--- a/policies/gcp/Cloud Storage Batch Operations/google_storage_batch_operations_job/rewrite_object.kms_key.rego
+++ b/policies/gcp/Cloud Storage Batch Operations/google_storage_batch_operations_job/rewrite_object.kms_key.rego
@@ -19,5 +19,7 @@ conditions := [[
     }
 ]]
 
-message := helpers.get_multi_summary(conditions, vars.variables).message
-details := helpers.get_multi_summary(conditions, vars.variables).details
+result := helpers.get_multi_summary(conditions, vars.variables)
+
+message := result.message
+details := result.details

--- a/policies/gcp/Cloud Storage/google_storage_anywhere_cache/zone.rego
+++ b/policies/gcp/Cloud Storage/google_storage_anywhere_cache/zone.rego
@@ -19,5 +19,5 @@ conditions := [
 ]
 summary := helpers.get_multi_summary(conditions, vars.variables)
 
-message := helpers.get_multi_summary(conditions, vars.variables).message
-details := helpers.get_multi_summary(conditions, vars.variables).details
+message := summary.message
+details := summary.details

--- a/policies/gcp/Cloud Storage/google_storage_bucket/force_destroy.rego
+++ b/policies/gcp/Cloud Storage/google_storage_bucket/force_destroy.rego
@@ -24,7 +24,7 @@ conditions := [
 summary := helpers.get_multi_summary(conditions, vars.variables)
 
 # Message summary
-message := helpers.get_multi_summary(conditions, vars.variables).message
+message := summary.message
 
 # Detailed condition-wise results
-details := helpers.get_multi_summary(conditions, vars.variables).details
+details := summary.details

--- a/policies/gcp/Cloud Storage/google_storage_bucket/ip_filter.public_network_source.allowed_ip_cidr_ranges.rego
+++ b/policies/gcp/Cloud Storage/google_storage_bucket/ip_filter.public_network_source.allowed_ip_cidr_ranges.rego
@@ -20,5 +20,5 @@ conditions := [
 
 summary := helpers.get_multi_summary(conditions, vars.variables)
 
-message := helpers.get_multi_summary(conditions, vars.variables).message
-details := helpers.get_multi_summary(conditions, vars.variables).details
+message := summary.message
+details := summary.details

--- a/policies/gcp/Cloud Storage/google_storage_bucket/location.rego
+++ b/policies/gcp/Cloud Storage/google_storage_bucket/location.rego
@@ -23,4 +23,4 @@ conditions := [
 summary := helpers.get_multi_summary(conditions, vars.variables)
 message := summary.message
 
-details := helpers.get_multi_summary(conditions, vars.variables).details
+details := summary.details

--- a/policies/gcp/Cloud Storage/google_storage_bucket/public_access_prevention.rego
+++ b/policies/gcp/Cloud Storage/google_storage_bucket/public_access_prevention.rego
@@ -20,5 +20,5 @@ conditions := [
 
 summary := helpers.get_multi_summary(conditions, vars.variables)
 
-message := helpers.get_multi_summary(conditions, vars.variables).message
-details := helpers.get_multi_summary(conditions, vars.variables).details
+message := summary.message
+details := summary.details

--- a/policies/gcp/Cloud Storage/google_storage_bucket/retention_policy.is_locked.rego
+++ b/policies/gcp/Cloud Storage/google_storage_bucket/retention_policy.is_locked.rego
@@ -21,5 +21,5 @@ conditions := [
 summary := helpers.get_multi_summary(conditions, vars.variables)
 
 
-message := helpers.get_multi_summary(conditions, vars.variables).message
-details := helpers.get_multi_summary(conditions, vars.variables).details
+message := summary.message
+details := summary.details

--- a/policies/gcp/Cloud Storage/google_storage_bucket/retention_policy.retention_period.rego
+++ b/policies/gcp/Cloud Storage/google_storage_bucket/retention_policy.retention_period.rego
@@ -21,5 +21,5 @@ conditions := [
 summary := helpers.get_multi_summary(conditions, vars.variables)
 
 
-message := helpers.get_multi_summary(conditions, vars.variables).message
-details := helpers.get_multi_summary(conditions, vars.variables).details
+message := summary.message
+details := summary.details

--- a/policies/gcp/Cloud Storage/google_storage_bucket/uniform_bucket_level_access.rego
+++ b/policies/gcp/Cloud Storage/google_storage_bucket/uniform_bucket_level_access.rego
@@ -20,5 +20,5 @@ conditions := [
 
 summary := helpers.get_multi_summary(conditions, vars.variables)
 
-message := helpers.get_multi_summary(conditions, vars.variables).message
-details := helpers.get_multi_summary(conditions, vars.variables).details
+message := summary.message
+details := summary.details

--- a/policies/gcp/Cloud Storage/google_storage_bucket_access_control/entity.rego
+++ b/policies/gcp/Cloud Storage/google_storage_bucket_access_control/entity.rego
@@ -23,5 +23,5 @@ conditions := [
 
 summary := helpers.get_multi_summary(conditions, vars.variables)
 
-message := helpers.get_multi_summary(conditions, vars.variables).message
-details := helpers.get_multi_summary(conditions, vars.variables).details
+message := summary.message
+details := summary.details

--- a/policies/gcp/Cloud Storage/google_storage_bucket_acl/role_entity.rego
+++ b/policies/gcp/Cloud Storage/google_storage_bucket_acl/role_entity.rego
@@ -28,5 +28,5 @@ conditions := [
 
 summary := helpers.get_multi_summary(conditions, vars.variables)
 
-message := helpers.get_multi_summary(conditions, vars.variables).message
-details := helpers.get_multi_summary(conditions, vars.variables).details
+message := summary.message
+details := summary.details

--- a/policies/gcp/Cloud Storage/google_storage_bucket_iam_binding/members.rego
+++ b/policies/gcp/Cloud Storage/google_storage_bucket_iam_binding/members.rego
@@ -23,5 +23,5 @@ conditions := [
 
 summary := helpers.get_multi_summary(conditions, vars.variables)
 
-message := helpers.get_multi_summary(conditions, vars.variables).message
-details := helpers.get_multi_summary(conditions, vars.variables).details
+message := summary.message
+details := summary.details

--- a/policies/gcp/Cloud Storage/google_storage_bucket_iam_member/member.rego
+++ b/policies/gcp/Cloud Storage/google_storage_bucket_iam_member/member.rego
@@ -23,5 +23,5 @@ conditions := [
 
 summary := helpers.get_multi_summary(conditions, vars.variables)
 
-message := helpers.get_multi_summary(conditions, vars.variables).message
-details := helpers.get_multi_summary(conditions, vars.variables).details
+message := summary.message
+details := summary.details

--- a/policies/gcp/Cloud Storage/google_storage_bucket_object/kms_key_name.rego
+++ b/policies/gcp/Cloud Storage/google_storage_bucket_object/kms_key_name.rego
@@ -27,6 +27,6 @@ conditions := [
 
 summary := helpers.get_multi_summary(conditions, vars.variables)
 
-message := helpers.get_multi_summary(conditions, vars.variables).message
+message := summary.message
 
-details := helpers.get_multi_summary(conditions, vars.variables).details
+details := summary.details

--- a/policies/gcp/Cloud Storage/google_storage_default_object_access_control/entity.rego
+++ b/policies/gcp/Cloud Storage/google_storage_default_object_access_control/entity.rego
@@ -22,5 +22,5 @@ conditions := [
 
 summary := helpers.get_multi_summary(conditions, vars.variables)
 
-message := helpers.get_multi_summary(conditions, vars.variables).message
-details := helpers.get_multi_summary(conditions, vars.variables).details
+message := summary.message
+details := summary.details

--- a/policies/gcp/Cloud Storage/google_storage_default_object_acl/role_entity.rego
+++ b/policies/gcp/Cloud Storage/google_storage_default_object_acl/role_entity.rego
@@ -23,5 +23,5 @@ conditions := [
 
 summary := helpers.get_multi_summary(conditions, vars.variables)
 
-message := helpers.get_multi_summary(conditions, vars.variables).message
-details := helpers.get_multi_summary(conditions, vars.variables).details
+message := summary.message
+details := summary.details

--- a/policies/gcp/Cloud Storage/google_storage_folder/force_destroy.rego
+++ b/policies/gcp/Cloud Storage/google_storage_folder/force_destroy.rego
@@ -23,6 +23,6 @@ conditions := [
 
 summary := helpers.get_multi_summary(conditions, vars.variables)
 
-message := helpers.get_multi_summary(conditions, vars.variables).message
+message := summary.message
 
-details := helpers.get_multi_summary(conditions, vars.variables).details
+details := summary.details

--- a/policies/gcp/Cloud Storage/google_storage_managed_folder/force_destroy.rego
+++ b/policies/gcp/Cloud Storage/google_storage_managed_folder/force_destroy.rego
@@ -21,6 +21,6 @@ conditions := [
 
 summary := helpers.get_multi_summary(conditions, vars.variables)
 
-message := helpers.get_multi_summary(conditions, vars.variables).message
+message := summary.message
 
-details := helpers.get_multi_summary(conditions, vars.variables).details
+details := summary.details

--- a/policies/gcp/Cloud Storage/google_storage_managed_folder_iam_binding/members.rego
+++ b/policies/gcp/Cloud Storage/google_storage_managed_folder_iam_binding/members.rego
@@ -23,5 +23,5 @@ conditions := [
 
 summary := helpers.get_multi_summary(conditions, vars.variables)
 
-message := helpers.get_multi_summary(conditions, vars.variables).message
-details := helpers.get_multi_summary(conditions, vars.variables).details
+message := summary.message
+details := summary.details

--- a/policies/gcp/Cloud Storage/google_storage_managed_folder_iam_member/member.rego
+++ b/policies/gcp/Cloud Storage/google_storage_managed_folder_iam_member/member.rego
@@ -23,5 +23,5 @@ conditions := [
 
 summary := helpers.get_multi_summary(conditions, vars.variables)
 
-message := helpers.get_multi_summary(conditions, vars.variables).message
-details := helpers.get_multi_summary(conditions, vars.variables).details
+message := summary.message
+details := summary.details

--- a/policies/gcp/Cloud Storage/google_storage_object_access_control/entity.rego
+++ b/policies/gcp/Cloud Storage/google_storage_object_access_control/entity.rego
@@ -23,5 +23,5 @@ conditions := [
 
 summary := helpers.get_multi_summary(conditions, vars.variables)
 
-message := helpers.get_multi_summary(conditions, vars.variables).message
-details := helpers.get_multi_summary(conditions, vars.variables).details
+message := summary.message
+details := summary.details

--- a/policies/gcp/Cloud Storage/google_storage_object_acl/predefined_acl.rego
+++ b/policies/gcp/Cloud Storage/google_storage_object_acl/predefined_acl.rego
@@ -22,5 +22,5 @@ conditions := [
 
 summary := helpers.get_multi_summary(conditions, vars.variables)
 
-message := helpers.get_multi_summary(conditions, vars.variables).message
-details := helpers.get_multi_summary(conditions, vars.variables).details
+message := summary.message
+details := summary.details

--- a/policies/gcp/Cloud Storage/google_storage_object_acl/role_entity.rego
+++ b/policies/gcp/Cloud Storage/google_storage_object_acl/role_entity.rego
@@ -23,5 +23,5 @@ conditions := [
 
 summary := helpers.get_multi_summary(conditions, vars.variables)
 
-message := helpers.get_multi_summary(conditions, vars.variables).message
-details := helpers.get_multi_summary(conditions, vars.variables).details
+message := summary.message
+details := summary.details

--- a/policies/gcp/Cloud Tasks/google_cloud_tasks_queue/http_target.http_method.rego
+++ b/policies/gcp/Cloud Tasks/google_cloud_tasks_queue/http_target.http_method.rego
@@ -21,6 +21,8 @@ conditions := [
     ]
 ]
 
-message := helpers.get_multi_summary(conditions, vars.variables).message
+result := helpers.get_multi_summary(conditions, vars.variables)
 
-details := helpers.get_multi_summary(conditions, vars.variables).details
+message := result.message
+
+details := result.details

--- a/policies/gcp/Cloud Tasks/google_cloud_tasks_queue/retry_config.max_attempts.rego
+++ b/policies/gcp/Cloud Tasks/google_cloud_tasks_queue/retry_config.max_attempts.rego
@@ -20,6 +20,8 @@ conditions := [
     ]
 ]
 
-message := helpers.get_multi_summary(conditions, vars.variables).message
+result := helpers.get_multi_summary(conditions, vars.variables)
 
-details := helpers.get_multi_summary(conditions, vars.variables).details
+message := result.message
+
+details := result.details

--- a/policies/gcp/Cloud Tasks/google_cloud_tasks_queue/stackdriver_logging_config.sampling_ratio.rego
+++ b/policies/gcp/Cloud Tasks/google_cloud_tasks_queue/stackdriver_logging_config.sampling_ratio.rego
@@ -41,6 +41,8 @@ conditions := [
 
 ]
 
-message := helpers.get_multi_summary(conditions, vars.variables).message
+result := helpers.get_multi_summary(conditions, vars.variables)
 
-details := helpers.get_multi_summary(conditions, vars.variables).details
+message := result.message
+
+details := result.details

--- a/policies/gcp/Cloud Tasks/google_cloud_tasks_queue_iam_binding/members.rego
+++ b/policies/gcp/Cloud Tasks/google_cloud_tasks_queue_iam_binding/members.rego
@@ -39,6 +39,8 @@ conditions := [
 
 ]
 
-message := helpers.get_multi_summary(conditions, vars.variables).message
+result := helpers.get_multi_summary(conditions, vars.variables)
 
-details := helpers.get_multi_summary(conditions, vars.variables).details
+message := result.message
+
+details := result.details

--- a/policies/gcp/Cloud Tasks/google_cloud_tasks_queue_iam_binding/role.rego
+++ b/policies/gcp/Cloud Tasks/google_cloud_tasks_queue_iam_binding/role.rego
@@ -41,6 +41,8 @@ conditions := [
 
 ]
 
-message := helpers.get_multi_summary(conditions, vars.variables).message
+result := helpers.get_multi_summary(conditions, vars.variables)
 
-details := helpers.get_multi_summary(conditions, vars.variables).details
+message := result.message
+
+details := result.details

--- a/policies/gcp/Cloud VMware Engine/google_vmwareengine_network/location.rego
+++ b/policies/gcp/Cloud VMware Engine/google_vmwareengine_network/location.rego
@@ -19,4 +19,4 @@ conditions := [[
 summary := helpers.get_multi_summary(conditions, vars.variables)
 message := summary.message
 
-details := helpers.get_multi_summary(conditions, vars.variables).details
+details := summary.details

--- a/policies/gcp/Cloud VMware Engine/google_vmwareengine_network/type.rego
+++ b/policies/gcp/Cloud VMware Engine/google_vmwareengine_network/type.rego
@@ -19,4 +19,4 @@ conditions := [[
 summary := helpers.get_multi_summary(conditions, vars.variables)
 message := summary.message
 
-details := helpers.get_multi_summary(conditions, vars.variables).details
+details := summary.details

--- a/policies/gcp/Cloud VMware Engine/google_vmwareengine_network_peering/import_custom_routes_with_public_ip.rego
+++ b/policies/gcp/Cloud VMware Engine/google_vmwareengine_network_peering/import_custom_routes_with_public_ip.rego
@@ -19,4 +19,4 @@ conditions := [[
 summary := helpers.get_multi_summary(conditions, vars.variables)
 message := summary.message
 
-details := helpers.get_multi_summary(conditions, vars.variables).details
+details := summary.details

--- a/policies/gcp/Cloud VMware Engine/google_vmwareengine_network_peering/peer_network_type.rego
+++ b/policies/gcp/Cloud VMware Engine/google_vmwareengine_network_peering/peer_network_type.rego
@@ -19,4 +19,4 @@ conditions := [[
 summary := helpers.get_multi_summary(conditions, vars.variables)
 message := summary.message
 
-details := helpers.get_multi_summary(conditions, vars.variables).details
+details := summary.details

--- a/policies/gcp/Cloud VMware Engine/google_vmwareengine_network_policy/external_ip.enabled.rego
+++ b/policies/gcp/Cloud VMware Engine/google_vmwareengine_network_policy/external_ip.enabled.rego
@@ -19,4 +19,4 @@ conditions := [[
 summary := helpers.get_multi_summary(conditions, vars.variables)
 message := summary.message
 
-details := helpers.get_multi_summary(conditions, vars.variables).details
+details := summary.details

--- a/policies/gcp/Cloud VMware Engine/google_vmwareengine_network_policy/internet_access.enabled.rego
+++ b/policies/gcp/Cloud VMware Engine/google_vmwareengine_network_policy/internet_access.enabled.rego
@@ -19,4 +19,4 @@ conditions := [[
 summary := helpers.get_multi_summary(conditions, vars.variables)
 message := summary.message
 
-details := helpers.get_multi_summary(conditions, vars.variables).details
+details := summary.details

--- a/policies/gcp/Cloud VMware Engine/google_vmwareengine_network_policy/location.rego
+++ b/policies/gcp/Cloud VMware Engine/google_vmwareengine_network_policy/location.rego
@@ -19,4 +19,4 @@ conditions := [[
 summary := helpers.get_multi_summary(conditions, vars.variables)
 message := summary.message
 
-details := helpers.get_multi_summary(conditions, vars.variables).details
+details := summary.details

--- a/policies/gcp/Cloud VMware Engine/google_vmwareengine_private_cloud/location.rego
+++ b/policies/gcp/Cloud VMware Engine/google_vmwareengine_private_cloud/location.rego
@@ -19,4 +19,4 @@ conditions := [[
 summary := helpers.get_multi_summary(conditions, vars.variables)
 message := summary.message
 
-details := helpers.get_multi_summary(conditions, vars.variables).details
+details := summary.details

--- a/policies/gcp/Data Catalog/google_data_catalog_entry_group/region.rego
+++ b/policies/gcp/Data Catalog/google_data_catalog_entry_group/region.rego
@@ -15,6 +15,8 @@ conditions := [
     ]
 ]
 
-message := helpers.get_multi_summary(conditions, vars.variables).message
+result := helpers.get_multi_summary(conditions, vars.variables)
 
-details := helpers.get_multi_summary(conditions, vars.variables).details
+message := result.message
+
+details := result.details

--- a/policies/gcp/Data Catalog/google_data_catalog_entry_group_iam_binding/members.rego
+++ b/policies/gcp/Data Catalog/google_data_catalog_entry_group_iam_binding/members.rego
@@ -15,6 +15,8 @@ conditions := [
     ]
 ]
 
-message := helpers.get_multi_summary(conditions, vars.variables).message
+result := helpers.get_multi_summary(conditions, vars.variables)
 
-details := helpers.get_multi_summary(conditions, vars.variables).details
+message := result.message
+
+details := result.details

--- a/policies/gcp/Data Catalog/google_data_catalog_entry_group_iam_binding/role.rego
+++ b/policies/gcp/Data Catalog/google_data_catalog_entry_group_iam_binding/role.rego
@@ -15,6 +15,8 @@ conditions := [
     ]
 ]
 
-message := helpers.get_multi_summary(conditions, vars.variables).message
+result := helpers.get_multi_summary(conditions, vars.variables)
 
-details := helpers.get_multi_summary(conditions, vars.variables).details
+message := result.message
+
+details := result.details

--- a/policies/gcp/Data Catalog/google_data_catalog_entry_group_iam_member/member.rego
+++ b/policies/gcp/Data Catalog/google_data_catalog_entry_group_iam_member/member.rego
@@ -15,6 +15,8 @@ conditions := [
     ]
 ]
 
-message := helpers.get_multi_summary(conditions, vars.variables).message
+result := helpers.get_multi_summary(conditions, vars.variables)
 
-details := helpers.get_multi_summary(conditions, vars.variables).details
+message := result.message
+
+details := result.details

--- a/policies/gcp/Data Catalog/google_data_catalog_entry_group_iam_member/role.rego
+++ b/policies/gcp/Data Catalog/google_data_catalog_entry_group_iam_member/role.rego
@@ -15,6 +15,8 @@ conditions := [
     ]
 ]
 
-message := helpers.get_multi_summary(conditions, vars.variables).message
+result := helpers.get_multi_summary(conditions, vars.variables)
 
-details := helpers.get_multi_summary(conditions, vars.variables).details
+message := result.message
+
+details := result.details

--- a/policies/gcp/Data Catalog/google_data_catalog_policy_tag_iam_binding/members.rego
+++ b/policies/gcp/Data Catalog/google_data_catalog_policy_tag_iam_binding/members.rego
@@ -15,6 +15,8 @@ conditions := [
     ]
 ]
 
-message := helpers.get_multi_summary(conditions, vars.variables).message
+result := helpers.get_multi_summary(conditions, vars.variables)
 
-details := helpers.get_multi_summary(conditions, vars.variables).details
+message := result.message
+
+details := result.details

--- a/policies/gcp/Data Catalog/google_data_catalog_policy_tag_iam_binding/role.rego
+++ b/policies/gcp/Data Catalog/google_data_catalog_policy_tag_iam_binding/role.rego
@@ -15,6 +15,8 @@ conditions := [
     ]
 ]
 
-message := helpers.get_multi_summary(conditions, vars.variables).message
+result := helpers.get_multi_summary(conditions, vars.variables)
 
-details := helpers.get_multi_summary(conditions, vars.variables).details
+message := result.message
+
+details := result.details

--- a/policies/gcp/Data Catalog/google_data_catalog_policy_tag_iam_member/member.rego
+++ b/policies/gcp/Data Catalog/google_data_catalog_policy_tag_iam_member/member.rego
@@ -15,6 +15,8 @@ conditions := [
     ]
 ]
 
-message := helpers.get_multi_summary(conditions, vars.variables).message
+result := helpers.get_multi_summary(conditions, vars.variables)
 
-details := helpers.get_multi_summary(conditions, vars.variables).details
+message := result.message
+
+details := result.details

--- a/policies/gcp/Data Catalog/google_data_catalog_policy_tag_iam_member/role.rego
+++ b/policies/gcp/Data Catalog/google_data_catalog_policy_tag_iam_member/role.rego
@@ -15,6 +15,8 @@ conditions := [
     ]
 ]
 
-message := helpers.get_multi_summary(conditions, vars.variables).message
+result := helpers.get_multi_summary(conditions, vars.variables)
 
-details := helpers.get_multi_summary(conditions, vars.variables).details
+message := result.message
+
+details := result.details

--- a/policies/gcp/Data Catalog/google_data_catalog_tag_template/force_delete.rego
+++ b/policies/gcp/Data Catalog/google_data_catalog_tag_template/force_delete.rego
@@ -15,6 +15,8 @@ conditions := [
     ]
 ]
 
-message := helpers.get_multi_summary(conditions, vars.variables).message
+result := helpers.get_multi_summary(conditions, vars.variables)
 
-details := helpers.get_multi_summary(conditions, vars.variables).details
+message := result.message
+
+details := result.details

--- a/policies/gcp/Data Catalog/google_data_catalog_tag_template/region.rego
+++ b/policies/gcp/Data Catalog/google_data_catalog_tag_template/region.rego
@@ -15,6 +15,8 @@ conditions := [
     ]
 ]
 
-message := helpers.get_multi_summary(conditions, vars.variables).message
+result := helpers.get_multi_summary(conditions, vars.variables)
 
-details := helpers.get_multi_summary(conditions, vars.variables).details
+message := result.message
+
+details := result.details

--- a/policies/gcp/Data Catalog/google_data_catalog_tag_template_iam_binding/members.rego
+++ b/policies/gcp/Data Catalog/google_data_catalog_tag_template_iam_binding/members.rego
@@ -15,6 +15,8 @@ conditions := [
     ]
 ]
 
-message := helpers.get_multi_summary(conditions, vars.variables).message
+result := helpers.get_multi_summary(conditions, vars.variables)
 
-details := helpers.get_multi_summary(conditions, vars.variables).details
+message := result.message
+
+details := result.details

--- a/policies/gcp/Data Catalog/google_data_catalog_tag_template_iam_binding/region.rego
+++ b/policies/gcp/Data Catalog/google_data_catalog_tag_template_iam_binding/region.rego
@@ -15,6 +15,8 @@ conditions := [
     ]
 ]
 
-message := helpers.get_multi_summary(conditions, vars.variables).message
+result := helpers.get_multi_summary(conditions, vars.variables)
 
-details := helpers.get_multi_summary(conditions, vars.variables).details
+message := result.message
+
+details := result.details

--- a/policies/gcp/Data Catalog/google_data_catalog_tag_template_iam_binding/role.rego
+++ b/policies/gcp/Data Catalog/google_data_catalog_tag_template_iam_binding/role.rego
@@ -15,6 +15,8 @@ conditions := [
     ]
 ]
 
-message := helpers.get_multi_summary(conditions, vars.variables).message
+result := helpers.get_multi_summary(conditions, vars.variables)
 
-details := helpers.get_multi_summary(conditions, vars.variables).details
+message := result.message
+
+details := result.details

--- a/policies/gcp/Data Catalog/google_data_catalog_tag_template_iam_member/member.rego
+++ b/policies/gcp/Data Catalog/google_data_catalog_tag_template_iam_member/member.rego
@@ -15,6 +15,8 @@ conditions := [
     ]
 ]
 
-message := helpers.get_multi_summary(conditions, vars.variables).message
+result := helpers.get_multi_summary(conditions, vars.variables)
 
-details := helpers.get_multi_summary(conditions, vars.variables).details
+message := result.message
+
+details := result.details

--- a/policies/gcp/Data Catalog/google_data_catalog_tag_template_iam_member/region.rego
+++ b/policies/gcp/Data Catalog/google_data_catalog_tag_template_iam_member/region.rego
@@ -15,6 +15,8 @@ conditions := [
     ]
 ]
 
-message := helpers.get_multi_summary(conditions, vars.variables).message
+result := helpers.get_multi_summary(conditions, vars.variables)
 
-details := helpers.get_multi_summary(conditions, vars.variables).details
+message := result.message
+
+details := result.details

--- a/policies/gcp/Data Catalog/google_data_catalog_tag_template_iam_member/role.rego
+++ b/policies/gcp/Data Catalog/google_data_catalog_tag_template_iam_member/role.rego
@@ -15,6 +15,8 @@ conditions := [
     ]
 ]
 
-message := helpers.get_multi_summary(conditions, vars.variables).message
+result := helpers.get_multi_summary(conditions, vars.variables)
 
-details := helpers.get_multi_summary(conditions, vars.variables).details
+message := result.message
+
+details := result.details

--- a/policies/gcp/Data Catalog/google_data_catalog_tag_template_iam_policy/region.rego
+++ b/policies/gcp/Data Catalog/google_data_catalog_tag_template_iam_policy/region.rego
@@ -15,6 +15,8 @@ conditions := [
     ]
 ]
 
-message := helpers.get_multi_summary(conditions, vars.variables).message
+result := helpers.get_multi_summary(conditions, vars.variables)
 
-details := helpers.get_multi_summary(conditions, vars.variables).details
+message := result.message
+
+details := result.details

--- a/policies/gcp/Data Catalog/google_data_catalog_taxonomy/activated_policy_types.rego
+++ b/policies/gcp/Data Catalog/google_data_catalog_taxonomy/activated_policy_types.rego
@@ -21,6 +21,8 @@ conditions := [
     ]
 ]
 
-message := helpers.get_multi_summary(conditions, vars.variables).message
+result := helpers.get_multi_summary(conditions, vars.variables)
 
-details := helpers.get_multi_summary(conditions, vars.variables).details
+message := result.message
+
+details := result.details

--- a/policies/gcp/Data Catalog/google_data_catalog_taxonomy/region.rego
+++ b/policies/gcp/Data Catalog/google_data_catalog_taxonomy/region.rego
@@ -15,6 +15,8 @@ conditions := [
     ]
 ]
 
-message := helpers.get_multi_summary(conditions, vars.variables).message
+result := helpers.get_multi_summary(conditions, vars.variables)
 
-details := helpers.get_multi_summary(conditions, vars.variables).details
+message := result.message
+
+details := result.details

--- a/policies/gcp/Data Catalog/google_data_catalog_taxonomy_iam_binding/members.rego
+++ b/policies/gcp/Data Catalog/google_data_catalog_taxonomy_iam_binding/members.rego
@@ -15,6 +15,8 @@ conditions := [
     ]
 ]
 
-message := helpers.get_multi_summary(conditions, vars.variables).message
+result := helpers.get_multi_summary(conditions, vars.variables)
 
-details := helpers.get_multi_summary(conditions, vars.variables).details
+message := result.message
+
+details := result.details

--- a/policies/gcp/Data Catalog/google_data_catalog_taxonomy_iam_binding/region.rego
+++ b/policies/gcp/Data Catalog/google_data_catalog_taxonomy_iam_binding/region.rego
@@ -15,6 +15,8 @@ conditions := [
     ]
 ]
 
-message := helpers.get_multi_summary(conditions, vars.variables).message
+result := helpers.get_multi_summary(conditions, vars.variables)
 
-details := helpers.get_multi_summary(conditions, vars.variables).details
+message := result.message
+
+details := result.details

--- a/policies/gcp/Data Catalog/google_data_catalog_taxonomy_iam_binding/role.rego
+++ b/policies/gcp/Data Catalog/google_data_catalog_taxonomy_iam_binding/role.rego
@@ -15,6 +15,8 @@ conditions := [
     ]
 ]
 
-message := helpers.get_multi_summary(conditions, vars.variables).message
+result := helpers.get_multi_summary(conditions, vars.variables)
 
-details := helpers.get_multi_summary(conditions, vars.variables).details
+message := result.message
+
+details := result.details

--- a/policies/gcp/Data Catalog/google_data_catalog_taxonomy_iam_member/member.rego
+++ b/policies/gcp/Data Catalog/google_data_catalog_taxonomy_iam_member/member.rego
@@ -15,6 +15,8 @@ conditions := [
     ]
 ]
 
-message := helpers.get_multi_summary(conditions, vars.variables).message
+result := helpers.get_multi_summary(conditions, vars.variables)
 
-details := helpers.get_multi_summary(conditions, vars.variables).details
+message := result.message
+
+details := result.details

--- a/policies/gcp/Data Catalog/google_data_catalog_taxonomy_iam_member/region.rego
+++ b/policies/gcp/Data Catalog/google_data_catalog_taxonomy_iam_member/region.rego
@@ -15,6 +15,8 @@ conditions := [
     ]
 ]
 
-message := helpers.get_multi_summary(conditions, vars.variables).message
+result := helpers.get_multi_summary(conditions, vars.variables)
 
-details := helpers.get_multi_summary(conditions, vars.variables).details
+message := result.message
+
+details := result.details

--- a/policies/gcp/Data Catalog/google_data_catalog_taxonomy_iam_member/role.rego
+++ b/policies/gcp/Data Catalog/google_data_catalog_taxonomy_iam_member/role.rego
@@ -15,6 +15,8 @@ conditions := [
     ]
 ]
 
-message := helpers.get_multi_summary(conditions, vars.variables).message
+result := helpers.get_multi_summary(conditions, vars.variables)
 
-details := helpers.get_multi_summary(conditions, vars.variables).details
+message := result.message
+
+details := result.details

--- a/policies/gcp/Data Catalog/google_data_catalog_taxonomy_iam_policy/region.rego
+++ b/policies/gcp/Data Catalog/google_data_catalog_taxonomy_iam_policy/region.rego
@@ -15,6 +15,8 @@ conditions := [
     ]
 ]
 
-message := helpers.get_multi_summary(conditions, vars.variables).message
+result := helpers.get_multi_summary(conditions, vars.variables)
 
-details := helpers.get_multi_summary(conditions, vars.variables).details
+message := result.message
+
+details := result.details

--- a/policies/gcp/DatabaseMigrationService/google_database_migration_service_connection_profile/cloudsql.settings.cmek_key_name.rego
+++ b/policies/gcp/DatabaseMigrationService/google_database_migration_service_connection_profile/cloudsql.settings.cmek_key_name.rego
@@ -17,5 +17,7 @@ conditions := [
     ]
 ]
 
-message := helpers.get_multi_summary(conditions, vars.variables).message
-details := helpers.get_multi_summary(conditions, vars.variables).details
+result := helpers.get_multi_summary(conditions, vars.variables)
+
+message := result.message
+details := result.details

--- a/policies/gcp/DatabaseMigrationService/google_database_migration_service_connection_profile/cloudsql.settings.ip_config.authorized_networks.value.rego
+++ b/policies/gcp/DatabaseMigrationService/google_database_migration_service_connection_profile/cloudsql.settings.ip_config.authorized_networks.value.rego
@@ -17,5 +17,7 @@ conditions := [
     ]
 ]
 
-message := helpers.get_multi_summary(conditions, vars.variables).message
-details := helpers.get_multi_summary(conditions, vars.variables).details
+result := helpers.get_multi_summary(conditions, vars.variables)
+
+message := result.message
+details := result.details

--- a/policies/gcp/DatabaseMigrationService/google_database_migration_service_connection_profile/cloudsql.settings.ip_config.private_network.rego
+++ b/policies/gcp/DatabaseMigrationService/google_database_migration_service_connection_profile/cloudsql.settings.ip_config.private_network.rego
@@ -17,5 +17,7 @@ conditions := [
     ]
 ]
 
-message := helpers.get_multi_summary(conditions, vars.variables).message
-details := helpers.get_multi_summary(conditions, vars.variables).details
+result := helpers.get_multi_summary(conditions, vars.variables)
+
+message := result.message
+details := result.details

--- a/policies/gcp/DatabaseMigrationService/google_database_migration_service_connection_profile/cloudsql.settings.ip_config.require_ssl.rego
+++ b/policies/gcp/DatabaseMigrationService/google_database_migration_service_connection_profile/cloudsql.settings.ip_config.require_ssl.rego
@@ -17,5 +17,7 @@ conditions := [
     ]
 ]
 
-message := helpers.get_multi_summary(conditions, vars.variables).message
-details := helpers.get_multi_summary(conditions, vars.variables).details
+result := helpers.get_multi_summary(conditions, vars.variables)
+
+message := result.message
+details := result.details

--- a/policies/gcp/DatabaseMigrationService/google_database_migration_service_connection_profile/location.rego
+++ b/policies/gcp/DatabaseMigrationService/google_database_migration_service_connection_profile/location.rego
@@ -17,5 +17,7 @@ conditions := [
     ]
 ]
 
-message := helpers.get_multi_summary(conditions, vars.variables).message
-details := helpers.get_multi_summary(conditions, vars.variables).details
+result := helpers.get_multi_summary(conditions, vars.variables)
+
+message := result.message
+details := result.details

--- a/policies/gcp/DatabaseMigrationService/google_database_migration_service_connection_profile/mysql.ssl.type.rego
+++ b/policies/gcp/DatabaseMigrationService/google_database_migration_service_connection_profile/mysql.ssl.type.rego
@@ -17,5 +17,7 @@ conditions := [
     ]
 ]
 
-message := helpers.get_multi_summary(conditions, vars.variables).message
-details := helpers.get_multi_summary(conditions, vars.variables).details
+result := helpers.get_multi_summary(conditions, vars.variables)
+
+message := result.message
+details := result.details

--- a/policies/gcp/DatabaseMigrationService/google_database_migration_service_connection_profile/oracle.forward_ssh_connectivity.hostname.rego
+++ b/policies/gcp/DatabaseMigrationService/google_database_migration_service_connection_profile/oracle.forward_ssh_connectivity.hostname.rego
@@ -17,5 +17,7 @@ conditions := [
   ]
 ]
 
-message := helpers.get_multi_summary(conditions, vars.variables).message
-details := helpers.get_multi_summary(conditions, vars.variables).details
+result := helpers.get_multi_summary(conditions, vars.variables)
+
+message := result.message
+details := result.details

--- a/policies/gcp/DatabaseMigrationService/google_database_migration_service_connection_profile/oracle.private_connectivity.private_connection.rego
+++ b/policies/gcp/DatabaseMigrationService/google_database_migration_service_connection_profile/oracle.private_connectivity.private_connection.rego
@@ -17,5 +17,7 @@ conditions := [
     ]
 ]
 
-message := helpers.get_multi_summary(conditions, vars.variables).message
-details := helpers.get_multi_summary(conditions, vars.variables).details
+result := helpers.get_multi_summary(conditions, vars.variables)
+
+message := result.message
+details := result.details

--- a/policies/gcp/DatabaseMigrationService/google_database_migration_service_connection_profile/postgresql.ssl.type.rego
+++ b/policies/gcp/DatabaseMigrationService/google_database_migration_service_connection_profile/postgresql.ssl.type.rego
@@ -17,5 +17,7 @@ conditions := [
     ]
 ]
 
-message := helpers.get_multi_summary(conditions, vars.variables).message
-details := helpers.get_multi_summary(conditions, vars.variables).details
+result := helpers.get_multi_summary(conditions, vars.variables)
+
+message := result.message
+details := result.details

--- a/policies/gcp/DatabaseMigrationService/google_database_migration_service_migration_job/dump_type.rego
+++ b/policies/gcp/DatabaseMigrationService/google_database_migration_service_migration_job/dump_type.rego
@@ -15,5 +15,7 @@ conditions := [
     ]
 ]
 
-message := helpers.get_multi_summary(conditions, vars.variables).message
-details := helpers.get_multi_summary(conditions, vars.variables).details
+result := helpers.get_multi_summary(conditions, vars.variables)
+
+message := result.message
+details := result.details

--- a/policies/gcp/DatabaseMigrationService/google_database_migration_service_migration_job/location.rego
+++ b/policies/gcp/DatabaseMigrationService/google_database_migration_service_migration_job/location.rego
@@ -15,5 +15,7 @@ conditions := [
     ]
 ]
 
-message := helpers.get_multi_summary(conditions, vars.variables).message
-details := helpers.get_multi_summary(conditions, vars.variables).details
+result := helpers.get_multi_summary(conditions, vars.variables)
+
+message := result.message
+details := result.details

--- a/policies/gcp/DatabaseMigrationService/google_database_migration_service_migration_job/reverse_ssh_connectivity.vm.rego
+++ b/policies/gcp/DatabaseMigrationService/google_database_migration_service_migration_job/reverse_ssh_connectivity.vm.rego
@@ -17,5 +17,7 @@ conditions := [
     ]
 ]
 
-message := helpers.get_multi_summary(conditions, vars.variables).message
-details := helpers.get_multi_summary(conditions, vars.variables).details
+result := helpers.get_multi_summary(conditions, vars.variables)
+
+message := result.message
+details := result.details

--- a/policies/gcp/DatabaseMigrationService/google_database_migration_service_migration_job/type.rego
+++ b/policies/gcp/DatabaseMigrationService/google_database_migration_service_migration_job/type.rego
@@ -15,5 +15,7 @@ conditions := [
     ]
 ]
 
-message := helpers.get_multi_summary(conditions, vars.variables).message
-details := helpers.get_multi_summary(conditions, vars.variables).details
+result := helpers.get_multi_summary(conditions, vars.variables)
+
+message := result.message
+details := result.details

--- a/policies/gcp/DatabaseMigrationService/google_database_migration_service_migration_job/vpc_peering_connectivity.vpc.rego
+++ b/policies/gcp/DatabaseMigrationService/google_database_migration_service_migration_job/vpc_peering_connectivity.vpc.rego
@@ -17,5 +17,7 @@ conditions := [
     ]
 ]
 
-message := helpers.get_multi_summary(conditions, vars.variables).message
-details := helpers.get_multi_summary(conditions, vars.variables).details
+result := helpers.get_multi_summary(conditions, vars.variables)
+
+message := result.message
+details := result.details

--- a/policies/gcp/DatabaseMigrationService/google_database_migration_service_private_connection/create_without_validation.rego
+++ b/policies/gcp/DatabaseMigrationService/google_database_migration_service_private_connection/create_without_validation.rego
@@ -15,5 +15,7 @@ conditions := [
     ]
 ]
 
-message := helpers.get_multi_summary(conditions, vars.variables).message
-details := helpers.get_multi_summary(conditions, vars.variables).details
+result := helpers.get_multi_summary(conditions, vars.variables)
+
+message := result.message
+details := result.details

--- a/policies/gcp/DatabaseMigrationService/google_database_migration_service_private_connection/location.rego
+++ b/policies/gcp/DatabaseMigrationService/google_database_migration_service_private_connection/location.rego
@@ -17,5 +17,7 @@ conditions := [
     ]
 ]
 
-message := helpers.get_multi_summary(conditions, vars.variables).message
-details := helpers.get_multi_summary(conditions, vars.variables).details
+result := helpers.get_multi_summary(conditions, vars.variables)
+
+message := result.message
+details := result.details

--- a/policies/gcp/Dataproc Metastore/google_dataproc_metastore_federation/backend_metastores.metastore_type.rego
+++ b/policies/gcp/Dataproc Metastore/google_dataproc_metastore_federation/backend_metastores.metastore_type.rego
@@ -19,5 +19,7 @@ conditions := [
   ]
 ]
    
-message := helpers.get_multi_summary(conditions, vars.variables).message
-details := helpers.get_multi_summary(conditions, vars.variables).details
+result := helpers.get_multi_summary(conditions, vars.variables)
+
+message := result.message
+details := result.details

--- a/policies/gcp/Dataproc Metastore/google_dataproc_metastore_federation/backend_metastores.name.rego
+++ b/policies/gcp/Dataproc Metastore/google_dataproc_metastore_federation/backend_metastores.name.rego
@@ -20,5 +20,7 @@ conditions := [
 ]
 
   
-message := helpers.get_multi_summary(conditions, vars.variables).message
-details := helpers.get_multi_summary(conditions, vars.variables).details
+result := helpers.get_multi_summary(conditions, vars.variables)
+
+message := result.message
+details := result.details

--- a/policies/gcp/Dataproc Metastore/google_dataproc_metastore_federation/deletion_protection.rego
+++ b/policies/gcp/Dataproc Metastore/google_dataproc_metastore_federation/deletion_protection.rego
@@ -20,5 +20,7 @@ conditions := [
 
 
 
-message := helpers.get_multi_summary(conditions, vars.variables).message
-details := helpers.get_multi_summary(conditions, vars.variables).details
+result := helpers.get_multi_summary(conditions, vars.variables)
+
+message := result.message
+details := result.details

--- a/policies/gcp/Dataproc Metastore/google_dataproc_metastore_federation/location.rego
+++ b/policies/gcp/Dataproc Metastore/google_dataproc_metastore_federation/location.rego
@@ -17,5 +17,7 @@ conditions := [
   ]
 ]
 
-message := helpers.get_multi_summary(conditions, vars.variables).message
-details := helpers.get_multi_summary(conditions, vars.variables).details
+result := helpers.get_multi_summary(conditions, vars.variables)
+
+message := result.message
+details := result.details

--- a/policies/gcp/Dataproc Metastore/google_dataproc_metastore_federation/version.rego
+++ b/policies/gcp/Dataproc Metastore/google_dataproc_metastore_federation/version.rego
@@ -18,5 +18,7 @@ conditions := [
   ]
 ]
 
-message := helpers.get_multi_summary(conditions, vars.variables).message
-details := helpers.get_multi_summary(conditions, vars.variables).details
+result := helpers.get_multi_summary(conditions, vars.variables)
+
+message := result.message
+details := result.details

--- a/policies/gcp/Dataproc Metastore/google_dataproc_metastore_service/database_type.rego
+++ b/policies/gcp/Dataproc Metastore/google_dataproc_metastore_service/database_type.rego
@@ -18,5 +18,7 @@ conditions := [
   ]
 ]
 
-message := helpers.get_multi_summary(conditions, vars.variables).message
-details := helpers.get_multi_summary(conditions, vars.variables).details
+result := helpers.get_multi_summary(conditions, vars.variables)
+
+message := result.message
+details := result.details

--- a/policies/gcp/Dataproc Metastore/google_dataproc_metastore_service/deletion_protection.rego
+++ b/policies/gcp/Dataproc Metastore/google_dataproc_metastore_service/deletion_protection.rego
@@ -19,5 +19,7 @@ conditions := [
 ]
 
 
-message := helpers.get_multi_summary(conditions, vars.variables).message
-details := helpers.get_multi_summary(conditions, vars.variables).details
+result := helpers.get_multi_summary(conditions, vars.variables)
+
+message := result.message
+details := result.details

--- a/policies/gcp/Dataproc Metastore/google_dataproc_metastore_service/encryption_config.kms_key.rego
+++ b/policies/gcp/Dataproc Metastore/google_dataproc_metastore_service/encryption_config.kms_key.rego
@@ -17,5 +17,7 @@ conditions := [
 ]
 
 
-message := helpers.get_multi_summary(conditions, vars.variables).message
-details := helpers.get_multi_summary(conditions, vars.variables).details
+result := helpers.get_multi_summary(conditions, vars.variables)
+
+message := result.message
+details := result.details

--- a/policies/gcp/Dataproc Metastore/google_dataproc_metastore_service/location.rego
+++ b/policies/gcp/Dataproc Metastore/google_dataproc_metastore_service/location.rego
@@ -18,5 +18,7 @@ conditions := [
 ]
 
 
-message := helpers.get_multi_summary(conditions, vars.variables).message
-details := helpers.get_multi_summary(conditions, vars.variables).details
+result := helpers.get_multi_summary(conditions, vars.variables)
+
+message := result.message
+details := result.details

--- a/policies/gcp/Dataproc Metastore/google_dataproc_metastore_service/metadata_integration.data_catalog_config.enabled.rego
+++ b/policies/gcp/Dataproc Metastore/google_dataproc_metastore_service/metadata_integration.data_catalog_config.enabled.rego
@@ -16,5 +16,7 @@ conditions := [
     ]
 ]
    
-message := helpers.get_multi_summary(conditions, vars.variables).message
-details := helpers.get_multi_summary(conditions, vars.variables).details
+result := helpers.get_multi_summary(conditions, vars.variables)
+
+message := result.message
+details := result.details

--- a/policies/gcp/Dataproc Metastore/google_dataproc_metastore_service/port.rego
+++ b/policies/gcp/Dataproc Metastore/google_dataproc_metastore_service/port.rego
@@ -18,5 +18,7 @@ conditions := [
 ]
 
 
-message := helpers.get_multi_summary(conditions, vars.variables).message
-details := helpers.get_multi_summary(conditions, vars.variables).details
+result := helpers.get_multi_summary(conditions, vars.variables)
+
+message := result.message
+details := result.details

--- a/policies/gcp/Dataproc Metastore/google_dataproc_metastore_service/scheduled_backup.enabled.rego
+++ b/policies/gcp/Dataproc Metastore/google_dataproc_metastore_service/scheduled_backup.enabled.rego
@@ -19,5 +19,7 @@ conditions := [
 ]
 
 
-message := helpers.get_multi_summary(conditions, vars.variables).message
-details := helpers.get_multi_summary(conditions, vars.variables).details
+result := helpers.get_multi_summary(conditions, vars.variables)
+
+message := result.message
+details := result.details

--- a/policies/gcp/Discovery Engine/google_discovery_engine_chat_engine/chat_engine_config.allow_cross_region.rego
+++ b/policies/gcp/Discovery Engine/google_discovery_engine_chat_engine/chat_engine_config.allow_cross_region.rego
@@ -20,6 +20,8 @@ conditions := [
 ]
 
 
-message := helpers.get_multi_summary(conditions, vars.variables).message
+result := helpers.get_multi_summary(conditions, vars.variables)
 
-details := helpers.get_multi_summary(conditions, vars.variables).details
+message := result.message
+
+details := result.details

--- a/policies/gcp/Discovery Engine/google_discovery_engine_chat_engine/location.rego
+++ b/policies/gcp/Discovery Engine/google_discovery_engine_chat_engine/location.rego
@@ -21,6 +21,8 @@ conditions := [
 ]
 
 
-message := helpers.get_multi_summary(conditions, vars.variables).message
+result := helpers.get_multi_summary(conditions, vars.variables)
 
-details := helpers.get_multi_summary(conditions, vars.variables).details
+message := result.message
+
+details := result.details

--- a/policies/gcp/Discovery Engine/google_discovery_engine_cmek_config/kms_key.rego
+++ b/policies/gcp/Discovery Engine/google_discovery_engine_cmek_config/kms_key.rego
@@ -21,6 +21,8 @@ conditions := [
 
 ]
 
-message := helpers.get_multi_summary(conditions, vars.variables).message
+result := helpers.get_multi_summary(conditions, vars.variables)
 
-details := helpers.get_multi_summary(conditions, vars.variables).details
+message := result.message
+
+details := result.details

--- a/policies/gcp/Discovery Engine/google_discovery_engine_cmek_config/location.rego
+++ b/policies/gcp/Discovery Engine/google_discovery_engine_cmek_config/location.rego
@@ -20,6 +20,8 @@ conditions := [
     ]
 ]
 
-message := helpers.get_multi_summary(conditions, vars.variables).message
+result := helpers.get_multi_summary(conditions, vars.variables)
 
-details := helpers.get_multi_summary(conditions, vars.variables).details
+message := result.message
+
+details := result.details

--- a/policies/gcp/Discovery Engine/google_discovery_engine_cmek_config/single_region_keys.kms_key.rego
+++ b/policies/gcp/Discovery Engine/google_discovery_engine_cmek_config/single_region_keys.kms_key.rego
@@ -21,6 +21,8 @@ conditions := [
     ]
 ]
 
-message := helpers.get_multi_summary(conditions, vars.variables).message
+result := helpers.get_multi_summary(conditions, vars.variables)
 
-details := helpers.get_multi_summary(conditions, vars.variables).details
+message := result.message
+
+details := result.details

--- a/policies/gcp/Discovery Engine/google_discovery_engine_control/filter_action.filter.rego
+++ b/policies/gcp/Discovery Engine/google_discovery_engine_control/filter_action.filter.rego
@@ -21,6 +21,8 @@ conditions := [
 ]
 
 
-message := helpers.get_multi_summary(conditions, vars.variables).message
+result := helpers.get_multi_summary(conditions, vars.variables)
 
-details := helpers.get_multi_summary(conditions, vars.variables).details
+message := result.message
+
+details := result.details

--- a/policies/gcp/Discovery Engine/google_discovery_engine_data_connector/data_source.rego
+++ b/policies/gcp/Discovery Engine/google_discovery_engine_data_connector/data_source.rego
@@ -19,6 +19,8 @@ conditions := [
     ]
 ]
 
-message := helpers.get_multi_summary(conditions, vars.variables).message
+result := helpers.get_multi_summary(conditions, vars.variables)
 
-details := helpers.get_multi_summary(conditions, vars.variables).details
+message := result.message
+
+details := result.details

--- a/policies/gcp/Discovery Engine/google_discovery_engine_data_connector/json_params.rego
+++ b/policies/gcp/Discovery Engine/google_discovery_engine_data_connector/json_params.rego
@@ -19,6 +19,8 @@ conditions := [
     ]
 ]
 
-message := helpers.get_multi_summary(conditions, vars.variables).message
+result := helpers.get_multi_summary(conditions, vars.variables)
 
-details := helpers.get_multi_summary(conditions, vars.variables).details
+message := result.message
+
+details := result.details

--- a/policies/gcp/Discovery Engine/google_discovery_engine_data_store/content_config.rego
+++ b/policies/gcp/Discovery Engine/google_discovery_engine_data_store/content_config.rego
@@ -19,6 +19,8 @@ conditions := [
     ]
 ]
 
-message := helpers.get_multi_summary(conditions, vars.variables).message
+result := helpers.get_multi_summary(conditions, vars.variables)
 
-details := helpers.get_multi_summary(conditions, vars.variables).details
+message := result.message
+
+details := result.details

--- a/policies/gcp/Discovery Engine/google_discovery_engine_data_store/document_processing_config.parsing_config_overrides.ocr_parsing_config.use_native_text.rego
+++ b/policies/gcp/Discovery Engine/google_discovery_engine_data_store/document_processing_config.parsing_config_overrides.ocr_parsing_config.use_native_text.rego
@@ -21,6 +21,8 @@ conditions := [
     ]
 ]
 
-message := helpers.get_multi_summary(conditions, vars.variables).message
+result := helpers.get_multi_summary(conditions, vars.variables)
 
-details := helpers.get_multi_summary(conditions, vars.variables).details
+message := result.message
+
+details := result.details

--- a/policies/gcp/Discovery Engine/google_discovery_engine_data_store/kms_key_name.rego
+++ b/policies/gcp/Discovery Engine/google_discovery_engine_data_store/kms_key_name.rego
@@ -19,6 +19,8 @@ conditions := [
     ]
 ]
 
-message := helpers.get_multi_summary(conditions, vars.variables).message
+result := helpers.get_multi_summary(conditions, vars.variables)
 
-details := helpers.get_multi_summary(conditions, vars.variables).details
+message := result.message
+
+details := result.details

--- a/policies/gcp/Discovery Engine/google_discovery_engine_data_store/location.rego
+++ b/policies/gcp/Discovery Engine/google_discovery_engine_data_store/location.rego
@@ -19,6 +19,8 @@ conditions := [
     ]
 ]
 
-message := helpers.get_multi_summary(conditions, vars.variables).message
+result := helpers.get_multi_summary(conditions, vars.variables)
 
-details := helpers.get_multi_summary(conditions, vars.variables).details
+message := result.message
+
+details := result.details

--- a/policies/gcp/Discovery Engine/google_discovery_engine_license_config/auto_renew.rego
+++ b/policies/gcp/Discovery Engine/google_discovery_engine_license_config/auto_renew.rego
@@ -20,6 +20,8 @@ conditions := [
 ]
 
 
-message := helpers.get_multi_summary(conditions, vars.variables).message
+result := helpers.get_multi_summary(conditions, vars.variables)
 
-details := helpers.get_multi_summary(conditions, vars.variables).details
+message := result.message
+
+details := result.details

--- a/policies/gcp/Discovery Engine/google_discovery_engine_license_config/subscription_tier.rego
+++ b/policies/gcp/Discovery Engine/google_discovery_engine_license_config/subscription_tier.rego
@@ -20,6 +20,8 @@ conditions := [
 ]
 
 
-message := helpers.get_multi_summary(conditions, vars.variables).message
+result := helpers.get_multi_summary(conditions, vars.variables)
 
-details := helpers.get_multi_summary(conditions, vars.variables).details
+message := result.message
+
+details := result.details

--- a/policies/gcp/Discovery Engine/google_discovery_engine_schema/json_schema.rego
+++ b/policies/gcp/Discovery Engine/google_discovery_engine_schema/json_schema.rego
@@ -20,6 +20,8 @@ conditions := [
     ]
 ]
 
-message := helpers.get_multi_summary(conditions, vars.variables).message
+result := helpers.get_multi_summary(conditions, vars.variables)
 
-details := helpers.get_multi_summary(conditions, vars.variables).details
+message := result.message
+
+details := result.details

--- a/policies/gcp/Discovery Engine/google_discovery_engine_search_engine/industry_vertical.rego
+++ b/policies/gcp/Discovery Engine/google_discovery_engine_search_engine/industry_vertical.rego
@@ -20,6 +20,8 @@ conditions := [
 ]
 
 
-message := helpers.get_multi_summary(conditions, vars.variables).message
+result := helpers.get_multi_summary(conditions, vars.variables)
 
-details := helpers.get_multi_summary(conditions, vars.variables).details
+message := result.message
+
+details := result.details

--- a/policies/gcp/Discovery Engine/google_discovery_engine_sitemap/uri.rego
+++ b/policies/gcp/Discovery Engine/google_discovery_engine_sitemap/uri.rego
@@ -20,6 +20,8 @@ conditions := [
 ]
 
 
-message := helpers.get_multi_summary(conditions, vars.variables).message
+result := helpers.get_multi_summary(conditions, vars.variables)
 
-details := helpers.get_multi_summary(conditions, vars.variables).details
+message := result.message
+
+details := result.details

--- a/policies/gcp/Firebase App Check/google_firebase_app_check_app_attest_config/token_ttl.rego
+++ b/policies/gcp/Firebase App Check/google_firebase_app_check_app_attest_config/token_ttl.rego
@@ -18,5 +18,7 @@ conditions := [
   ]
 ]
 
-message := helpers.get_multi_summary(conditions, vars.variables).message
-details := helpers.get_multi_summary(conditions, vars.variables).details
+result := helpers.get_multi_summary(conditions, vars.variables)
+
+message := result.message
+details := result.details

--- a/policies/gcp/Firebase App Check/google_firebase_app_check_device_check_config/private_key.rego
+++ b/policies/gcp/Firebase App Check/google_firebase_app_check_device_check_config/private_key.rego
@@ -17,5 +17,5 @@ conditions := [
 ]
 
 result = helpers.get_multi_summary(conditions, vars.variables)
-message = result.message
-details = result.details
+message := result.message
+details := result.details

--- a/policies/gcp/Firebase App Check/google_firebase_app_check_device_check_config/token_ttl.rego
+++ b/policies/gcp/Firebase App Check/google_firebase_app_check_device_check_config/token_ttl.rego
@@ -18,5 +18,7 @@ conditions := [
   ]
 ]
 
-message := helpers.get_multi_summary(conditions, vars.variables).message
-details := helpers.get_multi_summary(conditions, vars.variables).details
+result := helpers.get_multi_summary(conditions, vars.variables)
+
+message := result.message
+details := result.details

--- a/policies/gcp/Firebase App Check/google_firebase_app_check_recaptcha_v3_config/site_secret.rego
+++ b/policies/gcp/Firebase App Check/google_firebase_app_check_recaptcha_v3_config/site_secret.rego
@@ -17,5 +17,5 @@ conditions := [
 ]
 
 result = helpers.get_multi_summary(conditions, vars.variables)
-message = result.message
-details = result.details
+message := result.message
+details := result.details

--- a/policies/gcp/Firebase App Check/google_firebase_app_check_service_config/enforcement_mode.rego
+++ b/policies/gcp/Firebase App Check/google_firebase_app_check_service_config/enforcement_mode.rego
@@ -17,5 +17,5 @@ conditions := [
 ]
 
 result = helpers.get_multi_summary(conditions, vars.variables)
-message = result.message
-details = result.details
+message := result.message
+details := result.details

--- a/policies/gcp/Firebase App Hosting/google_firebase_app_hosting_backend/location.rego
+++ b/policies/gcp/Firebase App Hosting/google_firebase_app_hosting_backend/location.rego
@@ -16,5 +16,7 @@ conditions := [
     ]
 ]
 
-message := helpers.get_multi_summary(conditions, vars.variables).message
-details := helpers.get_multi_summary(conditions, vars.variables).details
+result := helpers.get_multi_summary(conditions, vars.variables)
+
+message := result.message
+details := result.details

--- a/policies/gcp/Firebase App Hosting/google_firebase_app_hosting_backend/serving_locality.rego
+++ b/policies/gcp/Firebase App Hosting/google_firebase_app_hosting_backend/serving_locality.rego
@@ -16,5 +16,7 @@ conditions := [
     ]
 ]
 
-message := helpers.get_multi_summary(conditions, vars.variables).message
-details := helpers.get_multi_summary(conditions, vars.variables).details
+result := helpers.get_multi_summary(conditions, vars.variables)
+
+message := result.message
+details := result.details

--- a/policies/gcp/Firebase App Hosting/google_firebase_app_hosting_build/source.container.image.rego
+++ b/policies/gcp/Firebase App Hosting/google_firebase_app_hosting_build/source.container.image.rego
@@ -34,5 +34,7 @@ conditions := [
     ]
 ]
 
-message := helpers.get_multi_summary(conditions, vars.variables).message
-details := helpers.get_multi_summary(conditions, vars.variables).details
+result := helpers.get_multi_summary(conditions, vars.variables)
+
+message := result.message
+details := result.details

--- a/policies/gcp/Firebase App Hosting/google_firebase_app_hosting_traffic/rollout_policy.codebase_branch.rego
+++ b/policies/gcp/Firebase App Hosting/google_firebase_app_hosting_traffic/rollout_policy.codebase_branch.rego
@@ -26,5 +26,7 @@ conditions := [
     ]
 ]
 
-message := helpers.get_multi_summary(conditions, vars.variables).message
-details := helpers.get_multi_summary(conditions, vars.variables).details
+result := helpers.get_multi_summary(conditions, vars.variables)
+
+message := result.message
+details := result.details

--- a/policies/gcp/Firebase Data Connect/google_firebase_data_connect_service/deletion_policy.rego
+++ b/policies/gcp/Firebase Data Connect/google_firebase_data_connect_service/deletion_policy.rego
@@ -18,6 +18,8 @@ conditions := [
     ]
 ]
    
-message := helpers.get_multi_summary(conditions, vars.variables).message
+result := helpers.get_multi_summary(conditions, vars.variables)
 
-details := helpers.get_multi_summary(conditions, vars.variables).details
+message := result.message
+
+details := result.details

--- a/policies/gcp/Firestore/google_firestore_backup_schedule/retention.rego
+++ b/policies/gcp/Firestore/google_firestore_backup_schedule/retention.rego
@@ -21,6 +21,6 @@ conditions := [
 ]
 
 summary := helpers.get_multi_summary(conditions, vars.variables)
-message := helpers.get_multi_summary(conditions, vars.variables).message
-details := helpers.get_multi_summary(conditions, vars.variables).details
+message := summary.message
+details := summary.details
 

--- a/policies/gcp/Firestore/google_firestore_database/app_engine_integration_mode.rego
+++ b/policies/gcp/Firestore/google_firestore_database/app_engine_integration_mode.rego
@@ -21,5 +21,5 @@ conditions := [
 ]
 summary := helpers.get_multi_summary(conditions, vars.variables)
 
-message := helpers.get_multi_summary(conditions, vars.variables).message
-details := helpers.get_multi_summary(conditions, vars.variables).details
+message := summary.message
+details := summary.details

--- a/policies/gcp/Firestore/google_firestore_database/concurrency_mode.rego
+++ b/policies/gcp/Firestore/google_firestore_database/concurrency_mode.rego
@@ -22,5 +22,5 @@ conditions := [
 
 summary := helpers.get_multi_summary(conditions, vars.variables)
 
-message := helpers.get_multi_summary(conditions, vars.variables).message
-details := helpers.get_multi_summary(conditions, vars.variables).details
+message := summary.message
+details := summary.details

--- a/policies/gcp/Firestore/google_firestore_database/location_id.rego
+++ b/policies/gcp/Firestore/google_firestore_database/location_id.rego
@@ -22,5 +22,5 @@ conditions := [
 
 summary := helpers.get_multi_summary(conditions, vars.variables)
 
-message := helpers.get_multi_summary(conditions, vars.variables).message
-details := helpers.get_multi_summary(conditions, vars.variables).details
+message := summary.message
+details := summary.details

--- a/policies/gcp/Firestore/google_firestore_document/collection.rego
+++ b/policies/gcp/Firestore/google_firestore_document/collection.rego
@@ -21,5 +21,5 @@ conditions := [
 ]
 summary := helpers.get_multi_summary(conditions, vars.variables)
 
-message := helpers.get_multi_summary(conditions, vars.variables).message
-details := helpers.get_multi_summary(conditions, vars.variables).details
+message := summary.message
+details := summary.details

--- a/policies/gcp/Firestore/google_firestore_document/fields.rego
+++ b/policies/gcp/Firestore/google_firestore_document/fields.rego
@@ -23,5 +23,5 @@ conditions := [
 
 summary := helpers.get_multi_summary(conditions, vars.variables)
 
-message := helpers.get_multi_summary(conditions, vars.variables).message
-details := helpers.get_multi_summary(conditions, vars.variables).details
+message := summary.message
+details := summary.details

--- a/policies/gcp/GKEHub/google_gke_hub_feature/spec.fleetobservability.logging_config.default_config.mode.rego
+++ b/policies/gcp/GKEHub/google_gke_hub_feature/spec.fleetobservability.logging_config.default_config.mode.rego
@@ -15,5 +15,7 @@ conditions := [[
 	},
 ]]
 
-message := helpers.get_multi_summary(conditions, vars.variables).message
-details := helpers.get_multi_summary(conditions, vars.variables).details
+result := helpers.get_multi_summary(conditions, vars.variables)
+
+message := result.message
+details := result.details

--- a/policies/gcp/GKEHub/google_gke_hub_feature_iam_binding/members.rego
+++ b/policies/gcp/GKEHub/google_gke_hub_feature_iam_binding/members.rego
@@ -21,6 +21,8 @@ conditions := [[
   }
 ]]
 
-message := helpers.get_multi_summary(conditions, vars.variables).message
-details := helpers.get_multi_summary(conditions, vars.variables).details
+result := helpers.get_multi_summary(conditions, vars.variables)
+
+message := result.message
+details := result.details
 

--- a/policies/gcp/GKEHub/google_gke_hub_feature_iam_member/member.rego
+++ b/policies/gcp/GKEHub/google_gke_hub_feature_iam_member/member.rego
@@ -19,5 +19,7 @@ conditions := [
   ]
 ]
 
-message := helpers.get_multi_summary(conditions, vars.variables).message
-details := helpers.get_multi_summary(conditions, vars.variables).details
+result := helpers.get_multi_summary(conditions, vars.variables)
+
+message := result.message
+details := result.details

--- a/policies/gcp/GKEHub/google_gke_hub_feature_membership/configmanagement.config_sync.git.https_proxy.rego
+++ b/policies/gcp/GKEHub/google_gke_hub_feature_membership/configmanagement.config_sync.git.https_proxy.rego
@@ -17,6 +17,8 @@ conditions := [
   ]
 ]
 
-message := helpers.get_multi_summary(conditions, vars.variables).message
-details := helpers.get_multi_summary(conditions, vars.variables).details
+result := helpers.get_multi_summary(conditions, vars.variables)
+
+message := result.message
+details := result.details
 

--- a/policies/gcp/GKEHub/google_gke_hub_feature_membership/configmanagement.policy_controller.enabled.rego
+++ b/policies/gcp/GKEHub/google_gke_hub_feature_membership/configmanagement.policy_controller.enabled.rego
@@ -18,5 +18,7 @@ conditions := [
   ]
 ]
 
-message := helpers.get_multi_summary(conditions, vars.variables).message
-details := helpers.get_multi_summary(conditions, vars.variables).details
+result := helpers.get_multi_summary(conditions, vars.variables)
+
+message := result.message
+details := result.details

--- a/policies/gcp/GKEHub/google_gke_hub_fleet/default_cluster_config.binary_authorization_config.policy_bindings.name.rego
+++ b/policies/gcp/GKEHub/google_gke_hub_fleet/default_cluster_config.binary_authorization_config.policy_bindings.name.rego
@@ -18,5 +18,7 @@ conditions := [
   ]
 ]
 
-message := helpers.get_multi_summary(conditions, vars.variables).message
-details := helpers.get_multi_summary(conditions, vars.variables).details
+result := helpers.get_multi_summary(conditions, vars.variables)
+
+message := result.message
+details := result.details

--- a/policies/gcp/GKEHub/google_gke_hub_membership/authority.issuer.rego
+++ b/policies/gcp/GKEHub/google_gke_hub_membership/authority.issuer.rego
@@ -33,6 +33,8 @@ conditions := [
   ]
 ]
 
-message := helpers.get_multi_summary(conditions, vars.variables).message
-details := helpers.get_multi_summary(conditions, vars.variables).details
+result := helpers.get_multi_summary(conditions, vars.variables)
+
+message := result.message
+details := result.details
 

--- a/policies/gcp/GKEHub/google_gke_hub_scope_iam_binding/members.rego
+++ b/policies/gcp/GKEHub/google_gke_hub_scope_iam_binding/members.rego
@@ -17,6 +17,8 @@ conditions := [
   ]
 ]
 
-message := helpers.get_multi_summary(conditions, vars.variables).message
-details := helpers.get_multi_summary(conditions, vars.variables).details
+result := helpers.get_multi_summary(conditions, vars.variables)
+
+message := result.message
+details := result.details
 

--- a/policies/gcp/GKEHub/google_gke_hub_scope_iam_member/member.rego
+++ b/policies/gcp/GKEHub/google_gke_hub_scope_iam_member/member.rego
@@ -17,6 +17,8 @@ conditions := [
   ]
 ]
 
-message := helpers.get_multi_summary(conditions, vars.variables).message
-details := helpers.get_multi_summary(conditions, vars.variables).details
+result := helpers.get_multi_summary(conditions, vars.variables)
+
+message := result.message
+details := result.details
 

--- a/policies/gcp/GKEHub/google_gke_hub_scope_iam_policy/policy_data.rego
+++ b/policies/gcp/GKEHub/google_gke_hub_scope_iam_policy/policy_data.rego
@@ -17,5 +17,7 @@ conditions := [
   ]
 ]
 
-message := helpers.get_multi_summary(conditions, vars.variables).message
-details := helpers.get_multi_summary(conditions, vars.variables).details
+result := helpers.get_multi_summary(conditions, vars.variables)
+
+message := result.message
+details := result.details

--- a/policies/gcp/Gemini for Google Cloud/google_gemini_code_repository_index/force_destroy.rego
+++ b/policies/gcp/Gemini for Google Cloud/google_gemini_code_repository_index/force_destroy.rego
@@ -13,5 +13,7 @@ conditions := [
     }
     ]
 ]
-message := helpers.get_multi_summary(conditions, vars.variables).message
-details := helpers.get_multi_summary(conditions, vars.variables).details
+result := helpers.get_multi_summary(conditions, vars.variables)
+
+message := result.message
+details := result.details

--- a/policies/gcp/Gemini for Google Cloud/google_gemini_code_repository_index/kms_key.rego
+++ b/policies/gcp/Gemini for Google Cloud/google_gemini_code_repository_index/kms_key.rego
@@ -17,4 +17,4 @@ conditions := [
 
 summary := helpers.get_multi_summary(conditions, vars.variables)
 message := summary.message
-details := helpers.get_multi_summary(conditions, vars.variables).details
+details := summary.details

--- a/policies/gcp/Gemini for Google Cloud/google_gemini_code_repository_index/location.rego
+++ b/policies/gcp/Gemini for Google Cloud/google_gemini_code_repository_index/location.rego
@@ -17,4 +17,4 @@ conditions := [
 
 summary := helpers.get_multi_summary(conditions, vars.variables)
 message := summary.message
-details := helpers.get_multi_summary(conditions, vars.variables).details
+details := summary.details

--- a/policies/gcp/Gemini for Google Cloud/google_gemini_data_sharing_with_google_setting/enable_data_sharing.rego
+++ b/policies/gcp/Gemini for Google Cloud/google_gemini_data_sharing_with_google_setting/enable_data_sharing.rego
@@ -18,4 +18,4 @@ conditions := [
 
 summary := helpers.get_multi_summary(conditions, vars.variables)
 message := summary.message
-details := helpers.get_multi_summary(conditions, vars.variables).details
+details := summary.details

--- a/policies/gcp/Gemini for Google Cloud/google_gemini_data_sharing_with_google_setting/enable_preview_data_sharing.rego
+++ b/policies/gcp/Gemini for Google Cloud/google_gemini_data_sharing_with_google_setting/enable_preview_data_sharing.rego
@@ -18,4 +18,4 @@ conditions := [
 
 summary := helpers.get_multi_summary(conditions, vars.variables)
 message := summary.message
-details := helpers.get_multi_summary(conditions, vars.variables).details
+details := summary.details

--- a/policies/gcp/Gemini for Google Cloud/google_gemini_gemini_gcp_enablement_setting/enable_customer_data_sharing.rego
+++ b/policies/gcp/Gemini for Google Cloud/google_gemini_gemini_gcp_enablement_setting/enable_customer_data_sharing.rego
@@ -18,4 +18,4 @@ conditions := [
 
 summary := helpers.get_multi_summary(conditions, vars.variables)
 message := summary.message
-details := helpers.get_multi_summary(conditions, vars.variables).details
+details := summary.details

--- a/policies/gcp/Gemini for Google Cloud/google_gemini_gemini_gcp_enablement_setting/web_grounding_type.rego
+++ b/policies/gcp/Gemini for Google Cloud/google_gemini_gemini_gcp_enablement_setting/web_grounding_type.rego
@@ -18,4 +18,4 @@ conditions := [
 
 summary := helpers.get_multi_summary(conditions, vars.variables)
 message := summary.message
-details := helpers.get_multi_summary(conditions, vars.variables).details
+details := summary.details

--- a/policies/gcp/Gemini for Google Cloud/google_gemini_logging_setting/log_metadata.rego
+++ b/policies/gcp/Gemini for Google Cloud/google_gemini_logging_setting/log_metadata.rego
@@ -18,4 +18,4 @@ conditions := [
 
 summary := helpers.get_multi_summary(conditions, vars.variables)
 message := summary.message
-details := helpers.get_multi_summary(conditions, vars.variables).details
+details := summary.details

--- a/policies/gcp/Gemini for Google Cloud/google_gemini_logging_setting/log_prompts_and_responses.rego
+++ b/policies/gcp/Gemini for Google Cloud/google_gemini_logging_setting/log_prompts_and_responses.rego
@@ -18,4 +18,4 @@ conditions := [
 
 summary := helpers.get_multi_summary(conditions, vars.variables)
 message := summary.message
-details := helpers.get_multi_summary(conditions, vars.variables).details
+details := summary.details

--- a/policies/gcp/Gemini for Google Cloud/google_gemini_release_channel_setting/release_channel.rego
+++ b/policies/gcp/Gemini for Google Cloud/google_gemini_release_channel_setting/release_channel.rego
@@ -18,4 +18,4 @@ conditions := [
 
 summary := helpers.get_multi_summary(conditions, vars.variables)
 message := summary.message
-details := helpers.get_multi_summary(conditions, vars.variables).details
+details := summary.details

--- a/policies/gcp/Google Cloud Managed Lustre/google_lustre_instance/gke_support_enabled.rego
+++ b/policies/gcp/Google Cloud Managed Lustre/google_lustre_instance/gke_support_enabled.rego
@@ -20,5 +20,7 @@ conditions := [
   ]
 ]
 
-message := helpers.get_multi_summary(conditions, vars.variables).message
-details := helpers.get_multi_summary(conditions, vars.variables).details
+result := helpers.get_multi_summary(conditions, vars.variables)
+
+message := result.message
+details := result.details

--- a/policies/gcp/Google Cloud Managed Lustre/google_lustre_instance/location.rego
+++ b/policies/gcp/Google Cloud Managed Lustre/google_lustre_instance/location.rego
@@ -23,7 +23,9 @@ conditions := [
 ]
 
 # Summary message for compliance
-message := helpers.get_multi_summary(conditions, vars.variables).message
+result := helpers.get_multi_summary(conditions, vars.variables)
+
+message := result.message
 
 # Detailed compliance info for debugging
-details := helpers.get_multi_summary(conditions, vars.variables).details
+details := result.details

--- a/policies/gcp/Google Cloud Managed Lustre/google_lustre_instance/network.rego
+++ b/policies/gcp/Google Cloud Managed Lustre/google_lustre_instance/network.rego
@@ -20,5 +20,7 @@ conditions := [
     }
   ]
 ]
-message := helpers.get_multi_summary(conditions, vars.variables).message
-details := helpers.get_multi_summary(conditions, vars.variables).details
+result := helpers.get_multi_summary(conditions, vars.variables)
+
+message := result.message
+details := result.details

--- a/policies/gcp/Google Cloud Managed Lustre/google_lustre_instance/per_unit_storage_throughput.rego
+++ b/policies/gcp/Google Cloud Managed Lustre/google_lustre_instance/per_unit_storage_throughput.rego
@@ -21,5 +21,7 @@ conditions := [
   ]
 ]
 
-message := helpers.get_multi_summary(conditions, vars.variables).message
-details := helpers.get_multi_summary(conditions, vars.variables).details
+result := helpers.get_multi_summary(conditions, vars.variables)
+
+message := result.message
+details := result.details

--- a/policies/gcp/Google Cloud NetApp Volumes/google_netapp_active_directory/dns.rego
+++ b/policies/gcp/Google Cloud NetApp Volumes/google_netapp_active_directory/dns.rego
@@ -21,5 +21,7 @@ conditions := [
   ]
 ]
 
-message := helpers.get_multi_summary(conditions, vars.variables).message
-details := helpers.get_multi_summary(conditions, vars.variables).details
+result := helpers.get_multi_summary(conditions, vars.variables)
+
+message := result.message
+details := result.details

--- a/policies/gcp/Google Cloud NetApp Volumes/google_netapp_active_directory/domain.rego
+++ b/policies/gcp/Google Cloud NetApp Volumes/google_netapp_active_directory/domain.rego
@@ -16,6 +16,8 @@ conditions := [
     ]
 ]
 
-message := helpers.get_multi_summary(conditions, vars.variables).message
+result := helpers.get_multi_summary(conditions, vars.variables)
 
-details := helpers.get_multi_summary(conditions, vars.variables).details
+message := result.message
+
+details := result.details

--- a/policies/gcp/Google Cloud NetApp Volumes/google_netapp_active_directory/password.rego
+++ b/policies/gcp/Google Cloud NetApp Volumes/google_netapp_active_directory/password.rego
@@ -18,5 +18,7 @@ conditions := [
   ]
 ]
 
-message := helpers.get_multi_summary(conditions, vars.variables).message
-details := helpers.get_multi_summary(conditions, vars.variables).details
+result := helpers.get_multi_summary(conditions, vars.variables)
+
+message := result.message
+details := result.details

--- a/policies/gcp/Google Cloud NetApp Volumes/google_netapp_active_directory/username.rego
+++ b/policies/gcp/Google Cloud NetApp Volumes/google_netapp_active_directory/username.rego
@@ -18,5 +18,7 @@ conditions := [
   ]
 ]
 
-message := helpers.get_multi_summary(conditions, vars.variables).message
-details := helpers.get_multi_summary(conditions, vars.variables).details
+result := helpers.get_multi_summary(conditions, vars.variables)
+
+message := result.message
+details := result.details

--- a/policies/gcp/Google Cloud NetApp Volumes/google_netapp_backup/location.rego
+++ b/policies/gcp/Google Cloud NetApp Volumes/google_netapp_backup/location.rego
@@ -18,5 +18,7 @@ conditions := [
   ]
 ]
 
-message := helpers.get_multi_summary(conditions, vars.variables).message
-details := helpers.get_multi_summary(conditions, vars.variables).details
+result := helpers.get_multi_summary(conditions, vars.variables)
+
+message := result.message
+details := result.details

--- a/policies/gcp/Google Cloud NetApp Volumes/google_netapp_backup/source_volume.rego
+++ b/policies/gcp/Google Cloud NetApp Volumes/google_netapp_backup/source_volume.rego
@@ -23,5 +23,7 @@ conditions := [
   ]
 ]
 
-message := helpers.get_multi_summary(conditions, vars.variables).message
-details := helpers.get_multi_summary(conditions, vars.variables).details
+result := helpers.get_multi_summary(conditions, vars.variables)
+
+message := result.message
+details := result.details

--- a/policies/gcp/Google Cloud NetApp Volumes/google_netapp_backup/vault_name.rego
+++ b/policies/gcp/Google Cloud NetApp Volumes/google_netapp_backup/vault_name.rego
@@ -23,5 +23,7 @@ conditions := [
   ]
 ]
 
-message := helpers.get_multi_summary(conditions, vars.variables).message
-details := helpers.get_multi_summary(conditions, vars.variables).details
+result := helpers.get_multi_summary(conditions, vars.variables)
+
+message := result.message
+details := result.details

--- a/policies/gcp/Google Cloud NetApp Volumes/google_netapp_backup_policy/daily_backup_limit.rego
+++ b/policies/gcp/Google Cloud NetApp Volumes/google_netapp_backup_policy/daily_backup_limit.rego
@@ -16,5 +16,7 @@ conditions := [
   ]
 ]
 
-message := helpers.get_multi_summary(conditions, vars.variables).message
-details := helpers.get_multi_summary(conditions, vars.variables).details
+result := helpers.get_multi_summary(conditions, vars.variables)
+
+message := result.message
+details := result.details

--- a/policies/gcp/Google Cloud NetApp Volumes/google_netapp_backup_policy/location.rego
+++ b/policies/gcp/Google Cloud NetApp Volumes/google_netapp_backup_policy/location.rego
@@ -19,5 +19,7 @@ conditions := [
 ]
 
 
-message := helpers.get_multi_summary(conditions, vars.variables).message
-details := helpers.get_multi_summary(conditions, vars.variables).details
+result := helpers.get_multi_summary(conditions, vars.variables)
+
+message := result.message
+details := result.details

--- a/policies/gcp/Google Cloud NetApp Volumes/google_netapp_backup_vault/location.rego
+++ b/policies/gcp/Google Cloud NetApp Volumes/google_netapp_backup_vault/location.rego
@@ -19,5 +19,7 @@ conditions := [
 ]
 
 
-message := helpers.get_multi_summary(conditions, vars.variables).message
-details := helpers.get_multi_summary(conditions, vars.variables).details
+result := helpers.get_multi_summary(conditions, vars.variables)
+
+message := result.message
+details := result.details

--- a/policies/gcp/Google Cloud NetApp Volumes/google_netapp_kmsconfig/crypto_key_name.rego
+++ b/policies/gcp/Google Cloud NetApp Volumes/google_netapp_kmsconfig/crypto_key_name.rego
@@ -23,5 +23,7 @@ conditions := [
   ]
 ]
 
-message := helpers.get_multi_summary(conditions, vars.variables).message
-details := helpers.get_multi_summary(conditions, vars.variables).details
+result := helpers.get_multi_summary(conditions, vars.variables)
+
+message := result.message
+details := result.details

--- a/policies/gcp/Google Cloud NetApp Volumes/google_netapp_kmsconfig/location.rego
+++ b/policies/gcp/Google Cloud NetApp Volumes/google_netapp_kmsconfig/location.rego
@@ -19,5 +19,7 @@ conditions := [
 ]
 
 
-message := helpers.get_multi_summary(conditions, vars.variables).message
-details := helpers.get_multi_summary(conditions, vars.variables).details
+result := helpers.get_multi_summary(conditions, vars.variables)
+
+message := result.message
+details := result.details

--- a/policies/gcp/Google Cloud NetApp Volumes/google_netapp_storage_pool/location.rego
+++ b/policies/gcp/Google Cloud NetApp Volumes/google_netapp_storage_pool/location.rego
@@ -19,5 +19,7 @@ conditions := [
 ]
 
 
-message := helpers.get_multi_summary(conditions, vars.variables).message
-details := helpers.get_multi_summary(conditions, vars.variables).details
+result := helpers.get_multi_summary(conditions, vars.variables)
+
+message := result.message
+details := result.details

--- a/policies/gcp/Google Cloud NetApp Volumes/google_netapp_storage_pool/network.rego
+++ b/policies/gcp/Google Cloud NetApp Volumes/google_netapp_storage_pool/network.rego
@@ -23,5 +23,7 @@ conditions := [
   ]
 ]
 
-message := helpers.get_multi_summary(conditions, vars.variables).message
-details := helpers.get_multi_summary(conditions, vars.variables).details
+result := helpers.get_multi_summary(conditions, vars.variables)
+
+message := result.message
+details := result.details

--- a/policies/gcp/Google Cloud NetApp Volumes/google_netapp_volume/protocols.rego
+++ b/policies/gcp/Google Cloud NetApp Volumes/google_netapp_volume/protocols.rego
@@ -16,6 +16,8 @@ conditions := [
     ]
 ]
 
-message := helpers.get_multi_summary(conditions, vars.variables).message
+result := helpers.get_multi_summary(conditions, vars.variables)
 
-details := helpers.get_multi_summary(conditions, vars.variables).details
+message := result.message
+
+details := result.details

--- a/policies/gcp/Google Cloud NetApp Volumes/google_netapp_volume_quota_rule/disk_limit_mib.rego
+++ b/policies/gcp/Google Cloud NetApp Volumes/google_netapp_volume_quota_rule/disk_limit_mib.rego
@@ -16,5 +16,7 @@ conditions := [
   ]
 ]
 
-message := helpers.get_multi_summary(conditions, vars.variables).message
-details := helpers.get_multi_summary(conditions, vars.variables).details
+result := helpers.get_multi_summary(conditions, vars.variables)
+
+message := result.message
+details := result.details

--- a/policies/gcp/Google Cloud NetApp Volumes/google_netapp_volume_quota_rule/location.rego
+++ b/policies/gcp/Google Cloud NetApp Volumes/google_netapp_volume_quota_rule/location.rego
@@ -19,5 +19,7 @@ conditions := [
 ]
 
 
-message := helpers.get_multi_summary(conditions, vars.variables).message
-details := helpers.get_multi_summary(conditions, vars.variables).details
+result := helpers.get_multi_summary(conditions, vars.variables)
+
+message := result.message
+details := result.details

--- a/policies/gcp/Google Cloud NetApp Volumes/google_netapp_volume_replication/location.rego
+++ b/policies/gcp/Google Cloud NetApp Volumes/google_netapp_volume_replication/location.rego
@@ -18,5 +18,7 @@ conditions := [
   ]
 ]
 
-message := helpers.get_multi_summary(conditions, vars.variables).message
-details := helpers.get_multi_summary(conditions, vars.variables).details
+result := helpers.get_multi_summary(conditions, vars.variables)
+
+message := result.message
+details := result.details

--- a/policies/gcp/Google Cloud NetApp Volumes/google_netapp_volume_replication/replication_schedule.rego
+++ b/policies/gcp/Google Cloud NetApp Volumes/google_netapp_volume_replication/replication_schedule.rego
@@ -18,5 +18,7 @@ conditions := [
   ]
 ]
 
-message := helpers.get_multi_summary(conditions, vars.variables).message
-details := helpers.get_multi_summary(conditions, vars.variables).details
+result := helpers.get_multi_summary(conditions, vars.variables)
+
+message := result.message
+details := result.details

--- a/policies/gcp/Google Cloud NetApp Volumes/google_netapp_volume_snapshot/location.rego
+++ b/policies/gcp/Google Cloud NetApp Volumes/google_netapp_volume_snapshot/location.rego
@@ -18,5 +18,7 @@ conditions := [
   ]
 ]
 
-message := helpers.get_multi_summary(conditions, vars.variables).message
-details := helpers.get_multi_summary(conditions, vars.variables).details
+result := helpers.get_multi_summary(conditions, vars.variables)
+
+message := result.message
+details := result.details

--- a/policies/gcp/Google Cloud NetApp Volumes/google_netapp_volume_snapshot/volume_name.rego
+++ b/policies/gcp/Google Cloud NetApp Volumes/google_netapp_volume_snapshot/volume_name.rego
@@ -18,5 +18,7 @@ conditions := [
   ]
 ]
 
-message := helpers.get_multi_summary(conditions, vars.variables).message
-details := helpers.get_multi_summary(conditions, vars.variables).details
+result := helpers.get_multi_summary(conditions, vars.variables)
+
+message := result.message
+details := result.details

--- a/policies/gcp/Google Distributed Cloud Edge/google_edgecontainer_cluster/networking.cluster_ipv4_cidr_blocks.rego
+++ b/policies/gcp/Google Distributed Cloud Edge/google_edgecontainer_cluster/networking.cluster_ipv4_cidr_blocks.rego
@@ -22,8 +22,10 @@ conditions := [
 # ------------------------------------------------------------
 # Compliance messages
 # ------------------------------------------------------------
-message := helpers.get_multi_summary(conditions, vars.variables).message
-details := helpers.get_multi_summary(conditions, vars.variables).details
+result := helpers.get_multi_summary(conditions, vars.variables)
+
+message := result.message
+details := result.details
 
 # Add this summary rule
 summary := {

--- a/policies/gcp/Google Distributed Cloud Edge/google_edgecontainer_cluster/target_version.rego
+++ b/policies/gcp/Google Distributed Cloud Edge/google_edgecontainer_cluster/target_version.rego
@@ -24,8 +24,10 @@ conditions := [
 # ------------------------------------------------------------
 # Compliance messages
 # ------------------------------------------------------------
-message := helpers.get_multi_summary(conditions, vars.variables).message
-details := helpers.get_multi_summary(conditions, vars.variables).details
+result := helpers.get_multi_summary(conditions, vars.variables)
+
+message := result.message
+details := result.details
 
 summary := {
     "message": message,

--- a/policies/gcp/Google Distributed Cloud Edge/google_edgecontainer_node_pool/local_disk_encryption.kms_key.rego
+++ b/policies/gcp/Google Distributed Cloud Edge/google_edgecontainer_node_pool/local_disk_encryption.kms_key.rego
@@ -18,8 +18,10 @@ conditions := [
     ],
 ]
 
-message := helpers.get_multi_summary(conditions, vars.variables).message
-details := helpers.get_multi_summary(conditions, vars.variables).details
+result := helpers.get_multi_summary(conditions, vars.variables)
+
+message := result.message
+details := result.details
 
 summary := {
     "message": message,

--- a/policies/gcp/Google Distributed Cloud Edge/google_edgecontainer_vpn_connection/vpc.rego
+++ b/policies/gcp/Google Distributed Cloud Edge/google_edgecontainer_vpn_connection/vpc.rego
@@ -18,8 +18,10 @@ conditions := [
     ]
 ]
 
-message := helpers.get_multi_summary(conditions, vars.variables).message
-details := helpers.get_multi_summary(conditions, vars.variables).details
+result := helpers.get_multi_summary(conditions, vars.variables)
+
+message := result.message
+details := result.details
 
 summary := {
     "message": message,

--- a/policies/gcp/Identity-Aware Proxy/google_iap_app_engine_service_iam_member/member.rego
+++ b/policies/gcp/Identity-Aware Proxy/google_iap_app_engine_service_iam_member/member.rego
@@ -119,5 +119,7 @@ conditions := [
 ]
 
 # Summaries (unchanged usage with your helpers)
-message := helpers.get_multi_summary(conditions, vars.variables).message
-details := helpers.get_multi_summary(conditions, vars.variables).details
+result := helpers.get_multi_summary(conditions, vars.variables)
+
+message := result.message
+details := result.details

--- a/policies/gcp/Identity-Aware Proxy/google_iap_app_engine_service_iam_member/role.rego
+++ b/policies/gcp/Identity-Aware Proxy/google_iap_app_engine_service_iam_member/role.rego
@@ -49,5 +49,7 @@ conditions := [
 ]
 
 # Summaries (same helper usage as member policy)
-message := helpers.get_multi_summary(conditions, vars.variables).message
-details := helpers.get_multi_summary(conditions, vars.variables).details
+result := helpers.get_multi_summary(conditions, vars.variables)
+
+message := result.message
+details := result.details

--- a/policies/gcp/Identity-Aware Proxy/google_iap_brand/application_title.rego
+++ b/policies/gcp/Identity-Aware Proxy/google_iap_brand/application_title.rego
@@ -33,5 +33,7 @@ conditions := [
   ]
 ]
 
-message := helpers.get_multi_summary(conditions, vars.variables).message
-details := helpers.get_multi_summary(conditions, vars.variables).details
+result := helpers.get_multi_summary(conditions, vars.variables)
+
+message := result.message
+details := result.details

--- a/policies/gcp/Identity-Aware Proxy/google_iap_brand/support_email.rego
+++ b/policies/gcp/Identity-Aware Proxy/google_iap_brand/support_email.rego
@@ -38,5 +38,7 @@ conditions := [
   ]
 ]
 
-message := helpers.get_multi_summary(conditions, vars.variables).message
-details := helpers.get_multi_summary(conditions, vars.variables).details
+result := helpers.get_multi_summary(conditions, vars.variables)
+
+message := result.message
+details := result.details

--- a/policies/gcp/Identity-Aware Proxy/google_iap_settings/application_settings.cookie_domain.rego
+++ b/policies/gcp/Identity-Aware Proxy/google_iap_settings/application_settings.cookie_domain.rego
@@ -50,5 +50,7 @@ conditions := [
 ]
 
 # Summaries (same helper usage)
-message := helpers.get_multi_summary(conditions, vars.variables).message
-details := helpers.get_multi_summary(conditions, vars.variables).details
+result := helpers.get_multi_summary(conditions, vars.variables)
+
+message := result.message
+details := result.details

--- a/policies/gcp/Memorystore/google_memorystore_instance/authorization_mode.rego
+++ b/policies/gcp/Memorystore/google_memorystore_instance/authorization_mode.rego
@@ -21,5 +21,5 @@ conditions := [
 ]
 summary := helpers.get_multi_summary(conditions, vars.variables)
 
-message := helpers.get_multi_summary(conditions, vars.variables).message
-details := helpers.get_multi_summary(conditions, vars.variables).details
+message := summary.message
+details := summary.details

--- a/policies/gcp/Model Armor/google_model_armor_floorsetting/filter_config.malicious_uri_filter_settings.filter_enforcement.rego
+++ b/policies/gcp/Model Armor/google_model_armor_floorsetting/filter_config.malicious_uri_filter_settings.filter_enforcement.rego
@@ -33,5 +33,7 @@ conditions := [
   ]
 ]
 
-message := helpers.get_multi_summary(conditions, vars.variables).message
-details := helpers.get_multi_summary(conditions, vars.variables).details
+result := helpers.get_multi_summary(conditions, vars.variables)
+
+message := result.message
+details := result.details

--- a/policies/gcp/Model Armor/google_model_armor_floorsetting/filter_config.rai_settings.rai_filters.confidence_level.rego
+++ b/policies/gcp/Model Armor/google_model_armor_floorsetting/filter_config.rai_settings.rai_filters.confidence_level.rego
@@ -31,5 +31,7 @@ conditions := [
   ]
 ]
 
-message := helpers.get_multi_summary(conditions, vars.variables).message
-details := helpers.get_multi_summary(conditions, vars.variables).details
+result := helpers.get_multi_summary(conditions, vars.variables)
+
+message := result.message
+details := result.details

--- a/policies/gcp/Model Armor/google_model_armor_floorsetting/filter_config.rai_settings.rai_filters.filter_type.rego
+++ b/policies/gcp/Model Armor/google_model_armor_floorsetting/filter_config.rai_settings.rai_filters.filter_type.rego
@@ -19,5 +19,7 @@ conditions := [
   ]
 ]
 
-message := helpers.get_multi_summary(conditions, vars.variables).message
-details := helpers.get_multi_summary(conditions, vars.variables).details
+result := helpers.get_multi_summary(conditions, vars.variables)
+
+message := result.message
+details := result.details

--- a/policies/gcp/Model Armor/google_model_armor_floorsetting/location.rego
+++ b/policies/gcp/Model Armor/google_model_armor_floorsetting/location.rego
@@ -19,5 +19,7 @@ conditions := [
   ]
 ]
 
-message := helpers.get_multi_summary(conditions, vars.variables).message
-details := helpers.get_multi_summary(conditions, vars.variables).details
+result := helpers.get_multi_summary(conditions, vars.variables)
+
+message := result.message
+details := result.details

--- a/policies/gcp/Model Armor/google_model_armor_template/filter_config.malicious_uri_filter_settings.filter_enforcement.rego
+++ b/policies/gcp/Model Armor/google_model_armor_template/filter_config.malicious_uri_filter_settings.filter_enforcement.rego
@@ -33,5 +33,7 @@ conditions := [
   ]
 ]
 
-message := helpers.get_multi_summary(conditions, vars.variables).message
-details := helpers.get_multi_summary(conditions, vars.variables).details
+result := helpers.get_multi_summary(conditions, vars.variables)
+
+message := result.message
+details := result.details

--- a/policies/gcp/Model Armor/google_model_armor_template/filter_config.rai_settings.rai_filters.confidence_level.rego
+++ b/policies/gcp/Model Armor/google_model_armor_template/filter_config.rai_settings.rai_filters.confidence_level.rego
@@ -31,5 +31,7 @@ conditions := [
   ]
 ]
 
-message := helpers.get_multi_summary(conditions, vars.variables).message
-details := helpers.get_multi_summary(conditions, vars.variables).details
+result := helpers.get_multi_summary(conditions, vars.variables)
+
+message := result.message
+details := result.details

--- a/policies/gcp/Model Armor/google_model_armor_template/filter_config.rai_settings.rai_filters.filter_type.rego
+++ b/policies/gcp/Model Armor/google_model_armor_template/filter_config.rai_settings.rai_filters.filter_type.rego
@@ -20,5 +20,7 @@ conditions := [
   ]
 ]
 
-message := helpers.get_multi_summary(conditions, vars.variables).message
-details := helpers.get_multi_summary(conditions, vars.variables).details
+result := helpers.get_multi_summary(conditions, vars.variables)
+
+message := result.message
+details := result.details

--- a/policies/gcp/Model Armor/google_model_armor_template/location.rego
+++ b/policies/gcp/Model Armor/google_model_armor_template/location.rego
@@ -19,5 +19,7 @@ conditions := [
   ]
 ]
 
-message := helpers.get_multi_summary(conditions, vars.variables).message
-details := helpers.get_multi_summary(conditions, vars.variables).details
+result := helpers.get_multi_summary(conditions, vars.variables)
+
+message := result.message
+details := result.details

--- a/policies/gcp/OS Config v2/google_os_config_v2_policy_orchestrator/action.rego
+++ b/policies/gcp/OS Config v2/google_os_config_v2_policy_orchestrator/action.rego
@@ -22,5 +22,7 @@ conditions := [
     ],
 ]
 
-message := helpers.get_multi_summary(conditions, vars.variables).message
-details := helpers.get_multi_summary(conditions, vars.variables).details
+result := helpers.get_multi_summary(conditions, vars.variables)
+
+message := result.message
+details := result.details

--- a/policies/gcp/OS Config v2/google_os_config_v2_policy_orchestrator/orchestrated_resource.os_policy_assignment_v1_payload.instance_filter.inventories.os_short_name.rego
+++ b/policies/gcp/OS Config v2/google_os_config_v2_policy_orchestrator/orchestrated_resource.os_policy_assignment_v1_payload.instance_filter.inventories.os_short_name.rego
@@ -15,5 +15,7 @@ conditions := [
     ]
 ]
 
-message := helpers.get_multi_summary(conditions, vars.variables).message
-details := helpers.get_multi_summary(conditions, vars.variables).details
+result := helpers.get_multi_summary(conditions, vars.variables)
+
+message := result.message
+details := result.details

--- a/policies/gcp/OS Config v2/google_os_config_v2_policy_orchestrator/orchestration_scope.selectors.location_selector.included_locations.rego
+++ b/policies/gcp/OS Config v2/google_os_config_v2_policy_orchestrator/orchestration_scope.selectors.location_selector.included_locations.rego
@@ -21,5 +21,7 @@ conditions := [
     ],
 ]
 
-message := helpers.get_multi_summary(conditions, vars.variables).message
-details := helpers.get_multi_summary(conditions, vars.variables).details
+result := helpers.get_multi_summary(conditions, vars.variables)
+
+message := result.message
+details := result.details

--- a/policies/gcp/OS Config v2/google_os_config_v2_policy_orchestrator_for_folder/action.rego
+++ b/policies/gcp/OS Config v2/google_os_config_v2_policy_orchestrator_for_folder/action.rego
@@ -22,5 +22,7 @@ conditions := [
     ],
 ]
 
-message := helpers.get_multi_summary(conditions, vars.variables).message
-details := helpers.get_multi_summary(conditions, vars.variables).details
+result := helpers.get_multi_summary(conditions, vars.variables)
+
+message := result.message
+details := result.details

--- a/policies/gcp/OS Config v2/google_os_config_v2_policy_orchestrator_for_folder/orchestrated_resource.os_policy_assignment_v1_payload.instance_filter.inventories.os_short_name.rego
+++ b/policies/gcp/OS Config v2/google_os_config_v2_policy_orchestrator_for_folder/orchestrated_resource.os_policy_assignment_v1_payload.instance_filter.inventories.os_short_name.rego
@@ -15,5 +15,7 @@ conditions := [
     ]
 ]
 
-message := helpers.get_multi_summary(conditions, vars.variables).message
-details := helpers.get_multi_summary(conditions, vars.variables).details
+result := helpers.get_multi_summary(conditions, vars.variables)
+
+message := result.message
+details := result.details

--- a/policies/gcp/OS Config v2/google_os_config_v2_policy_orchestrator_for_folder/orchestration_scope.selectors.location_selector.included_locations.rego
+++ b/policies/gcp/OS Config v2/google_os_config_v2_policy_orchestrator_for_folder/orchestration_scope.selectors.location_selector.included_locations.rego
@@ -21,5 +21,7 @@ conditions := [
     ],
 ]
 
-message := helpers.get_multi_summary(conditions, vars.variables).message
-details := helpers.get_multi_summary(conditions, vars.variables).details
+result := helpers.get_multi_summary(conditions, vars.variables)
+
+message := result.message
+details := result.details

--- a/policies/gcp/OS Config v2/google_os_config_v2_policy_orchestrator_for_organization/action.rego
+++ b/policies/gcp/OS Config v2/google_os_config_v2_policy_orchestrator_for_organization/action.rego
@@ -22,5 +22,7 @@ conditions := [
     ],
 ]
 
-message := helpers.get_multi_summary(conditions, vars.variables).message
-details := helpers.get_multi_summary(conditions, vars.variables).details
+result := helpers.get_multi_summary(conditions, vars.variables)
+
+message := result.message
+details := result.details

--- a/policies/gcp/OS Config v2/google_os_config_v2_policy_orchestrator_for_organization/orchestrated_resource.os_policy_assignment_v1_payload.instance_filter.inventories.os_short_name.rego
+++ b/policies/gcp/OS Config v2/google_os_config_v2_policy_orchestrator_for_organization/orchestrated_resource.os_policy_assignment_v1_payload.instance_filter.inventories.os_short_name.rego
@@ -15,5 +15,7 @@ conditions := [
     ]
 ]
 
-message := helpers.get_multi_summary(conditions, vars.variables).message
-details := helpers.get_multi_summary(conditions, vars.variables).details
+result := helpers.get_multi_summary(conditions, vars.variables)
+
+message := result.message
+details := result.details

--- a/policies/gcp/OS Config v2/google_os_config_v2_policy_orchestrator_for_organization/organization_id.rego
+++ b/policies/gcp/OS Config v2/google_os_config_v2_policy_orchestrator_for_organization/organization_id.rego
@@ -19,5 +19,7 @@ conditions := [
     ],
 ]
 
-message := helpers.get_multi_summary(conditions, vars.variables).message
-details := helpers.get_multi_summary(conditions, vars.variables).details
+result := helpers.get_multi_summary(conditions, vars.variables)
+
+message := result.message
+details := result.details

--- a/policies/gcp/OS Config v2/google_os_config_v2_policy_orchestrator_for_organization/policy_orchestrator_id.rego
+++ b/policies/gcp/OS Config v2/google_os_config_v2_policy_orchestrator_for_organization/policy_orchestrator_id.rego
@@ -16,5 +16,7 @@ conditions := [
     ],
 ]
 
-message := helpers.get_multi_summary(conditions, vars.variables).message
-details := helpers.get_multi_summary(conditions, vars.variables).details
+result := helpers.get_multi_summary(conditions, vars.variables)
+
+message := result.message
+details := result.details

--- a/policies/gcp/Parallelstore/google_parallelstore_instance/location.rego
+++ b/policies/gcp/Parallelstore/google_parallelstore_instance/location.rego
@@ -18,5 +18,7 @@ conditions := [
   ]
 ]
 
-message := helpers.get_multi_summary(conditions, vars.variables).message
-details := helpers.get_multi_summary(conditions, vars.variables).details
+result := helpers.get_multi_summary(conditions, vars.variables)
+
+message := result.message
+details := result.details

--- a/policies/gcp/Parameter Manager/google_parameter_manager_parameter/kms_key.rego
+++ b/policies/gcp/Parameter Manager/google_parameter_manager_parameter/kms_key.rego
@@ -19,4 +19,4 @@ conditions := [[
 summary := helpers.get_multi_summary(conditions, vars.variables)
 message := summary.message
 
-details := helpers.get_multi_summary(conditions, vars.variables).details
+details := summary.details

--- a/policies/gcp/Parameter Manager/google_parameter_manager_regional_parameter/kms_key.rego
+++ b/policies/gcp/Parameter Manager/google_parameter_manager_regional_parameter/kms_key.rego
@@ -19,4 +19,4 @@ conditions := [[
 summary := helpers.get_multi_summary(conditions, vars.variables)
 message := summary.message
 
-details := helpers.get_multi_summary(conditions, vars.variables).details
+details := summary.details

--- a/policies/gcp/Parameter Manager/google_parameter_manager_regional_parameter/location.rego
+++ b/policies/gcp/Parameter Manager/google_parameter_manager_regional_parameter/location.rego
@@ -19,4 +19,4 @@ conditions := [[
 summary := helpers.get_multi_summary(conditions, vars.variables)
 message := summary.message
 
-details := helpers.get_multi_summary(conditions, vars.variables).details
+details := summary.details

--- a/policies/gcp/Privileged Access Manager/google_privileged_access_manager_entitlement/additional_notification_targets.admin_email_recipients.rego
+++ b/policies/gcp/Privileged Access Manager/google_privileged_access_manager_entitlement/additional_notification_targets.admin_email_recipients.rego
@@ -18,5 +18,7 @@ conditions := [
     ],
 ]
 
-message := helpers.get_multi_summary(conditions, vars.variables).message
-details := helpers.get_multi_summary(conditions, vars.variables).details
+result := helpers.get_multi_summary(conditions, vars.variables)
+
+message := result.message
+details := result.details

--- a/policies/gcp/Privileged Access Manager/google_privileged_access_manager_entitlement/approval_workflow.manual_approvals.steps.approvals_needed.rego
+++ b/policies/gcp/Privileged Access Manager/google_privileged_access_manager_entitlement/approval_workflow.manual_approvals.steps.approvals_needed.rego
@@ -19,5 +19,7 @@ conditions := [
 ]
 
 
-message := helpers.get_multi_summary(conditions, vars.variables).message
-details := helpers.get_multi_summary(conditions, vars.variables).details
+result := helpers.get_multi_summary(conditions, vars.variables)
+
+message := result.message
+details := result.details

--- a/policies/gcp/Privileged Access Manager/google_privileged_access_manager_entitlement/eligible_users.principals.rego
+++ b/policies/gcp/Privileged Access Manager/google_privileged_access_manager_entitlement/eligible_users.principals.rego
@@ -18,5 +18,7 @@ conditions := [
     ],
 ]
 
-message := helpers.get_multi_summary(conditions, vars.variables).message
-details := helpers.get_multi_summary(conditions, vars.variables).details
+result := helpers.get_multi_summary(conditions, vars.variables)
+
+message := result.message
+details := result.details

--- a/policies/gcp/Privileged Access Manager/google_privileged_access_manager_entitlement/location.rego
+++ b/policies/gcp/Privileged Access Manager/google_privileged_access_manager_entitlement/location.rego
@@ -18,5 +18,7 @@ conditions := [
 ]
 
 
-message := helpers.get_multi_summary(conditions, vars.variables).message
-details := helpers.get_multi_summary(conditions, vars.variables).details
+result := helpers.get_multi_summary(conditions, vars.variables)
+
+message := result.message
+details := result.details

--- a/policies/gcp/Privileged Access Manager/google_privileged_access_manager_entitlement/max_request_duration.rego
+++ b/policies/gcp/Privileged Access Manager/google_privileged_access_manager_entitlement/max_request_duration.rego
@@ -18,5 +18,7 @@ conditions := [
   ]
 ]
 
-message := helpers.get_multi_summary(conditions, vars.variables).message
-details := helpers.get_multi_summary(conditions, vars.variables).details
+result := helpers.get_multi_summary(conditions, vars.variables)
+
+message := result.message
+details := result.details

--- a/policies/gcp/Privileged Access Manager/google_privileged_access_manager_entitlement/privileged_access.gcp_iam_access.role_bindings.role.rego
+++ b/policies/gcp/Privileged Access Manager/google_privileged_access_manager_entitlement/privileged_access.gcp_iam_access.role_bindings.role.rego
@@ -15,5 +15,7 @@ conditions := [
   ],
 ]
 
-message := helpers.get_multi_summary(conditions, vars.variables).message
-details := helpers.get_multi_summary(conditions, vars.variables).details
+result := helpers.get_multi_summary(conditions, vars.variables)
+
+message := result.message
+details := result.details

--- a/policies/gcp/RecaptchaEnterprise/google_recaptcha_enterprise_key/web_settings.allow_all_domains.rego
+++ b/policies/gcp/RecaptchaEnterprise/google_recaptcha_enterprise_key/web_settings.allow_all_domains.rego
@@ -20,5 +20,7 @@ conditions := [
   ]
 ]
 
-message := helpers.get_multi_summary(conditions, vars.variables).message
-details := helpers.get_multi_summary(conditions, vars.variables).details
+result := helpers.get_multi_summary(conditions, vars.variables)
+
+message := result.message
+details := result.details

--- a/policies/gcp/Security Command Center (SCC)/google_scc_event_threat_detection_custom_module/enablement_state.rego
+++ b/policies/gcp/Security Command Center (SCC)/google_scc_event_threat_detection_custom_module/enablement_state.rego
@@ -16,5 +16,7 @@ conditions := [
     ]
 ]
 
-message := helpers.get_multi_summary(conditions, vars.variables).message
-details := helpers.get_multi_summary(conditions, vars.variables).details
+result := helpers.get_multi_summary(conditions, vars.variables)
+
+message := result.message
+details := result.details

--- a/policies/gcp/Security Command Center (SCC)/google_scc_folder_custom_module/enablement_state.rego
+++ b/policies/gcp/Security Command Center (SCC)/google_scc_folder_custom_module/enablement_state.rego
@@ -16,5 +16,7 @@ conditions := [
     ]
 ]
    
-message := helpers.get_multi_summary(conditions, vars.variables).message
-details := helpers.get_multi_summary(conditions, vars.variables).details
+result := helpers.get_multi_summary(conditions, vars.variables)
+
+message := result.message
+details := result.details

--- a/policies/gcp/Security Command Center (SCC)/google_scc_notification_config/organization.rego
+++ b/policies/gcp/Security Command Center (SCC)/google_scc_notification_config/organization.rego
@@ -18,5 +18,7 @@ conditions := [
   ]
 ]
 
-message := helpers.get_multi_summary(conditions, vars.variables).message
-details := helpers.get_multi_summary(conditions, vars.variables).details
+result := helpers.get_multi_summary(conditions, vars.variables)
+
+message := result.message
+details := result.details

--- a/policies/gcp/Security Command Center (SCC)/google_scc_notification_config/pubsub_topic.rego
+++ b/policies/gcp/Security Command Center (SCC)/google_scc_notification_config/pubsub_topic.rego
@@ -24,5 +24,7 @@ conditions := [
   ]
 ]
 
-message := helpers.get_multi_summary(conditions, vars.variables).message
-details := helpers.get_multi_summary(conditions, vars.variables).details
+result := helpers.get_multi_summary(conditions, vars.variables)
+
+message := result.message
+details := result.details

--- a/policies/gcp/Security Command Center (SCC)/google_scc_notification_config/streaming_config.filter.rego
+++ b/policies/gcp/Security Command Center (SCC)/google_scc_notification_config/streaming_config.filter.rego
@@ -25,5 +25,7 @@ conditions := [
   ]
 ]
 
-message := helpers.get_multi_summary(conditions, vars.variables).message
-details := helpers.get_multi_summary(conditions, vars.variables).details
+result := helpers.get_multi_summary(conditions, vars.variables)
+
+message := result.message
+details := result.details

--- a/policies/gcp/Security Command Center (SCC)/google_scc_organization_custom_module/enablement_state.rego
+++ b/policies/gcp/Security Command Center (SCC)/google_scc_organization_custom_module/enablement_state.rego
@@ -16,5 +16,7 @@ conditions := [
     ]
 ]
    
-message := helpers.get_multi_summary(conditions, vars.variables).message
-details := helpers.get_multi_summary(conditions, vars.variables).details
+result := helpers.get_multi_summary(conditions, vars.variables)
+
+message := result.message
+details := result.details

--- a/policies/gcp/Security Command Center (SCC)/google_scc_organization_scc_big_query_export/dataset.rego
+++ b/policies/gcp/Security Command Center (SCC)/google_scc_organization_scc_big_query_export/dataset.rego
@@ -23,5 +23,7 @@ conditions := [
 ]
 
 
-message := helpers.get_multi_summary(conditions, vars.variables).message
-details := helpers.get_multi_summary(conditions, vars.variables).details
+result := helpers.get_multi_summary(conditions, vars.variables)
+
+message := result.message
+details := result.details

--- a/policies/gcp/Security Command Center (SCC)/google_scc_organization_scc_big_query_export/filter.rego
+++ b/policies/gcp/Security Command Center (SCC)/google_scc_organization_scc_big_query_export/filter.rego
@@ -38,5 +38,7 @@ conditions := [
 ]
 
 
-message := helpers.get_multi_summary(conditions, vars.variables).message
-details := helpers.get_multi_summary(conditions, vars.variables).details
+result := helpers.get_multi_summary(conditions, vars.variables)
+
+message := result.message
+details := result.details

--- a/policies/gcp/Security Command Center (SCC)/google_scc_project_custom_module/enablement_state.rego
+++ b/policies/gcp/Security Command Center (SCC)/google_scc_project_custom_module/enablement_state.rego
@@ -16,5 +16,7 @@ conditions := [
     ]
 ]
    
-message := helpers.get_multi_summary(conditions, vars.variables).message
-details := helpers.get_multi_summary(conditions, vars.variables).details
+result := helpers.get_multi_summary(conditions, vars.variables)
+
+message := result.message
+details := result.details

--- a/policies/gcp/Serverless VPC Access/google_vpc_access_connector/ip_cidr_range.rego
+++ b/policies/gcp/Serverless VPC Access/google_vpc_access_connector/ip_cidr_range.rego
@@ -30,5 +30,7 @@ conditions := [
     ]
 ]
 
-message := helpers.get_multi_summary(conditions, vars.variables).message
-details := helpers.get_multi_summary(conditions, vars.variables).details
+result := helpers.get_multi_summary(conditions, vars.variables)
+
+message := result.message
+details := result.details

--- a/policies/gcp/Serverless VPC Access/google_vpc_access_connector/machine_type.rego
+++ b/policies/gcp/Serverless VPC Access/google_vpc_access_connector/machine_type.rego
@@ -30,5 +30,7 @@ conditions := [
     ]
 ]
 
-message := helpers.get_multi_summary(conditions, vars.variables).message
-details := helpers.get_multi_summary(conditions, vars.variables).details
+result := helpers.get_multi_summary(conditions, vars.variables)
+
+message := result.message
+details := result.details

--- a/policies/gcp/Serverless VPC Access/google_vpc_access_connector/max_instances.rego
+++ b/policies/gcp/Serverless VPC Access/google_vpc_access_connector/max_instances.rego
@@ -30,5 +30,7 @@ conditions := [
     ]
 ]
 
-message := helpers.get_multi_summary(conditions, vars.variables).message
-details := helpers.get_multi_summary(conditions, vars.variables).details
+result := helpers.get_multi_summary(conditions, vars.variables)
+
+message := result.message
+details := result.details

--- a/policies/gcp/Serverless VPC Access/google_vpc_access_connector/max_throughput.rego
+++ b/policies/gcp/Serverless VPC Access/google_vpc_access_connector/max_throughput.rego
@@ -30,5 +30,7 @@ conditions := [
     ]
 ]
 
-message := helpers.get_multi_summary(conditions, vars.variables).message
-details := helpers.get_multi_summary(conditions, vars.variables).details
+result := helpers.get_multi_summary(conditions, vars.variables)
+
+message := result.message
+details := result.details

--- a/policies/gcp/Serverless VPC Access/google_vpc_access_connector/min_instances.rego
+++ b/policies/gcp/Serverless VPC Access/google_vpc_access_connector/min_instances.rego
@@ -30,5 +30,7 @@ conditions := [
     ]
 ]
 
-message := helpers.get_multi_summary(conditions, vars.variables).message
-details := helpers.get_multi_summary(conditions, vars.variables).details
+result := helpers.get_multi_summary(conditions, vars.variables)
+
+message := result.message
+details := result.details

--- a/policies/gcp/Serverless VPC Access/google_vpc_access_connector/min_throughput.rego
+++ b/policies/gcp/Serverless VPC Access/google_vpc_access_connector/min_throughput.rego
@@ -30,5 +30,7 @@ conditions := [
     ]
 ]
 
-message := helpers.get_multi_summary(conditions, vars.variables).message
-details := helpers.get_multi_summary(conditions, vars.variables).details
+result := helpers.get_multi_summary(conditions, vars.variables)
+
+message := result.message
+details := result.details

--- a/policies/gcp/Serverless VPC Access/google_vpc_access_connector/network.rego
+++ b/policies/gcp/Serverless VPC Access/google_vpc_access_connector/network.rego
@@ -30,5 +30,7 @@ conditions := [
     ]
 ]
 
-message := helpers.get_multi_summary(conditions, vars.variables).message
-details := helpers.get_multi_summary(conditions, vars.variables).details
+result := helpers.get_multi_summary(conditions, vars.variables)
+
+message := result.message
+details := result.details

--- a/policies/gcp/Serverless VPC Access/google_vpc_access_connector/region.rego
+++ b/policies/gcp/Serverless VPC Access/google_vpc_access_connector/region.rego
@@ -30,5 +30,7 @@ conditions := [
     ]
 ]
 
-message := helpers.get_multi_summary(conditions, vars.variables).message
-details := helpers.get_multi_summary(conditions, vars.variables).details
+result := helpers.get_multi_summary(conditions, vars.variables)
+
+message := result.message
+details := result.details

--- a/policies/gcp/Serverless VPC Access/google_vpc_access_connector/subnet.name.rego
+++ b/policies/gcp/Serverless VPC Access/google_vpc_access_connector/subnet.name.rego
@@ -30,5 +30,7 @@ conditions := [
     ]
 ]
 
-message := helpers.get_multi_summary(conditions, vars.variables).message
-details := helpers.get_multi_summary(conditions, vars.variables).details
+result := helpers.get_multi_summary(conditions, vars.variables)
+
+message := result.message
+details := result.details


### PR DESCRIPTION
Mechanical cleanup so the tree itself shows contributors what good looks like. **No policy changes behaviour** — see the verification below.

| rule | before | after |
|---|---:|---:|
| repeated-helper-call | 498 | **5** |
| legacy-assign | 8 | **0** |
| *(all 11 other rules)* | 758 | 758 |
| **total** | **1,264** | **763** |

No rule's count rose. 501 files changed, all under `policies/gcp/`.

## What changed

**493 × repeated-helper-call.** The helper is now called once and bound, with the fields read off the binding — the shape 515 files already used. Two forms handled: the pure case (no binding, 419 files) gains `result := helpers.get_multi_summary(...)`; the hybrid case (74 files that already had a binding *and* still re-called the helper) keeps its binding and only loses the leftover calls. 9 files spell it `data.terraform.helpers.…` and keep that prefix.

**8 × legacy-assign.** `message = result.message` → `:=`.

## Five files deliberately skipped

They are being edited right now on open `Service/*` branches, and rewriting them here would hand those contributors a merge conflict in work they are mid-way through:

```
policies/gcp/BigQuery/google_bigquery_routine/data_governance_type.rego
policies/gcp/BigQuery/google_bigquery_routine/remote_function_options.connection.rego
policies/gcp/BigQuery/google_bigquery_routine/remote_function_options.endpoint.rego
policies/gcp/BigQuery/google_bigquery_routine/security_mode.rego
policies/gcp/Discovery Engine/google_discovery_engine_control/redirect_action.redirect_uri.rego
```

Those are exactly the 5 remaining findings. Verified against all 808 `.rego` paths touched by the 229 live `Service/*` branches: this commit touches none of them.

## Verification — behavioural, not just structural

- **`opa eval` document-tree comparison, `dev` vs this branch**: 83,700 package evaluations across an empty input plus 60 randomly sampled committed plan caches (61,380 of them producing a non-empty violation list, so the substantive branch was exercised). **Zero differences in the value of any pre-existing rule.** The only structural change is 419 packages gaining one `result` rule.
- `opa check policies/` exit 0. `--strict` reports the same 10 pre-existing unused-import errors as `dev`, no new ones.
- `linter.py` clean; linter tests 106 passed; full suite 182 passed.

What that does **not** prove: it isn't an exhaustive input space. But every edit is a pure hoist or a `=`→`:=` rename of an already-evaluated expression, so there is no input-dependent branch to miss.

## Not attempted

`package-case` (40) was investigated and deliberately skipped: renaming a package segment moves the OPA document path the pipeline addresses, and three separate conventions in this repo disagree on the target name (`big_query` per the rules page, `bigquery` per the branch-slug scheme, and `linter.py` documents that the segment intentionally differs from the folder). That is a human decision, not a derivation — and it's a warn.

`fixture-drift`, `hard-coded-value`, `presence-only`, `index-path`, `trivial-message`, `vars-friendly-name` all need judgement about intent and are being handled separately.

## One edit worth a human eye

`policies/gcp/Spanner/google_spanner_instance/force_destroy.rego` had **two** bindings of the same call; it now reads `summary := result`. Semantically identical and `opa check` is happy, but it is the one rewrite that makes a rule depend on another rather than being purely local.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015uFmZRNFNqoTccW58Kbs4b