### PR TITLE
Lint gate: blame a contributor only for findings they introduced

### DIFF
--- a/.github/workflows/policy_check_PR.yaml
+++ b/.github/workflows/policy_check_PR.yaml
@@ -34,7 +34,14 @@ jobs:
     steps:
       - uses: actions/checkout@v7
         with:
-          fetch-depth: 0          # need history for merge-base with the base branch
+          # Full history, for two things run_precommit_linter.py needs: the
+          # merge-base with the base branch (what did this PR change), and the
+          # base branch's *tree*, which it checks out into a temporary git
+          # worktree to work out which findings the PR introduced rather than
+          # inherited. On a shallow clone the gate fails loudly rather than
+          # blaming the contributor for the whole backlog — so this is
+          # load-bearing, not an optimisation.
+          fetch-depth: 0
 
       - name: Setup Python
         uses: actions/setup-python@v6
@@ -69,11 +76,15 @@ jobs:
 
       # PR gate: structural + content checks (content is on by default), but only
       # fail on files this PR changed vs its base branch — never the repo-wide tree.
+      # For policy_lint it narrows further: only findings this PR *introduced*,
+      # measured against a throwaway worktree of the base tree.
       - name: Lint changed files (structural + content)
         if: github.event_name == 'pull_request'
         env:
           BASE_REF: ${{ github.base_ref }}
         run: |
+          # Belt and braces with fetch-depth: 0 above — the base branch must be a
+          # real local commit, because its tree is checked out and linted.
           git fetch --quiet origin "$BASE_REF"
           python3 scripts/linters/run_precommit_linter.py --base "origin/$BASE_REF"
 

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -3,7 +3,9 @@
 #
 # - policy-linter runs scripts/linters/run_precommit_linter.py, which lints the
 #   whole tree but only FAILS on errors in the files you changed (this commit),
-#   so you are never blocked by the repo-wide backlog.
+#   so you are never blocked by the repo-wide backlog. For policy_lint findings
+#   it goes further and only fails on the ones this commit INTRODUCED, measured
+#   against HEAD, so a file that was already messy does not become your problem.
 # - branch-name-check enforces the branch naming convention.
 # - branch-scope-check keeps a Service/ branch to its own resource's files. It
 #   runs with --staged so it sees what you are about to commit, which is where a

--- a/Guide/Policy_writing_tutorial/policy-lint.md
+++ b/Guide/Policy_writing_tutorial/policy-lint.md
@@ -373,8 +373,21 @@ CI also runs `policy_lint.py` over **every** documented `gcp` resource on every 
 (`Policy lint (whole tree, report only)` in the `ALL` workflow) and publishes the JSON as a build
 artifact. That run is `continue-on-error` and exists so maintainers can track the repo-wide
 backlog over time — it is not a gate. Pre-existing findings elsewhere on `dev` are never held
-against you: your PR only fails on findings inside the `.rego` file (or fixture pair) **you**
-changed, exactly like the structural linter on the previous page.
+against you, exactly like the structural linter on the previous page.
+
+Nor are the pre-existing findings **inside** a file you touched. The PR lint job lints the
+resource types your change reaches twice — once on your branch, once on the base branch you
+started from — and fails only on findings that are not in the base result. So editing one
+argument in a resource type somebody else left messy does not hand you their backlog, and a
+change that *removes* findings can never fail. What you touched but did not break is printed
+under a `[NOTE]` line, so you can still see the file has known problems:
+
+    [NOTE] 3 pre-existing policy_lint error(s) in the file(s) you touched — not attributed
+    to you: hard-coded-value x2, index-path x1
+
+A finding counts as yours when its `(rule, service, resource type, argument)` appears more times
+on your branch than on the base — so introducing a *second* hard-coded value into a file that
+already had one does fail, and re-wording the message of an existing one does not.
 
 <div align="center">
 

--- a/scripts/linters/_tests/test_run_precommit_policy_lint.py
+++ b/scripts/linters/_tests/test_run_precommit_policy_lint.py
@@ -1,14 +1,21 @@
 """Unit tests for the policy_lint wiring in run_precommit_linter.py.
 
-These exercise the owned-triple derivation and the "fail only on findings the
-contributor's own changes reached" filter in isolation, with a fake
-``policy_lint.lint_resource`` (monkeypatched) — no git repo, no OPA, and no
-real policy tree required.
+These exercise the owned-triple derivation, the "fail only on findings the
+contributor's own changes reached" filter, and the base-tree comparison that
+narrows that further to the findings the change actually *introduced* — with a
+fake ``policy_lint.lint_resource`` (monkeypatched), so no OPA and no real policy
+tree is required.
+
+The base-tree tests that shell out to git build a throwaway one-commit repo in
+``tmp_path`` (the ``git_repo`` fixture) rather than touching this checkout.
 """
 
 import re
