### PR TITLE
Lint corrections: repeated-helper-call fails, fixture pairing rule was wrong, docs said something false

### DIFF
--- a/Guide/Policy_writing_tutorial/c-tf-and-nc-tf.md
+++ b/Guide/Policy_writing_tutorial/c-tf-and-nc-tf.md
@@ -69,8 +69,21 @@ resource "google_cloudfunctions_function" "non_compliant_example_1" {
 ```
 
 > **Fixture labels matter:** the linter requires both the resource label **and** the `name`
-> argument to follow `compliant_example_N` / `non_compliant_example_N` (numbered from 1). Add
-> further numbered blocks (`compliant_example_2`, …) if you need more than one example.
+> argument to follow `compliant_example_N` / `non_compliant_example_N`, numbered sequentially
+> from 1 within each file. Add further numbered blocks (`compliant_example_2`, …) if you need
+> more than one example.
+
+> **The two files do not have to hold the same number of examples.** `compliant.tf` and
+> `nonCompliant.tf` are numbered independently, and the harness matches each example by its
+> label, not by pairing them up — every `non_compliant_example_N` must be flagged by your policy,
+> and no `compliant_example_N` may be. So **N compliant against M non-compliant is fine**, and
+> one compliant baseline tested against several non-compliant examples — each breaking the rule
+> in a different way — is the shape to aim for. What you must never have is nothing on one side:
+> a fixture with no compliant example, or none non-compliant, is reported as
+> [`fixture-one-sided`](policy-lint.md#fixture-one-sided).
+
+Whatever else differs between the two files, the argument under test should be the **only**
+attribute whose value changes — see [`fixture-drift`](policy-lint.md#fixture-drift).
 
 <div align="center"> 
 

--- a/Guide/Policy_writing_tutorial/policy-lint.md
+++ b/Guide/Policy_writing_tutorial/policy-lint.md
@@ -188,6 +188,10 @@ Good — only the tested argument differs:
       public_access_prevention = "inherited"
     }
 
+Every example is compared, including one that has no same-numbered counterpart on the other
+side: an example without a numbered twin is compared against the **lowest-numbered** example
+opposite it. Adding a third non-compliant example therefore does not exempt it from this rule.
+
 These keys are expected to differ and are never reported:
 
 - `name` — the example's own label.
@@ -198,19 +202,33 @@ These keys are expected to differ and are never reported:
   example label itself** (`bucket = "compliant_example_1"`). Two genuinely different values there
   (`bucket = "prod-data-bucket"` vs `"dev-scratch-bucket"`) are drift like any other.
 
-## fixture-unpaired
+## fixture-one-sided
 
-An example has no counterpart with the same number: a `non_compliant_example_2` with no
-`compliant_example_2`, or the other way round. The harness compares the two halves of each
-numbered pair, so a lone example is never compared to anything — it looks like extra coverage but
-tests nothing.
+Your fixture has examples on one side only: no `compliant_example_N` at all, or no
+`non_compliant_example_N` at all.
 
-Either add the missing half with the same number, or renumber so every example is one half of a
-pair:
+That is the one fixture shape the harness cannot say anything about. It checks two things across
+your examples — every `non_compliant_example_N` **must** be flagged, and no `compliant_example_N`
+may be. With no non-compliant example there is nothing that has to be flagged, so a policy that
+matches nothing passes. With no compliant example there is nothing that has to stay unflagged, so
+a policy that flags everything passes. Either way the harness goes green and your policy is
+untested.
+
+Add the missing side — one example is enough — and run the harness again.
+
+**You do not need the same number of each.** The harness matches examples by their *label*, not by
+their number: a `non_compliant_example_3` with no `compliant_example_3` is evaluated exactly like
+every other non-compliant example. One compliant baseline tested against several non-compliant
+examples, each breaking the rule a different way, is a good fixture — several resource types in
+this repo are written that way deliberately, and none of them is a finding.
+
+Numbering is still required — sequential from 1, checked by `linter.py` — but
+the two files are numbered independently of each other:
 
     # compliant.tf                        # nonCompliant.tf
-    ..."compliant_example_1" { ... }      ..."non_compliant_example_1" { ... }
-    ..."compliant_example_2" { ... }      ..."non_compliant_example_2" { ... }
+    ..."compliant_example_1" { ... }      ..."non_compliant_example_1" { ... }   # not set
+                                          ..."non_compliant_example_2" { ... }   # wrong value
+                                          ..."non_compliant_example_3" { ... }   # wrong shape
 
 ## fixture-missing-plan
 
@@ -299,7 +317,10 @@ but never blocks on.
 The same helper is called twice with the same arguments, so the same work is done twice. The
 usual shape is `message` and `details` each writing the `helpers.get_multi_summary(...)` call out
 again — OPA then evaluates the whole `conditions` list once per field. Call it once, give the
-result a name, and read the fields off that name. A warning only; it never fails a build.
+result a name, and read the fields off that name.
+
+**This one fails the build.** Only the files your branch changed are checked, so an older policy
+elsewhere in the tree is never held against you — but a file you touch has to be clean.
 
 Bad:
 

--- a/scripts/linters/_tests/test_policy_lint.py
+++ b/scripts/linters/_tests/test_policy_lint.py
@@ -213,13 +213,23 @@ def test_repeated_helper_call_generalises_beyond_get_multi_summary(tmp_path):
     assert "use `result` at each of those sites" in same[0].message
 
 
-def test_repeated_helper_call_is_advisory(tmp_path):
-    """Style, not correctness: it must never fail a student's build on its own."""
+def test_repeated_helper_call_is_an_error(tmp_path):
+    """It fails the build: the owner's call, and CI only lints files you changed."""
     root = build_tree(tmp_path, "repeated_helper")
     findings = policy_lint.lint_resource(root, *REPEATED_HELPER)
     reported = [f for f in findings if f.rule == "repeated-helper-call"]
-    assert reported and all(f.severity == "warn" for f in reported)
-    assert "repeated-helper-call" in policy_lint.WARN_RULES
+    assert reported and all(f.severity == "error" for f in reported)
+    assert "repeated-helper-call" not in policy_lint.WARN_RULES
+
+
+def test_repeated_helper_call_fails_the_cli(tmp_path, capsys):
+    # Severity is only real if it moves the exit code.
+    root = build_tree(tmp_path, "repeated_helper")
+    rc = policy_lint.main(
+        ["--root", str(root), "--json", "gcp/GKEHub/google_gke_hub_scope_iam_policy"])
+    data = json.loads(capsys.readouterr().out)
+    assert rc == 1
+    assert {e["severity"] for e in data if e["rule"] == "repeated-helper-call"} == {"error"}
 
 
 def test_repeated_helper_call_reads_past_strings_and_comments():
@@ -631,27 +641,109 @@ def test_missing_opa_binary_is_one_cli_error(tmp_path, monkeypatch, capsys):
 
 
 # --------------------------------------------------------------------------- #
-# Fix wave 2: unpaired fixture resources are reported, not skipped.
+# Correction: an example without a numbered twin is still fully evaluated by the
+# harness, so only a fixture with nothing on one side is untested.
 # --------------------------------------------------------------------------- #
-def test_unpaired_fixture_resource_is_reported(tmp_path):
-    root = build_tree(tmp_path, "clean")
+CLEAN_BUCKET = ("gcp", "Cloud Storage", "google_storage_bucket")
+CLEAN_BUCKET_ARG = "public_access_prevention"
+
+
+def _bucket_plan(root):
+    """(cache_path, plan, resources) for the clean tree's bucket fixture."""
     input_dir = (root / "inputs" / "gcp" / "Cloud Storage" / "google_storage_bucket"
-                 / "public_access_prevention")
+                 / CLEAN_BUCKET_ARG)
     cache = policy_lint.plan_cache_for(root, input_dir)
     plan = json.loads(cache.read_text())
-    resources = plan["planned_values"]["root_module"]["resources"]
-    # A second non-compliant example with no compliant counterpart.
-    orphan = json.loads(json.dumps(
-        [r for r in resources if r["name"] == "non_compliant_example_1"][0]))
-    orphan["name"] = "non_compliant_example_2"
-    orphan["values"]["name"] = "non_compliant_example_2"
-    resources.append(orphan)
+    return cache, plan, plan["planned_values"]["root_module"]["resources"]
+
+
+def _clone_example(resources, source, new_name, **values):
+    """A copy of resource ``source`` relabelled ``new_name``, appended in place."""
+    clone = json.loads(json.dumps([r for r in resources if r["name"] == source][0]))
+    clone["name"] = new_name
+    clone["values"]["name"] = new_name
+    clone["values"].update(values)
+    resources.append(clone)
+    return clone
+
+
+def test_an_orphan_example_is_not_a_finding(tmp_path):
+    """The regression this rule change fixes.
+
+    ``auto_test.validate_policy_output`` matches examples by label pattern only —
+    every ``non_compliant_example_N`` must be flagged whether or not a
+    ``compliant_example_N`` exists — so 1-vs-2 is fully tested, not a smell.
+    """
+    root = build_tree(tmp_path, "clean")
+    cache, plan, resources = _bucket_plan(root)
+    _clone_example(resources, "non_compliant_example_1", "non_compliant_example_2")
     cache.write_text(json.dumps(plan))
 
-    findings = policy_lint.lint_resource(root, "gcp", "Cloud Storage", "google_storage_bucket")
-    assert pairs(findings) == {("public_access_prevention", "fixture-unpaired")}
-    assert "non_compliant_example_2" in findings[0].message
-    assert "fixture-unpaired" in policy_lint.RULES
+    findings = policy_lint.lint_resource(root, *CLEAN_BUCKET)
+    assert findings == []
+
+
+def test_an_orphan_compliant_example_is_not_a_finding(tmp_path):
+    root = build_tree(tmp_path, "clean")
+    cache, plan, resources = _bucket_plan(root)
+    _clone_example(resources, "compliant_example_1", "compliant_example_2")
+    cache.write_text(json.dumps(plan))
+
+    assert policy_lint.lint_resource(root, *CLEAN_BUCKET) == []
+
+
+@pytest.mark.parametrize("drop,missing", [
+    ("non_compliant", "no non_compliant_example_N"),
+    ("compliant", "no compliant_example_N"),
+])
+def test_a_one_sided_fixture_is_reported(tmp_path, drop, missing):
+    # Nothing on one side is the only genuinely untested shape: with no
+    # non-compliant example a policy that matches nothing passes; with no
+    # compliant example a policy that flags everything passes.
+    root = build_tree(tmp_path, "clean")
+    cache, plan, resources = _bucket_plan(root)
+    plan["planned_values"]["root_module"]["resources"] = [
+        r for r in resources if not r["name"].startswith(drop + "_example_")]
+    cache.write_text(json.dumps(plan))
+
+    findings = policy_lint.lint_resource(root, *CLEAN_BUCKET)
+    assert pairs(findings) == {(CLEAN_BUCKET_ARG, "fixture-one-sided")}
+    assert missing in findings[0].message
+    assert findings[0].severity == "error"
+    assert "fixture-one-sided" in policy_lint.RULES
+    assert "fixture-unpaired" not in policy_lint.RULES
+
+
+@pytest.mark.parametrize("source,orphan", [
+    ("non_compliant_example_1", "non_compliant_example_2"),
+    ("compliant_example_1", "compliant_example_2"),
+])
+def test_fixture_drift_is_caught_in_an_orphan_example(tmp_path, source, orphan):
+    # An orphan has no numbered twin, so without the widened pairing its drift
+    # would never be compared to anything.
+    root = build_tree(tmp_path, "clean")
+    cache, plan, resources = _bucket_plan(root)
+    _clone_example(resources, source, orphan, storage_class="NEARLINE")
+    cache.write_text(json.dumps(plan))
+
+    findings = policy_lint.lint_resource(root, *CLEAN_BUCKET)
+    assert pairs(findings) == {(CLEAN_BUCKET_ARG, "fixture-drift")}
+    assert "storage_class" in findings[0].message
+
+
+def test_drift_comparisons_cover_every_example(tmp_path):
+    # The pairing itself: twins together, each orphan against the lowest-numbered
+    # example on the other side, and nothing at all when one side is empty.
+    compliant = {"1": {"c": 1}, "4": {"c": 4}}
+    non_compliant = {"1": {"n": 1}, "2": {"n": 2}, "10": {"n": 10}}
+    assert policy_lint._drift_comparisons(compliant, non_compliant) == [
+        ({"c": 1}, {"n": 1}),                       # the numbered twin
+        ({"c": 1}, {"n": 2}),                       # orphan nc vs lowest compliant
+        ({"c": 1}, {"n": 10}),                      # "10" sorts numerically, not "1"
+        ({"c": 4}, {"n": 1}),                       # orphan c vs lowest non-compliant
+    ]
+    assert policy_lint._drift_comparisons({}, non_compliant) == []
+    assert policy_lint._drift_comparisons(compliant, {}) == []
 
 
 # --------------------------------------------------------------------------- #

--- a/scripts/linters/policy_lint.py
+++ b/scripts/linters/policy_lint.py
@@ -89,9 +89,9 @@ RULES = {
     "fixture-missing-plan": (
         "No committed plan cache for this fixture pair — run the test locally and "
         "commit inputs/plan_cache."),
-    "fixture-unpaired": (
-        "A compliant_example_N or non_compliant_example_N has no counterpart with the "
-        "same N — every example must be one half of a pair."),
+    "fixture-one-sided": (
+        "The fixture has no compliant examples at all, or no non-compliant examples "
+        "at all, so one half of what the harness checks is never exercised."),
     "vars-resource-type": (
         "`_vars.resource_type` does not match the resource-type directory."),
     "vars-friendly-name": (
@@ -103,17 +103,29 @@ RULES = {
     "package-case": "Package service segment is not lowercase snake_case (warn).",
     "repeated-helper-call": (
         "The same helper is called twice with the same arguments. Call it once, "
-        "bind the result to a variable, then read the fields off that (warn)."),
+        "bind the result to a variable, then read the fields off that."),
     "lint-error": (
         "The linter could not evaluate this policy (parse/opa failure) — run "
         "`opa check` on the file."),
 }
 
-# Advisory rules: the three style conventions, plus presence-only — whether
-# "presence is the control" is a judgement about the argument's rationale, which
-# a human (or the AI reviewer) makes, not something a linter can decide. It is
-# surfaced to the reviewer rather than failing a build.
-WARN_RULES = {"legacy-assign", "package-case", "presence-only", "repeated-helper-call"}
+# Advisory rules: two style conventions, plus presence-only — whether "presence
+# is the control" is a judgement about the argument's rationale, which a human
+# (or the AI reviewer) makes, not something a linter can decide. It is surfaced
+# to the reviewer rather than failing a build.
+#
+# `repeated-helper-call` is deliberately NOT here: it is an error, by the owner's
+# call. The size of the backlog is what made that look risky — measured on dev
+# 2026-08-31, 498 of 1,395 policy files carried the pattern — but the mechanical
+# cleanup (PR #565) takes that to 5, and those 5 are skipped only because open
+# Service/* branches are editing them.
+#
+# What keeps a backlog from reaching someone who did not write it is structural,
+# not the severity: run_precommit_linter.py fails only on findings the
+# contributor OWNS (a file their own branch changed — see `_finding_owned`), and
+# branch_scope.py stops a Service/* branch touching a file outside its own
+# resource type. A pre-existing finding elsewhere is reported, never failed on.
+WARN_RULES = {"legacy-assign", "package-case", "presence-only"}
 
 # --------------------------------------------------------------------------- #
 # Rule constants
@@ -634,7 +646,7 @@ def _lint_policy_file(root, platform, service, resource_type, rego_path, policie
     if legacy:
         add("legacy-assign", f"{', '.join(legacy)} assigned with '=' instead of ':='")
 
-    # --- repeated-helper-call (warn) --------------------------------------- #
+    # --- repeated-helper-call ---------------------------------------------- #
     # The kit convention is one binding per file: `result := helpers.get_multi_
     # summary(conditions, vars.variables)`, with `message` and `details` read off
     # `result`. Writing the call out again per field re-evaluates it per field.
@@ -754,6 +766,31 @@ def _is_fixture_label(value):
     return isinstance(value, str) and bool(FIXTURE_LABEL_RE.match(value))
 
 
+def _drift_comparisons(compliant, non_compliant):
+    """(compliant_values, non_compliant_values) pairs for the drift rule.
+
+    Numbered twins are compared to each other. An example with no twin is still
+    compared — to the lowest-numbered example on the other side — so that an
+    N-vs-M fixture cannot hide drift in the examples that happen to be orphans.
+    Every example on both sides therefore appears in at least one comparison.
+
+    Measured over the whole tree on 2026-08-31: this widens 1,050 comparisons to
+    1,110 and produces 0 additional findings and 0 additional drifted keys, so
+    it closes the gap without moving anyone's backlog.
+    """
+    if not compliant or not non_compliant:
+        return []
+    lowest_compliant = compliant[min(compliant, key=int)]
+    lowest_non_compliant = non_compliant[min(non_compliant, key=int)]
+    pairs = [(compliant[i], non_compliant[i])
+             for i in sorted(set(compliant) & set(non_compliant), key=int)]
+    pairs += [(lowest_compliant, non_compliant[i])
+              for i in sorted(set(non_compliant) - set(compliant), key=int)]
+    pairs += [(compliant[i], lowest_non_compliant)
+              for i in sorted(set(compliant) - set(non_compliant), key=int)]
+    return pairs
+
+
 def _lint_fixtures(root, platform, service, resource_type, stem, identity_key=None):
     input_dir = Path(root) / "inputs" / platform / service / resource_type / stem
     # A missing input directory is linter.py's finding (an orphan policy), not
@@ -792,16 +829,30 @@ def _lint_fixtures(root, platform, service, resource_type, stem, identity_key=No
         values = resource.get("values")
         bucket[match.group(2)] = values if isinstance(values, dict) else {}
 
-    # Every example must be half of a pair; a lone one is never compared, so
-    # without this it would silently escape every fixture rule.
-    unpaired = ([f"compliant_example_{i}" for i in sorted(set(compliant) - set(non_compliant))]
-                + [f"non_compliant_example_{i}"
-                   for i in sorted(set(non_compliant) - set(compliant))])
+    # --- fixture-one-sided ------------------------------------------------- #
+    # The harness does NOT pair examples by number. `validate_policy_output`
+    # matches labels against `^compliant_example_\d+$` / `^non_compliant_
+    # example_\d+$` and asserts two things over the whole set: no compliant
+    # example may be flagged, and every non-compliant example must be. An
+    # orphan `non_compliant_example_3` is therefore fully evaluated — N
+    # compliant against M non-compliant is a legitimate, and often better,
+    # shape (one baseline against several distinct failure modes).
+    #
+    # What is genuinely untested is a fixture with nothing on one side: with no
+    # non-compliant example nothing has to be flagged, so a policy that matches
+    # nothing passes; with no compliant example nothing has to stay unflagged,
+    # so a policy that flags everything passes.
     findings = []
-    if unpaired:
+    if not compliant or not non_compliant:
+        missing = []
+        if not compliant:
+            missing.append("no compliant_example_N resources")
+        if not non_compliant:
+            missing.append("no non_compliant_example_N resources")
         findings.append(Finding(
-            service, resource_type, stem, "fixture-unpaired",
-            "no counterpart with the same number for: " + ", ".join(unpaired)))
+            service, resource_type, stem, "fixture-one-sided",
+            f"the committed plan has {' and '.join(missing)} of type "
+            f"'{resource_type}' — a fixture needs at least one of each"))
 
     # Only the argument's *top-level* key is expected to differ; a nested
     # argument (a.b.c) is compared at its block key, since the plan nests it.