+import subprocess
 import sys
 from pathlib import Path
+
+import pytest
 
 project_root = Path(__file__).parent.parent.parent.parent
 sys.path.insert(0, str(project_root))
@@ -197,3 +204,253 @@ def test_every_rule_has_an_anchored_heading_in_the_rules_page():
     headings = set(re.findall(r"^##\s+([a-z0-9-]+)\s*$", page, re.MULTILINE))
     missing = set(policy_lint.RULES) - headings
     assert not missing, f"policy-lint.md is missing headings for: {sorted(missing)}"
+
+
+# --------------------------------------------------------------------------- #
+# _finding_key / _finding_counts — a finding's identity excludes its message
+# --------------------------------------------------------------------------- #
+def test_finding_key_excludes_the_message():
+    # Same finding, message re-worded by an unrelated edit (a line number moved).
+    a = Finding("BigQuery", "google_bigquery_dataset", "dataset_id",
+                "hard-coded-value", "project id 'projects/PDE' at line 12")
+    b = Finding("BigQuery", "google_bigquery_dataset", "dataset_id",
+                "hard-coded-value", "project id 'projects/PDE' at line 40")
+    assert rpl._finding_key(a) == rpl._finding_key(b)
+
+
+def test_finding_counts_ignores_warnings():
+    findings = [
+        Finding("BigQuery", "google_bigquery_dataset", "dataset_id",
+                "hard-coded-value", "err"),
+        Finding("BigQuery", "google_bigquery_dataset", "dataset_id",
+                "legacy-assign", "warn", severity="warn"),
+    ]
+    counts = rpl._finding_counts(findings)
+    assert sum(counts.values()) == 1
+    assert list(counts)[0][0][0] == "hard-coded-value"
+
+
+# --------------------------------------------------------------------------- #
+# _split_new_and_inherited — new vs inherited
+# --------------------------------------------------------------------------- #
+DATASET_REGO = "policies/gcp/BigQuery/google_bigquery_dataset/dataset_id.rego"
+
+
+def _owned(*findings):
+    """HEAD's owned (path, Finding) pairs for the dataset_id policy file."""
+    return [(DATASET_REGO, finding) for finding in findings]
+
+
+def _hard_coded(message="literal project id 'projects/PDE'"):
+    return Finding("BigQuery", "google_bigquery_dataset", "dataset_id",
+                   "hard-coded-value", message)
+
+
+def test_a_finding_present_in_both_base_and_head_is_inherited_not_new():
+    baseline = rpl._finding_counts([_hard_coded()])
+    new, inherited = rpl._split_new_and_inherited(_owned(_hard_coded()), baseline)
+    assert new == []
+    assert [f.rule for _, f in inherited] == ["hard-coded-value"]
+
+
+def test_a_finding_whose_message_shifted_is_still_inherited():
+    # The point of keying on (rule, service, resource, policy): a legitimate edit
+    # moves line numbers and counts inside the message, and that must not read as
+    # a new problem.
+    baseline = rpl._finding_counts([_hard_coded("2 conditions name 'projects/PDE'")])
+    new, inherited = rpl._split_new_and_inherited(
+        _owned(_hard_coded("3 conditions name 'projects/PDE'")), baseline)
+    assert new == []
+    assert len(inherited) == 1
+
+
+def test_a_genuinely_new_finding_fails():
+    baseline = rpl._finding_counts([_hard_coded()])
+    introduced = Finding("BigQuery", "google_bigquery_dataset", "dataset_id",
+                         "index-path", "attribute_path ends in [0]")
+    new, inherited = rpl._split_new_and_inherited(
+        _owned(_hard_coded(), introduced), baseline)
+    assert [f.rule for _, f in new] == ["index-path"]
+    assert [f.rule for _, f in inherited] == ["hard-coded-value"]
+
+
+def test_a_new_finding_in_a_resource_type_absent_from_the_base_is_new():
+    # A brand-new resource type lints to nothing on the base tree, so every
+    # finding in it belongs to the contributor who added it.
+    new, inherited = rpl._split_new_and_inherited(_owned(_hard_coded()),
+                                                  rpl._finding_counts([]))
+    assert len(new) == 1
+    assert inherited == []
+
+
+def test_removing_a_finding_passes():
+    baseline = rpl._finding_counts([_hard_coded("a"), _hard_coded("b")])
+    new, inherited = rpl._split_new_and_inherited(_owned(_hard_coded("a")), baseline)
+    assert new == []
+    assert len(inherited) == 1
+
+
+def test_removing_every_finding_passes():
+    baseline = rpl._finding_counts([_hard_coded()])
+    new, inherited = rpl._split_new_and_inherited([], baseline)
+    assert (new, inherited) == ([], [])
+
+
+def test_going_from_one_to_two_of_the_same_rule_in_the_same_file_fails():
+    # Counts, not set membership: the file already had one hard-coded value and
+    # the change added a second, so exactly one finding is the contributor's.
+    baseline = rpl._finding_counts([_hard_coded("literal 'projects/PDE'")])
+    new, inherited = rpl._split_new_and_inherited(
+        _owned(_hard_coded("literal 'projects/PDE'"),
+               _hard_coded("literal 'projects/OTHER'")), baseline)
+    assert [f.message for _, f in new] == ["literal 'projects/OTHER'"]
+    assert [f.message for _, f in inherited] == ["literal 'projects/PDE'"]
+
+
+def test_two_findings_of_one_rule_unchanged_are_both_inherited():
+    baseline = rpl._finding_counts([_hard_coded("a"), _hard_coded("b")])
+    new, inherited = rpl._split_new_and_inherited(
+        _owned(_hard_coded("a"), _hard_coded("b")), baseline)
+    assert new == []
+    assert len(inherited) == 2
+
+
+# --------------------------------------------------------------------------- #
+# _base_commit / _base_tree / _subtract_baseline — real git, fake lint_resource
+# --------------------------------------------------------------------------- #
+@pytest.fixture
+def git_repo(tmp_path, monkeypatch):
+    """A throwaway one-commit repo, cwd'd into: the helpers shell out to git."""
+    repo = tmp_path / "repo"
+    repo.mkdir()
+
+    def git(*args):
+        subprocess.run(["git", "-C", str(repo), *args], check=True, capture_output=True)
+
+    git("init", "--quiet", "-b", "main")
+    git("config", "user.email", "linter@example.invalid")
+    git("config", "user.name", "Linter Test")
+    git("config", "commit.gpgsign", "false")
+    (repo / "README.md").write_text("base\n", encoding="utf-8")
+    git("add", "README.md")
+    git("commit", "--quiet", "-m", "base commit")
+    monkeypatch.chdir(repo)
+    return repo
+
+
+def test_missing_base_ref_fails_loudly_instead_of_blaming_everything(git_repo):
+    # A shallow CI clone: the base branch is simply not here. Treating that as
+    # "an empty base tree" would blame the contributor for the whole backlog of
+    # every file they touched, so it must be a hard, explained failure.
+    with pytest.raises(rpl.BaseTreeUnavailable) as excinfo:
+        rpl._base_commit("origin/dev")
+    message = str(excinfo.value)
+    assert "origin/dev" in message
+    assert "fetch-depth: 0" in message
+
+
+def test_main_refuses_to_run_at_all_without_a_reachable_base_ref(git_repo, capsys):
+    # Not just "everything is new": with no base ref, changed_files() diffs
+    # against a ref git cannot resolve, comes back empty, and the gate would
+    # otherwise pass every PR silently. It must fail instead.
+    assert rpl.main(["--base", "origin/dev"]) == 1
+    out = capsys.readouterr().out
+    assert "[FAIL]" in out
+    assert "fetch-depth: 0" in out
+    assert "skipping linter" not in out
+
+
+def test_subtract_baseline_propagates_a_missing_base_ref(git_repo):
+    with pytest.raises(rpl.BaseTreeUnavailable):
+        rpl._subtract_baseline(_owned(_hard_coded()), base="origin/dev")
+
+
+def test_base_commit_without_a_base_is_head(git_repo):
+    head = subprocess.run(["git", "rev-parse", "HEAD"],
+                          capture_output=True, text=True).stdout.strip()
+    assert rpl._base_commit() == head
+
+
+def test_subtract_baseline_lints_a_real_base_worktree_and_removes_it(git_repo, monkeypatch):
+    seen_roots = []
+
+    def fake_lint_resource(root, platform, service, resource_type):
+        seen_roots.append(Path(root))
+        return [_hard_coded("literal 'projects/PDE' (base wording)")]
+
+    monkeypatch.setattr(policy_lint, "lint_resource", fake_lint_resource)
+
+    new, inherited = rpl._subtract_baseline(
+        _owned(_hard_coded("literal 'projects/PDE' (head wording)")))
+
+    assert new == []
+    assert len(inherited) == 1
+    # The base tree is a separate checkout, not the tree we are standing in ...
+    assert seen_roots and seen_roots[0].resolve() != git_repo.resolve()
+    # ... and it is gone again, both on disk and as a registered worktree.
+    assert not seen_roots[0].exists()
+    listed = subprocess.run(["git", "worktree", "list", "--porcelain"],
+                            capture_output=True, text=True).stdout
+    assert "policy-lint-base-" not in listed
+
+
+def test_base_tree_is_removed_even_when_linting_it_raises(git_repo, monkeypatch):
+    seen_roots = []
+
+    def exploding_lint_resource(root, platform, service, resource_type):
+        seen_roots.append(Path(root))
+        raise policy_lint.PolicyLintError("opa fell over")
+
+    monkeypatch.setattr(policy_lint, "lint_resource", exploding_lint_resource)
+
+    with pytest.raises(policy_lint.PolicyLintError):
+        rpl._subtract_baseline(_owned(_hard_coded()))
+
+    assert seen_roots and not seen_roots[0].exists()
+
+
+def test_no_owned_findings_means_the_base_tree_is_never_built(monkeypatch):
+    # Cost control: a target that is clean at HEAD has nothing to subtract, so
+    # checking out and linting the base tree for it is pure waste.
+    def refuse(*args, **kwargs):
+        raise AssertionError("the base tree must not be built when nothing is owned")
+
+    monkeypatch.setattr(rpl, "_base_tree", refuse)
+    monkeypatch.setattr(rpl, "_base_commit", refuse)
+
+    assert rpl._subtract_baseline([]) == ([], [])
+
+
+def test_only_targets_with_a_finding_at_head_are_linted_on_the_base(git_repo, monkeypatch):
+    linted = []
+
+    def fake_lint_resource(root, platform, service, resource_type):
+        linted.append((platform, service, resource_type))
+        return []
+
+    monkeypatch.setattr(policy_lint, "lint_resource", fake_lint_resource)
+
+    # The base targets come from the owned findings, not from the changed set:
+    # a resource type the change touched but left clean never reaches the base
+    # tree at all, because there would be nothing to subtract from.
+    rpl._subtract_baseline(_owned(_hard_coded()))
+
+    assert linted == [("gcp", "BigQuery", "google_bigquery_dataset")]
+
+
+# --------------------------------------------------------------------------- #
+# _print_inherited — context, never a failure
+# --------------------------------------------------------------------------- #
+def test_print_inherited_says_nothing_when_there_is_nothing_inherited(capsys):
+    rpl._print_inherited([])
+    assert capsys.readouterr().out == ""
+
+
+def test_print_inherited_summarises_by_rule_and_elides_a_long_list(capsys):
+    inherited = [(f"policies/gcp/BigQuery/google_bigquery_dataset/arg_{i}.rego",
+                  _hard_coded(f"m{i}")) for i in range(rpl.INHERITED_PREVIEW + 5)]
+    rpl._print_inherited(inherited)
+    out = capsys.readouterr().out
+    assert f"hard-coded-value x{len(inherited)}" in out
+    assert "not attributed to you" in out
+    assert "... and 5 more" in out

--- a/scripts/linters/readme-linters.md
+++ b/scripts/linters/readme-linters.md
@@ -10,7 +10,9 @@ There are four supporting scripts:
 - `run_precommit_linter.py` — runs the linter but fails only on **your** changed
   files (so you are never blocked by the repo-wide backlog). It also runs
   `policy_lint.py` (below) over every resource type your changed files belong
-  to, on the same "own only what you changed" basis.
+  to, and there it fails only on the findings your change **introduced** —
+  measured against the base tree — so a pre-existing finding inside a file you
+  merely touched is reported as context, not as your fault.
 - `check_branch_name.py` — enforces the branch naming convention.
 - `branch_scope.py` — enforces that a `Service/<platform>/<service_slug>/<resource_type>`
   branch changes **only** that resource's files (`docs/` JSON, `inputs/`,
@@ -91,6 +93,28 @@ It also runs `policy_lint.py` over every resource type a changed file belongs
 to, and fails on an error-severity finding only when the specific `.rego` file
 (or fixture pair) it names was itself changed — see
 `Guide/Policy_writing_tutorial/policy-lint.md`.
+
+**Blame is limited to what you introduced.** Within a file you did change, a
+`policy_lint` finding fails the run only if it is not already there on the base
+tree. The same resource types are linted a second time against a detached
+`git worktree` of the base commit (the merge-base with `--base <ref>`, else
+`HEAD`), thrown away afterwards, and anything present in both is printed under a
+`[NOTE]` line as context instead of failing. Consequences worth knowing:
+
+- Removing findings can never fail. A mechanical cleanup PR passes.
+- A finding is identified by `(rule, service, resource, policy)` — **not** the
+  message, because messages carry line numbers and counts that shift when a file
+  is legitimately edited, and a shifted message must not read as a new problem.
+- Identities are compared by **count**, so one `hard-coded-value` in a file
+  becoming two still fails.
+- The base tree is built only when something is owned at HEAD, and only the
+  resource types that produced one of those findings are linted on it — a clean
+  change never pays for it at all. Measured: +0s on a clean one-resource PR,
+  ~1.7s on a one-resource PR that inherits a finding, ~3.1s on a 234-resource-type
+  cleanup PR.
+- If the base ref is not in the clone (a shallow CI checkout), the gate **fails
+  loudly** rather than treating the whole backlog as newly introduced. CI must
+  check out with `fetch-depth: 0`.
 
 ```bash
 python scripts/linters/run_precommit_linter.py            # staged + unstaged (pre-commit)

--- a/scripts/linters/run_precommit_linter.py
+++ b/scripts/linters/run_precommit_linter.py
@@ -16,15 +16,36 @@ fails the run when the .rego file (or, for a fixture finding, the argument
 directory) it names was itself changed — a sibling argument's pre-existing
 finding never blocks you. See Guide/Policy_writing_tutorial/policy-lint.md.
 
+Within a file you did touch, ``policy_lint`` goes one step further: a finding
+only fails the run when your change *introduced* it. The same resource types are
+linted a second time against the **base** tree — a detached ``git worktree`` of
+the merge-base, thrown away afterwards — and anything already there is reported
+as inherited context rather than as your fault. Removing findings can therefore
+never fail.
+
+A finding is identified by ``(rule, service, resource, policy)``, deliberately
+NOT including the message: messages carry line numbers and counts that shift
+when a file is legitimately edited, and a shifted message must not read as a new
+problem. Identities are compared by *count*, so going from one hard-coded value
+in a file to two still fails.
+
+The base run is not free, so it is bought only where it can pay: only the
+resource types that actually produced a finding you own at HEAD are linted on
+the base tree, and when your change is clean the base tree is never built at all.
+
 Modes (run from the repo root):
   (no args)         pre-commit: changed set = staged + unstaged worktree edits
   --base <ref>      CI/PR:      changed set = everything this branch changed vs
                                 the merge-base with <ref> (e.g. origin/dev)
   --all             maintainer: no filter — fail on ANY error in the tree
 """
+import contextlib
 import os
+import shutil
 import subprocess
 import sys
+import tempfile
+from collections import Counter
 from pathlib import Path
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
@@ -40,6 +61,21 @@ RELEVANT_PREFIXES = ("docs/", "inputs/", "policies/")
 # opposed to a policy .rego file — displayed and owned via the argument
 # directory under inputs/, not a single policy file.
 FIXTURE_RULES = {"fixture-drift", "fixture-missing-plan"}
+
+# How many inherited findings to list before eliding the rest. They are context,
+# not work items: enough to prove the problem is real and show where it lives,
+# not so many that they bury the findings the contributor must actually fix.
+INHERITED_PREVIEW = 10
+
+
+class BaseTreeUnavailable(RuntimeError):
+    """The tree this change is measured against could not be materialised.
+
+    Always fatal, never "assume it is all new": a shallow CI clone that cannot
+    reach the base commit would otherwise silently blame the contributor for the
+    entire pre-existing backlog of every file they touched — the exact failure
+    this gate exists to prevent.
+    """
 
 
 def _git(*args):
@@ -142,6 +178,180 @@ def _policy_lint_findings(triples, changed, root=REPO_ROOT):
     return owned, backlog
 
 
+# --------------------------------------------------------------------------- #
+# "Did this change introduce it?" — the base-tree comparison
+# --------------------------------------------------------------------------- #
+def _finding_key(finding):
+    """The identity of a ``policy_lint`` finding for base-vs-head comparison.
+
+    ``(rule, service, resource, policy)`` — deliberately WITHOUT the message.
+    Messages carry line numbers and counts ("2 conditions", "differ on: x, y")
+    that shift when a file is legitimately edited, and a shifted message must
+    not read as a new problem.
+    """
+    return (finding.rule, finding.service, finding.resource, finding.policy)
+
+
+def _finding_counts(findings):
+    """Counter of ``(identity, message)`` over the error-severity findings.
+
+    Keeping the message *as well* costs nothing and buys better reporting: when
+    a file has two findings of one rule, the exact-message match decides which
+    of them is shown as the new one. It never changes the verdict — that is
+    settled by the count per identity (see ``_split_new_and_inherited``).
+    """
+    return Counter((_finding_key(f), f.message)
+                   for f in findings if f.severity == "error")
+
+
+def _base_commit(base=None):
+    """The commit whose tree is "the code before this change".
+
+    With ``--base <ref>`` (CI) that is the merge-base, the same reference point
+    ``changed_files`` uses, so merging the base branch in to catch up never
+    counts as the contributor's edit. Without it (pre-commit) it is ``HEAD``:
+    only what you are about to commit is yours.
+
+    Raises ``BaseTreeUnavailable`` rather than guessing — see that class.
+    """
+    ref = base or "HEAD"
+    fetch_hint = (f"check out with `fetch-depth: 0` (or `git fetch origin "
+                  f"{ref.removeprefix('origin/')}`) so the gate can tell a finding "
+                  "you introduced from one you inherited")
+    rev = subprocess.run(["git", "rev-parse", "--verify", "--quiet", f"{ref}^{{commit}}"],
+                         capture_output=True, text=True)
+    commit = rev.stdout.strip()
+    if rev.returncode != 0 or not commit:
+        raise BaseTreeUnavailable(f"{ref!r} is not in this clone — {fetch_hint}.")
+
+    if base:
+        merge_base = subprocess.run(["git", "merge-base", "HEAD", base],
+                                    capture_output=True, text=True)
+        commit = merge_base.stdout.strip()
+        if merge_base.returncode != 0 or not commit:
+            raise BaseTreeUnavailable(
+                f"HEAD and {base!r} have no common ancestor in this clone, which "
+                f"means the history is shallow — {fetch_hint}.")
+
+    # A ref can resolve while its tree is absent: that is exactly what a shallow
+    # clone looks like from here, and it must fail rather than lint an empty tree.
+    if subprocess.run(["git", "cat-file", "-e", f"{commit}^{{tree}}"],
+                      capture_output=True).returncode != 0:
+        raise BaseTreeUnavailable(
+            f"the tree of {commit[:12]} is missing from this clone (shallow "
+            f"history) — {fetch_hint}.")
+    return commit
+
+
+@contextlib.contextmanager
+def _base_tree(commit):
+    """A throwaway detached checkout of ``commit``, removed on the way out.
+
+    A ``git worktree`` and not a stash/checkout dance, because this runs inside
+    a checkout somebody else is standing in — a contributor's working tree with
+    uncommitted edits, or a CI job mid-run. A worktree touches neither.
+    """
+    parent = tempfile.mkdtemp(prefix="policy-lint-base-")
+    path = os.path.join(parent, "tree")
+    add = subprocess.run(["git", "worktree", "add", "--detach", "--quiet", path, commit],
+                         capture_output=True, text=True)
+    if add.returncode != 0:
+        shutil.rmtree(parent, ignore_errors=True)
+        raise BaseTreeUnavailable(
+            f"could not check out the base tree at {commit[:12]}: "
+            f"{(add.stderr or add.stdout).strip()}")
+    try:
+        yield Path(path)
+    finally:
+        subprocess.run(["git", "worktree", "remove", "--force", path],
+                       capture_output=True, text=True)
+        shutil.rmtree(parent, ignore_errors=True)
+        subprocess.run(["git", "worktree", "prune"], capture_output=True, text=True)
+
+
+def _baseline_counts(triples, base_root):
+    """What ``triples`` already produced on the base tree, as ``_finding_counts``.
+
+    No ownership filter here: a finding that predates the branch is inherited
+    whether or not it happens to sit in a file this change touched.
+    """
+    findings = []
+    for platform, service, resource_type in sorted(triples):
+        findings += policy_lint.lint_resource(base_root, platform, service, resource_type)
+    return _finding_counts(findings)
+
+
+def _split_new_and_inherited(owned, baseline):
+    """Split HEAD's owned ``(path, Finding)`` pairs into ``(new, inherited)``.
+
+    Per identity, ``max(0, head_count - base_count)`` findings are new — so one
+    ``hard-coded-value`` in a file becoming two still fails, and two becoming
+    one passes.
+    """
+    exact = Counter(baseline)
+    by_identity = Counter()
+    for (key, _message), count in baseline.items():
+        by_identity[key] += count
+
+    new, inherited, pending = [], [], []
+    # Pass 1: identity AND message match — unambiguously the same finding.
+    for path, finding in owned:
+        key = _finding_key(finding)
+        if exact[(key, finding.message)] > 0:
+            exact[(key, finding.message)] -= 1
+            by_identity[key] -= 1
+            inherited.append((path, finding))
+        else:
+            pending.append((path, finding))
+    # Pass 2: identity only — the message moved (a line number, a count), which
+    # must never read as a new problem. What is left over is genuinely new.
+    for path, finding in pending:
+        key = _finding_key(finding)
+        if by_identity[key] > 0:
+            by_identity[key] -= 1
+            inherited.append((path, finding))
+        else:
+            new.append((path, finding))
+    return new, inherited
+
+
+def _subtract_baseline(owned, base=None):
+    """``(new, inherited)`` for HEAD's owned findings, against the base tree.
+
+    Cost control (the owner pays for Actions minutes): the base tree is built
+    only when something is owned at HEAD, and only the resource types that
+    produced one of those findings are linted there. A target that is clean at
+    HEAD has nothing to subtract, so linting it on the base is pure waste.
+    """
+    if not owned:
+        return [], []
+    with _base_tree(_base_commit(base)) as base_root:
+        baseline = _baseline_counts(_owned_triples({path for path, _ in owned}), base_root)
+    return _split_new_and_inherited(owned, baseline)
+
+
+def _print_inherited(inherited):
+    """Report the pre-existing findings in the contributor's own files.
+
+    Context, never a failure: they were there before this change, and clearing
+    them is separate work. But saying nothing would hide that the file you just
+    edited has known problems, which is the other half of being honest about
+    who owns what.
+    """
+    if not inherited:
+        return
+    by_rule = Counter(finding.rule for _, finding in inherited)
+    summary = ", ".join(f"{rule} x{count}" for rule, count in sorted(by_rule.items()))
+    print(f"\n[NOTE] {len(inherited)} pre-existing policy_lint error(s) in the file(s) "
+          f"you touched — not attributed to you: {summary}")
+    listed = sorted(inherited, key=lambda pair: (pair[0], pair[1].rule))
+    for path, finding in listed[:INHERITED_PREVIEW]:
+        print(f"  - {finding.rule}: {path}")
+    if len(listed) > INHERITED_PREVIEW:
+        print(f"  - ... and {len(listed) - INHERITED_PREVIEW} more (see them all with "
+              "`python3 scripts/linters/policy_lint.py <platform>/<service>/<resource_type>`)")
+
+
 def _error_path(line):
     """Extract the file/dir path from a '[ERROR] [content] <path>: msg' line."""
     s = line[len("[ERROR]"):].strip()