@@ -809,8 +860,7 @@ def _lint_fixtures(root, platform, service, resource_type, stem, identity_key=No
     ignored = FIXTURE_IGNORED_KEYS | {argument_key}
 
     drifted = set()
-    for index in sorted(set(compliant) & set(non_compliant)):
-        good, bad = compliant[index], non_compliant[index]
+    for good, bad in _drift_comparisons(compliant, non_compliant):
         for key in set(good) | set(bad):
             if key in ignored:
                 continue

--- a/scripts/linters/run_precommit_linter.py
+++ b/scripts/linters/run_precommit_linter.py
@@ -60,7 +60,13 @@ RELEVANT_PREFIXES = ("docs/", "inputs/", "policies/")
 # Findings about the fixture pair itself (compliant.tf/nonCompliant.tf), as
 # opposed to a policy .rego file — displayed and owned via the argument
 # directory under inputs/, not a single policy file.
-FIXTURE_RULES = {"fixture-drift", "fixture-missing-plan"}
+#
+# fixture-one-sided belongs here for the same reason as the other two, and its
+# absence was a real bug under the old name (fixture-unpaired): the finding is
+# about inputs/, so leaving it out blamed it on a .rego file the contributor may
+# never have touched. It fires 0 times on the tree today, so this closes a trap
+# set for whoever first writes a fixture with nothing on one side.
+FIXTURE_RULES = {"fixture-drift", "fixture-missing-plan", "fixture-one-sided"}
 
 # How many inherited findings to list before eliding the rest. They are context,
 # not work items: enough to prove the problem is real and show where it lives,


### PR DESCRIPTION
⛔ **MERGE #565 FIRST.** See the ordering note at the bottom — merging this before the cleanup would newly hold 77 resource types at stage 3 in the portal.

Three corrections.

## 1. `repeated-helper-call` → error

Asked for as error; the change was pushed after #564 had already merged, so `dev` still has it in `WARN_RULES` and the merged title says "warn".

## 2. `fixture-unpaired` was enforcing a requirement that does not exist → `fixture-one-sided`

The rule demanded every `compliant_example_N` have a `non_compliant_example_N`. **The harness has no such requirement.** `auto_test.py::validate_policy_output` matches on the label patterns alone — every non-compliant example must be flagged, every compliant one must not. There is no numeric pairing anywhere in it, so an orphan example is *fully evaluated*. The only thing that paired by number was this linter's own drift loop.

Consequences on `dev` today: `gcp/Identity-Aware Proxy/google_iap_app_engine_service_iam_member/member` — 1 compliant baseline against 8 distinct failure modes, each caught by its own situation — was reported as an **error**. All 34 findings are legitimate N-vs-M fixtures, ranging from (1,2) to (1,8) and (2,1) to (4,2). Meanwhile `linter.py`, the linter contributors are pointed at first, passes all 1,023 fixtures including these. Two linters, contradictory rules.

Had we "fixed" the data instead, the IAP fixture would have gained seven duplicate compliant resources that test nothing and slow every plan.

**Now:** fires only when a fixture has no compliant examples at all, or no non-compliant examples at all — the only genuinely-untested state. That is **0 findings** across the tree, so it is a pure safety net.

**And `fixture-drift` now covers orphans**, closing the gap that pairing was standing in for: each non-compliant is compared to its numbered twin when one exists, else to the lowest-numbered compliant, and the mirror for orphan compliants. Measured: **60 previously-uncompared examples now compared (1,050 → 1,110 comparisons), 0 new findings, 0 new drifted keys.** The 419 drift findings are byte-identical.

## 3. The rules page asserted something false

> "The harness compares the two halves of each numbered pair, so a lone example is never compared to anything — it looks like extra coverage but tests nothing."

The harness does no such comparison — that was only ever true of this linter's drift loop. As written it told a contributor their working, genuinely-evaluated fixture was worthless. Rewritten, and `c-tf-and-nc-tf.md` now says plainly that N compliant vs M non-compliant is fine (numbering, which is real, is unchanged).

## Verification

| | dev | this branch |
|---|---|---|
| `fixture-unpaired` | 34 error | id gone |
| `fixture-one-sided` | — | **0** |
| `fixture-drift` | 419 | 419, identical messages |
| `repeated-helper-call` | 498 warn | 498 **error** |

189 tests pass (182 on dev, +7). New tests pin the severity through the **exit code**, both orphan directions, one-sided fixtures both ways, drift caught inside an orphan, and that `"10"` sorts after `"2"`.

## ⛔ Merge order — this is not cosmetic

The portal does **not** scope lint findings the way PDE CI does. `policy_scan_runner.py` filters to `severity == "error"` **and `resource == <the student's resource type>`** — so a student inherits any error finding in a sibling argument file of their own resource type, whoever wrote it.

On `dev` today, 228 resource types carry a `repeated-helper-call`. Flipping it to error **before** the cleanup lands would newly hold **77 resource types** at stage 3 (Policies Working) for work their owners did not write. The stage bar is now live for students, so that is immediately visible.

**#565 takes the affected set from 228 resource types to 2.** Merge it first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015uFmZRNFNqoTccW58Kbs4b