@@ -160,6 +370,18 @@ def main(argv=None):
             print("[ERROR] --base requires a value, e.g. --base origin/dev.")
             return 2
         base = argv[i + 1]
+
+    if base:
+        # Resolved up-front, before anything else, because an unreachable base
+        # ref is silent in both directions: `changed_files` would fall back to a
+        # diff against a ref git cannot resolve, come back empty, and the whole
+        # gate would report "nothing to check" and pass. A CI job that cannot see
+        # its base branch must say so, not quietly wave the PR through.
+        try:
+            _base_commit(base)
+        except BaseTreeUnavailable as exc:
+            print(f"[FAIL] cannot establish what this branch changed: {exc}")
+            return 1
 
     changed = None
     if not lint_all:
@@ -200,30 +422,43 @@ def main(argv=None):
     # fixture drift, ...) over the resource types this change touches. Only
     # runs in changed-files modes — `--all` stays a linter.py-only, structural
     # + reconciliation gate.
-    policy_lint_owned, policy_lint_backlog = [], 0
+    policy_lint_new, policy_lint_inherited, policy_lint_backlog = [], [], 0
     if changed is not None:
         triples = _owned_triples(changed)
         if triples:
             try:
-                policy_lint_owned, policy_lint_backlog = _policy_lint_findings(triples, changed)
+                policy_lint_owned, policy_lint_backlog = _policy_lint_findings(
+                    triples, changed)
+                # Only the findings this change *introduced* are the
+                # contributor's; everything the base tree already produced is
+                # inherited. No owned findings means no base tree is built.
+                policy_lint_new, policy_lint_inherited = _subtract_baseline(
+                    policy_lint_owned, base)
+            except BaseTreeUnavailable as exc:
+                print("\n[FAIL] policy_lint cannot tell the findings you introduced "
+                      f"from the ones you inherited: {exc}")
+                return 1
             except policy_lint.PolicyLintError as exc:
                 print(f"\n[FAIL] policy_lint could not run: {exc}")
                 return 1
 
-    if policy_lint_owned:
-        print("\n[FAIL] policy_lint error(s) you must fix:\n")
-        for path, finding in policy_lint_owned:
+    if policy_lint_new:
+        print("\n[FAIL] policy_lint error(s) your change introduced:\n")
+        for path, finding in policy_lint_new:
             print(f"  {finding.rule}: {path} — {finding.message}")
+        _print_inherited(policy_lint_inherited)
         if policy_lint_backlog:
             print(f"\n({policy_lint_backlog} pre-existing policy_lint error(s) elsewhere "
                   "are not attributed to you.)")
         return 1
 
+    _print_inherited(policy_lint_inherited)
+
     suffix = f" ({backlog} pre-existing backlog error(s) elsewhere ignored)" if backlog else ""
     if policy_lint_backlog:
         suffix += (f"; {policy_lint_backlog} pre-existing policy_lint backlog error(s) "
                    "elsewhere ignored")
-    print(f"\n[OK] no lint errors in scope{suffix}.")
+    print(f"\n[OK] no lint errors attributed to you{suffix}.")
     return 0
 
 


### PR DESCRIPTION
⛔ **Merge this BEFORE #565 and #566.**

## The problem

The lint gate blames you for **every** finding in a file you touched, whether or not you caused it. PR #565 — a mechanical cleanup that removes 501 findings and adds none — failed with 89 errors across 67 files, every one of them pre-existing on `dev`:

```
(281 pre-existing policy_lint error(s) elsewhere are not attributed to you.)
##[error]Process completed with exit code 1
```

The gate already understood "not yours" for files you didn't touch. Inside a touched file it understood nothing. The same trap catches any contributor who edits one file in a resource type someone else left messy — and 264 of #565's 501 files carry an inherited error.

## What changes

Findings at HEAD are compared against the findings the **same targets** produce on the base tree, and only the difference fails. Removing findings always passes.

- **Identity is `(rule, service, resource, policy)` — deliberately not the message.** Messages carry line numbers and counts that shift when a file is legitimately edited, and a shifted message must not read as a new problem. Counts are compared per key, so one `hard-coded-value` becoming two still fails.
- Inherited findings are still **shown**, as a `[NOTE]` block summarised by rule with the first ten listed. You can see what the file carries; you're just not failed for it.

Verified on the real tree with real OPA:

| case | result |
|---|---|
| #565's diff | **exit 1 → exit 0**, 89 errors now reported as inherited context |
| add a new `projects/my-team-proj/...` to a clean policy | **fails**, names the new finding |
| file has one hard-coded value, contributor adds a second | **fails**, and names the *new* email, not the old one |
| append a comment to a file with an inherited finding | old: fail → new: **pass**, shown as context |
| shallow clone, base tree unreachable | **fails loudly** |

## Cost — the normal case pays nothing

| scenario | old | new |
|---|---|---|
| one-resource PR, clean at HEAD (**the common case**) | 0.99s | 1.09s |
| one-resource PR with an inherited finding | 1.05s | 2.80s |
| #565 (234 resource types, 501 files) | 6.91s | 10.01s |

The base tree is only linted for targets that actually have an owned finding at HEAD — on #565 that was 50 of 234 resource types, not all of them. A contributor whose change is clean never creates the worktree at all.

## A silent hole found while testing, and closed

With the base ref absent entirely (a shallow clone), the **existing** gate diffed against a ref git couldn't resolve, got an empty changed set, printed *"No docs/ inputs/ policies/ changes — skipping linter"* and **exited 0**. A CI job that could not see its base branch was waving every PR through. `--base` is now resolved up front and an unreachable ref fails with a `fetch-depth: 0` hint. Failing loudly has to cut both ways.

## Merge order

**This first**, then #565, then #566. #566 promotes `repeated-helper-call` from warning to error, and 493 of #565's 501 files carry one — merged on its own it turns nearly every PR touching an existing policy bright red for code the contributor didn't write. This is what makes that promotion survivable.

## Known, left deliberately

- **`linter.py`'s own content errors are still all-or-nothing** — the identical trap, one linter over. Closing it needs an identity for a free-text `[ERROR] [content] <path>: <msg>` line, where keying on the message reintroduces exactly the line-number fragility this design avoids. That's a decision, not a patch.
- **Fix-one-add-another in the same file nets to zero** and passes silently. The deliberate price of not keying on messages.
- **`fixture-unpaired` is attributed to the wrong path** (a pre-existing bug: `FIXTURE_RULES` omits it, so an `inputs/` finding is blamed on a `.rego`). 15 of #565's 89 arrived that way. #566 renames that rule, so whichever of these lands second should add the new id to that set.

202 tests pass (+23). `git grep -in "autocapstone"` → 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015uFmZRNFNqoTccW58Kbs4b