### PR TITLE
Policies: wildcard the hard-coded values, name the resources distinctly, fix the index paths

### DIFF
--- a/policies/gcp/API Hub/google_apihub_api_hub_instance/_vars.rego
+++ b/policies/gcp/API Hub/google_apihub_api_hub_instance/_vars.rego
@@ -1,7 +1,7 @@
 package terraform.gcp.security.api_hub.google_apihub_api_hub_instance.vars
 
 variables := {
-    "friendly_resource_name": "API Hub", 
+    "friendly_resource_name": "API Hub Instance", 
     "resource_type":  "google_apihub_api_hub_instance", 
     "resource_value_name" : "api_hub_instance_id" 
 }

--- a/policies/gcp/API Hub/google_apihub_api_hub_instance/config.cmek_key_name.rego
+++ b/policies/gcp/API Hub/google_apihub_api_hub_instance/config.cmek_key_name.rego
@@ -3,6 +3,12 @@ package terraform.gcp.security.api_hub.google_apihub_api_hub_instance.config_cme
 import data.terraform.helpers
 import data.terraform.gcp.security.api_hub.google_apihub_api_hub_instance.vars
 
+# policy_lint reports hard-coded-value on the value below, and the finding stands.
+# A pattern whitelist only judges values that MATCH its target: one that does not
+# match the shape is never flagged at all. This argument's non-compliant example
+# is "NULL" and "my_key_random_key", so converting would make the fixture pass for the wrong
+# reason. Either _helpers needs a pattern whitelist that fails a non-matching
+# value, or the fixture needs a wrongly-scoped (not malformed) example.
 conditions := [
     [
     {"situation_description" : "Resource cmek_key_name is not compliant.",

--- a/policies/gcp/API Hub/google_apihub_curation/_vars.rego
+++ b/policies/gcp/API Hub/google_apihub_curation/_vars.rego
@@ -2,7 +2,7 @@ package terraform.gcp.security.api_hub.google_apihub_curation.vars
 
 
 variables := {
-    "friendly_resource_name": "API Hub", 
+    "friendly_resource_name": "API Hub Curation", 
     "resource_type":  "google_apihub_curation", 
     "resource_value_name" : "curation_id" 
 }

--- a/policies/gcp/API Hub/google_apihub_plugin/_vars.rego
+++ b/policies/gcp/API Hub/google_apihub_plugin/_vars.rego
@@ -2,7 +2,7 @@ package terraform.gcp.security.api_hub.google_apihub_plugin.vars
 
 
 variables := {
-    "friendly_resource_name": "API Hub", 
+    "friendly_resource_name": "API Hub Plugin", 
     "resource_type":  "google_apihub_plugin", 
     "resource_value_name" : "plugin_id" 
 }

--- a/policies/gcp/API Hub/google_apihub_plugin/config_template.auth_config_template.service_account.service_account.rego
+++ b/policies/gcp/API Hub/google_apihub_plugin/config_template.auth_config_template.service_account.service_account.rego
@@ -10,8 +10,8 @@ conditions := [
         {
             "condition": "Service account not valid",
             "attribute_path" : ["config_template",0,"auth_config_template",0,"service_account",0,"service_account"],
-            "values" : ["service@pde.com"],
-            "policy_type" : "whitelist" 
+            "values" : ["*@*", [["service"], ["pde.com"]]],
+            "policy_type" : "pattern whitelist" 
         }
     ]
 ]

--- a/policies/gcp/API Hub/google_apihub_plugin/config_template.auth_config_template.supported_auth_types.rego
+++ b/policies/gcp/API Hub/google_apihub_plugin/config_template.auth_config_template.supported_auth_types.rego
@@ -8,8 +8,8 @@ conditions := [
         {"situation_description" : "Check supported_auth_types match whitelist",
         "remedies":[ "Use valid supported auth types"]},
         {
-            "condition": "Auth types not set to allowed types",
-            "attribute_path" : ["config_template",0,"auth_config_template",0,"supported_auth_types",0],
+            "condition": "Every supported auth type must be an allowed type",
+            "attribute_path" : ["config_template",0,"auth_config_template",0,"supported_auth_types"],
             "values" : ["USER_PASSWORD"],
             "policy_type" : "whitelist" 
         }

--- a/policies/gcp/API Hub/google_apihub_plugin_instance/_vars.rego
+++ b/policies/gcp/API Hub/google_apihub_plugin_instance/_vars.rego
@@ -2,7 +2,7 @@ package terraform.gcp.security.api_hub.google_apihub_plugin_instance.vars
 
 
 variables := {
-    "friendly_resource_name": "API Hub", 
+    "friendly_resource_name": "API Hub Plugin Instance", 
     "resource_type":  "google_apihub_plugin_instance", 
     "resource_value_name" : "plugin_instance_id" 
 }

--- a/policies/gcp/Access Approval/google_folder_access_approval_settings/_vars.rego
+++ b/policies/gcp/Access Approval/google_folder_access_approval_settings/_vars.rego
@@ -1,7 +1,7 @@
 package terraform.gcp.security.access_approval.google_folder_access_approval_settings.vars
 
 variables := {
-	"friendly_resource_name": "Access Approval",
+	"friendly_resource_name": "Folder Access Approval Settings",
 	"resource_type": "google_folder_access_approval_settings",
 	"resource_value_name": "name",
 }

--- a/policies/gcp/Access Approval/google_organization_access_approval_settings/_vars.rego
+++ b/policies/gcp/Access Approval/google_organization_access_approval_settings/_vars.rego
@@ -1,7 +1,7 @@
 package terraform.gcp.security.access_approval.google_organization_access_approval_settings.vars
 
 variables := {
-	"friendly_resource_name": "Access Approval",
+	"friendly_resource_name": "Organization Access Approval Settings",
 	"resource_type": "google_organization_access_approval_settings",
 	"resource_value_name": "name",
 }

--- a/policies/gcp/Access Approval/google_project_access_approval_settings/_vars.rego
+++ b/policies/gcp/Access Approval/google_project_access_approval_settings/_vars.rego
@@ -1,7 +1,7 @@
 package terraform.gcp.security.access_approval.google_project_access_approval_settings.vars
 
 variables := {
-	"friendly_resource_name": "Access Approval",
+	"friendly_resource_name": "Project Access Approval Settings",
 	"resource_type": "google_project_access_approval_settings",
 	"resource_value_name": "name",
 }

--- a/policies/gcp/Access Context Manager (VPC Service Controls)/google_access_context_manager_access_level_condition/members.rego
+++ b/policies/gcp/Access Context Manager (VPC Service Controls)/google_access_context_manager_access_level_condition/members.rego
@@ -3,6 +3,13 @@ package terraform.gcp.security.access_context_manager_vpc_service_controls.googl
 import data.terraform.gcp.security.access_context_manager_vpc_service_controls.google_access_context_manager_access_level_condition.vars
 import data.terraform.helpers
 
+# policy_lint reports hard-coded-value on the address(es) below, and the finding
+# stands. This attribute is a LIST, and the pattern policy types read the value as
+# a single string (shared.get_target_list regex-matches it), so pointing one at an
+# array makes it undefined -- which reads as "no violation", not as an error, and
+# the non-compliant example would silently stop being flagged. There is no
+# "element whitelist" type in policies/_helpers to check every element of a list
+# against an allowed pattern; adding one is what would unblock this.
 conditions := [[
 	{
 		"situation_description": "An allowed list of members.",

--- a/policies/gcp/Access Context Manager (VPC Service Controls)/google_access_context_manager_access_levels/access_levels.basic.conditions.members.rego
+++ b/policies/gcp/Access Context Manager (VPC Service Controls)/google_access_context_manager_access_levels/access_levels.basic.conditions.members.rego
@@ -3,6 +3,13 @@ package terraform.gcp.security.access_context_manager_vpc_service_controls.googl
 import data.terraform.gcp.security.access_context_manager_vpc_service_controls.google_access_context_manager_access_levels.vars
 import data.terraform.helpers
 
+# policy_lint reports hard-coded-value on the address(es) below, and the finding
+# stands. This attribute is a LIST, and the pattern policy types read the value as
+# a single string (shared.get_target_list regex-matches it), so pointing one at an
+# array makes it undefined -- which reads as "no violation", not as an error, and
+# the non-compliant example would silently stop being flagged. There is no
+# "element whitelist" type in policies/_helpers to check every element of a list
+# against an allowed pattern; adding one is what would unblock this.
 conditions := [[
 	{
 		"situation_description": "An allowed list of members.",

--- a/policies/gcp/Access Context Manager (VPC Service Controls)/google_access_context_manager_ingress_policy/resource.rego
+++ b/policies/gcp/Access Context Manager (VPC Service Controls)/google_access_context_manager_ingress_policy/resource.rego
@@ -11,8 +11,8 @@ conditions := [[
     {
         "condition": "resource is whitelisted",
         "attribute_path": ["resource"],
-        "values": ["projects/123456789"],
-        "policy_type": "whitelist"
+        "values": ["projects/*", [["123456789"]]],
+        "policy_type": "pattern whitelist"
     }
 ]]
 

--- a/policies/gcp/Access Context Manager (VPC Service Controls)/google_access_context_manager_service_perimeter_dry_run_resource/resource.rego
+++ b/policies/gcp/Access Context Manager (VPC Service Controls)/google_access_context_manager_service_perimeter_dry_run_resource/resource.rego
@@ -11,8 +11,8 @@ conditions := [[
     {
         "condition": "resource is whitelisted",
         "attribute_path": ["resource"],
-        "values": ["projects/123456789"],
-        "policy_type": "whitelist"
+        "values": ["projects/*", [["123456789"]]],
+        "policy_type": "pattern whitelist"
     }
 ]]
 

--- a/policies/gcp/Access Context Manager (VPC Service Controls)/google_access_context_manager_service_perimeter_resource/resource.rego
+++ b/policies/gcp/Access Context Manager (VPC Service Controls)/google_access_context_manager_service_perimeter_resource/resource.rego
@@ -11,8 +11,8 @@ conditions := [[
     {
         "condition": "resource is whitelisted",
         "attribute_path": ["resource"],
-        "values": ["projects/123456789"],
-        "policy_type": "whitelist"
+        "values": ["projects/*", [["123456789"]]],
+        "policy_type": "pattern whitelist"
     }
 ]]
 

--- a/policies/gcp/Anthos On-Prem/google_gkeonprem_bare_metal_admin_cluster/_vars.rego
+++ b/policies/gcp/Anthos On-Prem/google_gkeonprem_bare_metal_admin_cluster/_vars.rego
@@ -2,7 +2,7 @@ package terraform.gcp.security.anthos_on_prem.google_gkeonprem_bare_metal_admin_
 
 
 variables := {
-    "friendly_resource_name": "anthos on prem",
+    "friendly_resource_name": "GKE On-Prem Bare Metal Admin Cluster",
     "resource_type":  "google_gkeonprem_bare_metal_admin_cluster", 
     "resource_value_name" : "name",
 }

--- a/policies/gcp/Anthos On-Prem/google_gkeonprem_bare_metal_admin_cluster/security_config.authorization.admin_users.username.rego
+++ b/policies/gcp/Anthos On-Prem/google_gkeonprem_bare_metal_admin_cluster/security_config.authorization.admin_users.username.rego
@@ -9,8 +9,8 @@ import data.terraform.gcp.security.anthos_on_prem.google_gkeonprem_bare_metal_ad
     {
         "condition": "Test if username is secured admin username",
         "attribute_path" : ["security_config", 0, "authorization", 0, "admin_users", 0, "username"],
-        "values" : ["admin@hashicorptest.com"],
-        "policy_type" : "whitelist" 
+        "values" : ["*@*", [["admin"], ["hashicorptest.com"]]],
+        "policy_type" : "pattern whitelist" 
     }
     ]
  ]

--- a/policies/gcp/Anthos On-Prem/google_gkeonprem_bare_metal_cluster/_vars.rego
+++ b/policies/gcp/Anthos On-Prem/google_gkeonprem_bare_metal_cluster/_vars.rego
@@ -2,7 +2,7 @@ package terraform.gcp.security.anthos_on_prem.google_gkeonprem_bare_metal_cluste
 
 
 variables := {
-    "friendly_resource_name": "anthos on prem",
+    "friendly_resource_name": "GKE On-Prem Bare Metal Cluster",
     "resource_type":  "google_gkeonprem_bare_metal_cluster", 
     "resource_value_name" : "name",
 }

--- a/policies/gcp/Anthos On-Prem/google_gkeonprem_bare_metal_node_pool/_vars.rego
+++ b/policies/gcp/Anthos On-Prem/google_gkeonprem_bare_metal_node_pool/_vars.rego
@@ -2,7 +2,7 @@ package terraform.gcp.security.anthos_on_prem.google_gkeonprem_bare_metal_node_p
 
 
 variables := {
-    "friendly_resource_name": "anthos on prem",
+    "friendly_resource_name": "GKE On-Prem Bare Metal Node Pool",
     "resource_type":  "google_gkeonprem_bare_metal_node_pool", 
     "resource_value_name" : "name",
 }

--- a/policies/gcp/Anthos On-Prem/google_gkeonprem_vmware_admin_cluster/_vars.rego
+++ b/policies/gcp/Anthos On-Prem/google_gkeonprem_vmware_admin_cluster/_vars.rego
@@ -2,7 +2,7 @@ package terraform.gcp.security.anthos_on_prem.google_gkeonprem_vmware_admin_clus
 
 
 variables := {
-    "friendly_resource_name": "anthos on prem",
+    "friendly_resource_name": "GKE On-Prem VMware Admin Cluster",
     "resource_type":  "google_gkeonprem_vmware_admin_cluster", 
     "resource_value_name" : "name",
 }

--- a/policies/gcp/Anthos On-Prem/google_gkeonprem_vmware_admin_cluster/authorization.viewer_users.username.rego
+++ b/policies/gcp/Anthos On-Prem/google_gkeonprem_vmware_admin_cluster/authorization.viewer_users.username.rego
@@ -9,8 +9,8 @@ import data.terraform.gcp.security.anthos_on_prem.google_gkeonprem_vmware_admin_
     {
         "condition": "Test if the username is a secured gmail.com account",
         "attribute_path" : ["authorization", 0, "viewer_users", 0, "username"],
-        "values" : ["user1@gmail.com"],
-        "policy_type" : "whitelist" 
+        "values" : ["*@*", [["user1"], ["gmail.com"]]],
+        "policy_type" : "pattern whitelist" 
     }
     
     ]

--- a/policies/gcp/Anthos On-Prem/google_gkeonprem_vmware_cluster/_vars.rego
+++ b/policies/gcp/Anthos On-Prem/google_gkeonprem_vmware_cluster/_vars.rego
@@ -2,7 +2,7 @@ package terraform.gcp.security.anthos_on_prem.google_gkeonprem_vmware_cluster.va
 
 
 variables := {
-    "friendly_resource_name": "anthos on prem",
+    "friendly_resource_name": "GKE On-Prem VMware Cluster",
     "resource_type":  "google_gkeonprem_vmware_cluster", 
     "resource_value_name" : "name",
 }

--- a/policies/gcp/Anthos On-Prem/google_gkeonprem_vmware_node_pool/_vars.rego
+++ b/policies/gcp/Anthos On-Prem/google_gkeonprem_vmware_node_pool/_vars.rego
@@ -2,7 +2,7 @@ package terraform.gcp.security.anthos_on_prem.google_gkeonprem_vmware_node_pool.
 
 
 variables := {
-    "friendly_resource_name": "anthos on prem",
+    "friendly_resource_name": "GKE On-Prem VMware Node Pool",
     "resource_type":  "google_gkeonprem_vmware_node_pool", 
     "resource_value_name" : "name",
 }

--- a/policies/gcp/Apigee/google_apigee_addons_config/_vars.rego
+++ b/policies/gcp/Apigee/google_apigee_addons_config/_vars.rego
@@ -2,7 +2,7 @@ package terraform.gcp.security.apigee.google_apigee_addons_config.vars
 
 
 variables := {
-    "friendly_resource_name": "", 
+    "friendly_resource_name": "Apigee Addons Config", 
     "resource_type":  "google_apigee_addons_config",
     "resource_value_name" : "name"
 }

--- a/policies/gcp/Apigee/google_apigee_api/_vars.rego
+++ b/policies/gcp/Apigee/google_apigee_api/_vars.rego
@@ -2,7 +2,7 @@ package terraform.gcp.security.apigee.google_apigee_api.vars
 
 
 variables := {
-    "friendly_resource_name": "", 
+    "friendly_resource_name": "Apigee API", 
     "resource_type":  "google_apigee_api", 
     "resource_value_name" : "name" 
 }

--- a/policies/gcp/Apigee/google_apigee_api_deployment/_vars.rego
+++ b/policies/gcp/Apigee/google_apigee_api_deployment/_vars.rego
@@ -2,7 +2,7 @@ package terraform.gcp.security.apigee.google_apigee_api_deployment.vars
 
 
 variables := {
-    "friendly_resource_name": "", 
+    "friendly_resource_name": "Apigee API Deployment", 
     "resource_type":  "google_apigee_api_deployment",
     "resource_value_name" : "name" 
 }

--- a/policies/gcp/Apigee/google_apigee_api_product/_vars.rego
+++ b/policies/gcp/Apigee/google_apigee_api_product/_vars.rego
@@ -2,7 +2,7 @@ package terraform.gcp.security.apigee.google_apigee_api_product.vars
 
 
 variables := {
-    "friendly_resource_name": "", 
+    "friendly_resource_name": "Apigee API Product", 
     "resource_type":  "google_apigee_api_product",
     "resource_value_name" : "name" 
 }

--- a/policies/gcp/Apigee/google_apigee_developer_app/_vars.rego
+++ b/policies/gcp/Apigee/google_apigee_developer_app/_vars.rego
@@ -2,7 +2,7 @@ package terraform.gcp.security.apigee.google_apigee_developer_app.vars
 
 
 variables := {
-    "friendly_resource_name": "", 
+    "friendly_resource_name": "Apigee Developer App", 
     "resource_type":  "google_apigee_developer_app", 
     "resource_value_name" : "name"
 }

--- a/policies/gcp/Apigee/google_apigee_instance/disk_encryption_key_name.rego
+++ b/policies/gcp/Apigee/google_apigee_instance/disk_encryption_key_name.rego
@@ -16,8 +16,12 @@ conditions := [
         {
             "condition": "Check if disk_encryption_key_name uses an approved Australian KMS location",
             "attribute_path": ["disk_encryption_key_name"],
+            # Anchored on the location segment of the key path. The full key
+            # format is documented in the remedies: a pattern target only ever
+            # constrains the segments it captures, so spelling the rest of the
+            # path out here would pin a project id without checking anything.
             "values": [
-                "projects/.+/locations/*/keyRings/.+/cryptoKeys/.+",
+                "locations/*/keyRings/",
                 [["australia-southeast1", "australia-southeast2"]]
             ],
             "policy_type": "pattern whitelist"

--- a/policies/gcp/Apikeys/google_apikeys_key/restrictions.api_targets.methods.rego
+++ b/policies/gcp/Apikeys/google_apikeys_key/restrictions.api_targets.methods.rego
@@ -13,8 +13,8 @@ conditions := [
     },
     {
         "condition": "Check that api_targets.methods does not contain a wildcard.",
-        # restrictions[0].api_targets[0].methods[0]
-        "attribute_path" : ["restrictions", 0, "api_targets", 0, "methods", 0],
+        # restrictions[0].api_targets[0].methods
+        "attribute_path" : ["restrictions", 0, "api_targets", 0, "methods"],
         "values" : ["*"],
         "policy_type" : "blacklist"
     }

--- a/policies/gcp/Apikeys/google_apikeys_key/restrictions.browser_key_restrictions.allowed_referrers.rego
+++ b/policies/gcp/Apikeys/google_apikeys_key/restrictions.browser_key_restrictions.allowed_referrers.rego
@@ -13,8 +13,10 @@ conditions := [
     },
     {
         "condition": "Check that allowed_referrers does not contain overly broad patterns.",
-        # restrictions[0].browser_key_restrictions[0].allowed_referrers[0]
-        "attribute_path" : ["restrictions", 0, "browser_key_restrictions", 0, "allowed_referrers", 0],
+        # restrictions[0].browser_key_restrictions[0].allowed_referrers -- the whole list.
+        # Exact-match blacklist, not "element blacklist": the latter matches by substring,
+        # and a legitimate referrer such as "https://example.com/*" contains "*".
+        "attribute_path" : ["restrictions", 0, "browser_key_restrictions", 0, "allowed_referrers"],
         "values" : ["*", "http://*", "https://*"],
         "policy_type" : "blacklist"
     }

--- a/policies/gcp/Apikeys/google_apikeys_key/restrictions.server_key_restrictions.allowed_ips.rego
+++ b/policies/gcp/Apikeys/google_apikeys_key/restrictions.server_key_restrictions.allowed_ips.rego
@@ -13,8 +13,10 @@ conditions := [
     },
     {
         "condition": "Check that allowed_ips does not contain public 0.0.0.0/0.",
-        # restrictions[0].server_key_restrictions[0].allowed_ips[0]
-        "attribute_path" : ["restrictions", 0, "server_key_restrictions", 0, "allowed_ips", 0],
+        # restrictions[0].server_key_restrictions[0].allowed_ips -- the whole list.
+        # Exact-match blacklist, not "element blacklist": CIDR strings contain each other
+        # as substrings ("10.0.0.0/0" contains "0.0.0.0/0").
+        "attribute_path" : ["restrictions", 0, "server_key_restrictions", 0, "allowed_ips"],
         "values" : ["0.0.0.0/0"],
         "policy_type" : "blacklist"
     }

--- a/policies/gcp/App Hub/google_apphub_application/_vars.rego
+++ b/policies/gcp/App Hub/google_apphub_application/_vars.rego
@@ -1,7 +1,7 @@
 package terraform.gcp.security.app_hub.google_apphub_application.vars
 
 variables := {
-    "friendly_resource_name": "App Hub", 
+    "friendly_resource_name": "App Hub Application", 
     "resource_type":  "google_apphub_application", 
     "resource_value_name" : "name" 
 }

--- a/policies/gcp/App Hub/google_apphub_boundary/_vars.rego
+++ b/policies/gcp/App Hub/google_apphub_boundary/_vars.rego
@@ -1,7 +1,7 @@
 package terraform.gcp.security.app_hub.google_apphub_boundary.vars
 
 variables := {
-    "friendly_resource_name": "App Hub", 
+    "friendly_resource_name": "App Hub Boundary", 
     "resource_type":  "google_apphub_boundary", 
     "resource_value_name" : "name" 
 }

--- a/policies/gcp/App Hub/google_apphub_service/_vars.rego
+++ b/policies/gcp/App Hub/google_apphub_service/_vars.rego
@@ -1,7 +1,7 @@
 package terraform.gcp.security.app_hub.google_apphub_service.vars
 
 variables := {
-    "friendly_resource_name": "App Hub", 
+    "friendly_resource_name": "App Hub Service", 
     "resource_type":  "google_apphub_service", 
     "resource_value_name" : "name" 
 }

--- a/policies/gcp/App Hub/google_apphub_service_project_attachment/_vars.rego
+++ b/policies/gcp/App Hub/google_apphub_service_project_attachment/_vars.rego
@@ -1,7 +1,7 @@
 package terraform.gcp.security.app_hub.google_apphub_service_project_attachment.vars
 
 variables := {
-    "friendly_resource_name": "App Hub", 
+    "friendly_resource_name": "App Hub Service Project Attachment", 
     "resource_type":  "google_apphub_service_project_attachment", 
     "resource_value_name" : "name" 
 }

--- a/policies/gcp/App Hub/google_apphub_workload/_vars.rego
+++ b/policies/gcp/App Hub/google_apphub_workload/_vars.rego
@@ -1,7 +1,7 @@
 package terraform.gcp.security.app_hub.google_apphub_workload.vars
 
 variables := {
-    "friendly_resource_name": "App Hub", 
+    "friendly_resource_name": "App Hub Workload", 
     "resource_type":  "google_apphub_workload", 
     "resource_value_name" : "name" 
 }

--- a/policies/gcp/Backup for GKE/google_gke_backup_restore_channel/destination_project.rego
+++ b/policies/gcp/Backup for GKE/google_gke_backup_restore_channel/destination_project.rego
@@ -2,6 +2,12 @@ package terraform.gcp.security.backup_for_gke.google_gke_backup_restore_channel.
 import data.terraform.helpers
 import data.terraform.gcp.security.backup_for_gke.google_gke_backup_restore_channel.vars
 
+# policy_lint reports hard-coded-value on the value below, and the finding stands.
+# A pattern whitelist only judges values that MATCH its target: one that does not
+# match the shape is never flagged at all. This argument's non-compliant example
+# is a bare project name with no "projects/" prefix, so converting would make the fixture pass for the wrong
+# reason. Either _helpers needs a pattern whitelist that fails a non-matching
+# value, or the fixture needs a wrongly-scoped (not malformed) example.
 conditions := [
   [
     {

--- a/policies/gcp/BeyondCorp/google_beyondcorp_security_gateway_application_iam_binding/_vars.rego
+++ b/policies/gcp/BeyondCorp/google_beyondcorp_security_gateway_application_iam_binding/_vars.rego
@@ -1,7 +1,7 @@
 package terraform.gcp.security.beyondcorp.google_beyondcorp_security_gateway_application_iam_binding.vars
 
 variables := {
-  "friendly_resource_name": "BeyondCorp GCP managed IAM Binding",
+  "friendly_resource_name": "BeyondCorp Security Gateway Application IAM Binding",
   "resource_type":  "google_beyondcorp_security_gateway_application_iam_binding",
   "resource_value_name" : "security_gateway_id"
 }

--- a/policies/gcp/BeyondCorp/google_beyondcorp_security_gateway_application_iam_member/_vars.rego
+++ b/policies/gcp/BeyondCorp/google_beyondcorp_security_gateway_application_iam_member/_vars.rego
@@ -2,7 +2,7 @@ package terraform.gcp.security.beyondcorp.google_beyondcorp_security_gateway_app
 
 
 variables := {
-    "friendly_resource_name": "BeyondCorp GCP managed IAM Member",
+    "friendly_resource_name": "BeyondCorp Security Gateway Application IAM Member",
     "resource_type":  "google_beyondcorp_security_gateway_application_iam_member",
     "resource_value_name" : "security_gateway_id"
 }

--- a/policies/gcp/BeyondCorp/google_beyondcorp_security_gateway_iam_binding/_vars.rego
+++ b/policies/gcp/BeyondCorp/google_beyondcorp_security_gateway_iam_binding/_vars.rego
@@ -2,7 +2,7 @@ package terraform.gcp.security.beyondcorp.google_beyondcorp_security_gateway_iam
 
 
 variables := {
-    "friendly_resource_name": "BeyondCorp GCP managed IAM Binding",
+    "friendly_resource_name": "BeyondCorp Security Gateway IAM Binding",
     "resource_type":  "google_beyondcorp_security_gateway_iam_binding",
     "resource_value_name" : "security_gateway_id"
 }

--- a/policies/gcp/BeyondCorp/google_beyondcorp_security_gateway_iam_member/_vars.rego
+++ b/policies/gcp/BeyondCorp/google_beyondcorp_security_gateway_iam_member/_vars.rego
@@ -2,7 +2,7 @@ package terraform.gcp.security.beyondcorp.google_beyondcorp_security_gateway_iam
 
 
 variables := {
-    "friendly_resource_name": "BeyondCorp GCP managed IAM Member",
+    "friendly_resource_name": "BeyondCorp Security Gateway IAM Member",
     "resource_type":  "google_beyondcorp_security_gateway_iam_member",
     "resource_value_name" : "security_gateway_id"
 }

--- a/policies/gcp/BigQuery Data Policy V2/google_bigquery_datapolicyv2_data_policy/grantees.rego
+++ b/policies/gcp/BigQuery Data Policy V2/google_bigquery_datapolicyv2_data_policy/grantees.rego
@@ -48,8 +48,8 @@ conditions := [
         {
             "condition": "grantees must not contain direct user principals",
             "attribute_path": ["grantees"],
-            "values": ["principal://iam.googleapis.com/users/alice@example.com"],
-            "policy_type": "blacklist"
+            "values": ["principal://iam.googleapis.com/users/"],
+            "policy_type": "element blacklist"
         }
     ]
 ]

--- a/policies/gcp/BigQuery Data Policy/google_bigquery_datapolicy_data_policy_iam_member/_vars.rego
+++ b/policies/gcp/BigQuery Data Policy/google_bigquery_datapolicy_data_policy_iam_member/_vars.rego
@@ -2,7 +2,7 @@ package terraform.gcp.security.bigquery_data_policy.google_bigquery_datapolicy_d
 
 
 variables := {
-    "friendly_resource_name": "BigQuery Data Policy", 
+    "friendly_resource_name": "BigQuery Data Policy IAM Member", 
     "resource_type":  "bigquery_datapolicy_data_policy_iam", 
     "resource_value_name" : "data_policy_id" 
 }

--- a/policies/gcp/BigQuery Data Policy/google_bigquery_datapolicy_data_policy_iam_member/member.rego
+++ b/policies/gcp/BigQuery Data Policy/google_bigquery_datapolicy_data_policy_iam_member/member.rego
@@ -19,8 +19,8 @@ conditions := [
     {
         "condition": "Validating email",
         "attribute_path" : ["member"],
-        "values" : ["user:user@external.com"], 
-        "policy_type" : "blacklist"
+        "values" : ["*:*@*", [[], [], ["external.com"]]],
+        "policy_type" : "pattern blacklist"
     }
     ],
     [

--- a/policies/gcp/BigQuery/google_bigquery_dataset/access.group_by_email.rego
+++ b/policies/gcp/BigQuery/google_bigquery_dataset/access.group_by_email.rego
@@ -2,6 +2,13 @@ package terraform.gcp.security.BigQuery.google_bigquery_dataset.access_group_by_
 import data.terraform.helpers
 import data.terraform.gcp.security.BigQuery.google_bigquery_dataset.vars
 
+# policy_lint reports hard-coded-value on the address(es) below, and the finding
+# stands. This attribute is a LIST, and the pattern policy types read the value as
+# a single string (shared.get_target_list regex-matches it), so pointing one at an
+# array makes it undefined -- which reads as "no violation", not as an error, and
+# the non-compliant example would silently stop being flagged. There is no
+# "element whitelist" type in policies/_helpers to check every element of a list
+# against an allowed pattern; adding one is what would unblock this.
 conditions := [
     [
         {"situation_description" : "Incorrect Email",

--- a/policies/gcp/BigQuery/google_bigquery_dataset/access.user_by_email.rego
+++ b/policies/gcp/BigQuery/google_bigquery_dataset/access.user_by_email.rego
@@ -2,6 +2,13 @@ package terraform.gcp.security.BigQuery.google_bigquery_dataset.access_user_by_e
 import data.terraform.helpers
 import data.terraform.gcp.security.BigQuery.google_bigquery_dataset.vars
 
+# policy_lint reports hard-coded-value on the address(es) below, and the finding
+# stands. This attribute is a LIST, and the pattern policy types read the value as
+# a single string (shared.get_target_list regex-matches it), so pointing one at an
+# array makes it undefined -- which reads as "no violation", not as an error, and
+# the non-compliant example would silently stop being flagged. There is no
+# "element whitelist" type in policies/_helpers to check every element of a list
+# against an allowed pattern; adding one is what would unblock this.
 conditions := [
     [
         {"situation_description" : "Incorrect Email",

--- a/policies/gcp/BigQuery/google_bigquery_dataset_access/group_by_email.rego
+++ b/policies/gcp/BigQuery/google_bigquery_dataset_access/group_by_email.rego
@@ -9,8 +9,8 @@ conditions := [
         {
             "condition": "Check for correct group_by_email",
             "attribute_path" : ["group_by_email"],
-            "values" : ["user@example.com"],
-            "policy_type" : "whitelist"  
+            "values" : ["*@*", [["user"], ["example.com"]]],
+            "policy_type" : "pattern whitelist"  
         }
     ]
 ]

--- a/policies/gcp/BigQuery/google_bigquery_dataset_access/user_by_email.rego
+++ b/policies/gcp/BigQuery/google_bigquery_dataset_access/user_by_email.rego
@@ -9,8 +9,8 @@ conditions := [
         {
             "condition": "Check for correct user_by_email",
             "attribute_path" : ["user_by_email"],
-            "values" : ["user@example.com"],
-            "policy_type" : "whitelist"  
+            "values" : ["*@*", [["user"], ["example.com"]]],
+            "policy_type" : "pattern whitelist"  
         }
     ]
 ]

--- a/policies/gcp/BigQuery/google_bigquery_dataset_iam_policy/policy_data.rego
+++ b/policies/gcp/BigQuery/google_bigquery_dataset_iam_policy/policy_data.rego
@@ -5,6 +5,12 @@ import data.terraform.gcp.security.BigQuery.google_bigquery_dataset_iam_policy.v
 
 # Merged policy for `policy_data` — 2 independent scenarios, each a
 # situation in `conditions`, evaluated separately by helpers.get_multi_summary.
+# policy_lint reports hard-coded-value on the address inside the JSON below, and
+# the finding stands. policy_data is compared as a whole rendered IAM policy
+# document; a pattern target is used as a regex, and a JSON document's { [ ] "
+# characters are regex metacharacters, while roles/... contains a "/" that the
+# "*" wildcard ([^/]+) cannot cross. The address is part of the document being
+# matched, so a wildcard cannot replace it without the match failing.
 conditions := [
 [
         {"situation_description" : "allUsers detected",

--- a/policies/gcp/BigQuery/google_bigquery_job/_vars.rego
+++ b/policies/gcp/BigQuery/google_bigquery_job/_vars.rego
@@ -1,7 +1,7 @@
 package terraform.gcp.security.BigQuery.google_bigquery_job.vars
 
 variables := {
-    "friendly_resource_name": "BigQuery Dataset IAM Policy",
+    "friendly_resource_name": "BigQuery Job",
     "resource_type": "google_bigquery_job",  
     "resource_value_name": "job_id"
 }

--- a/policies/gcp/BigQuery/google_bigquery_routine/_vars.rego
+++ b/policies/gcp/BigQuery/google_bigquery_routine/_vars.rego
@@ -1,7 +1,7 @@
 package terraform.gcp.security.BigQuery.google_bigquery_routine.vars
 
 variables := {
-    "friendly_resource_name": "BigQuery Dataset IAM Policy",
+    "friendly_resource_name": "BigQuery Routine",
     "resource_type": "google_bigquery_routine",  
     "resource_value_name": "dataset_id"
 }

--- a/policies/gcp/BigQuery/google_bigquery_row_access_policy/_vars.rego
+++ b/policies/gcp/BigQuery/google_bigquery_row_access_policy/_vars.rego
@@ -1,7 +1,7 @@
 package terraform.gcp.security.BigQuery.google_bigquery_row_access_policy.vars
 
 variables := {
-    "friendly_resource_name": "BigQuery Dataset IAM Policy",
+    "friendly_resource_name": "BigQuery Row Access Policy",
     "resource_type": "google_bigquery_row_access_policy",  
     "resource_value_name": "dataset_id"
 }

--- a/policies/gcp/BigQuery/google_bigquery_table/_vars.rego
+++ b/policies/gcp/BigQuery/google_bigquery_table/_vars.rego
@@ -1,7 +1,7 @@
 package terraform.gcp.security.BigQuery.google_bigquery_table.vars
 
 variables := {
-    "friendly_resource_name": "BigQuery Dataset IAM Policy",
+    "friendly_resource_name": "BigQuery Table",
     "resource_type": "google_bigquery_table",  
     "resource_value_name": "dataset_id"
 }

--- a/policies/gcp/BigQuery/google_bigquery_table_iam_policy/_vars.rego
+++ b/policies/gcp/BigQuery/google_bigquery_table_iam_policy/_vars.rego
@@ -1,7 +1,7 @@
 package terraform.gcp.security.BigQuery.google_bigquery_table_iam_policy.vars
 
 variables := {
-    "friendly_resource_name": "BigQuery Dataset IAM Policy",
+    "friendly_resource_name": "BigQuery Table IAM Policy",
     "resource_type": "google_bigquery_table_iam_policy",  
     "resource_value_name": "dataset_id"
 }

--- a/policies/gcp/BigQuery/google_bigquery_table_iam_policy/policy_data.rego
+++ b/policies/gcp/BigQuery/google_bigquery_table_iam_policy/policy_data.rego
@@ -5,6 +5,12 @@ import data.terraform.gcp.security.BigQuery.google_bigquery_table_iam_policy.var
 
 # Merged policy for `policy_data` — 2 independent scenarios, each a
 # situation in `conditions`, evaluated separately by helpers.get_multi_summary.
+# policy_lint reports hard-coded-value on the address inside the JSON below, and
+# the finding stands. policy_data is compared as a whole rendered IAM policy
+# document; a pattern target is used as a regex, and a JSON document's { [ ] "
+# characters are regex metacharacters, while roles/... contains a "/" that the
+# "*" wildcard ([^/]+) cannot cross. The address is part of the document being
+# matched, so a wildcard cannot replace it without the match failing.
 conditions := [
 [
         {"situation_description" : "Check for valid members",

--- a/policies/gcp/Biglake/google_biglake_database/hive_options.location_uri.rego
+++ b/policies/gcp/Biglake/google_biglake_database/hive_options.location_uri.rego
@@ -14,8 +14,8 @@ conditions := [
     {
       "condition": "Restrict hive_options.location_uri to approved GCS prefixes",
       "attribute_path": ["hive_options", 0, "location_uri"],
-      "values": ["gs://org-au-biglake-metadata/metadata/"],
-      "policy_type": "whitelist"
+      "values": ["*://*/metadata/", [["gs"], ["org-au-biglake-metadata"]]],
+      "policy_type": "pattern whitelist"
     }
   ]
 ]

--- a/policies/gcp/Biglake/google_biglake_table/hive_options.storage_descriptor.location_uri.rego
+++ b/policies/gcp/Biglake/google_biglake_table/hive_options.storage_descriptor.location_uri.rego
@@ -13,8 +13,8 @@ conditions := [
     {
       "condition": "Restrict table storage location to approved GCS prefixes",
       "attribute_path": ["hive_options", 0,"storage_descriptor", 0, "location_uri"],
-      "values": ["gs://org-au-biglake-data/data/"],
-      "policy_type": "whitelist"
+      "values": ["*://*/data/", [["gs"], ["org-au-biglake-data"]]],
+      "policy_type": "pattern whitelist"
     }
   ]
 ]

--- a/policies/gcp/Binary Authorization/google_binary_authorization_attestor_iam_member/attestor.rego
+++ b/policies/gcp/Binary Authorization/google_binary_authorization_attestor_iam_member/attestor.rego
@@ -15,11 +15,13 @@ conditions := [
       "condition": "Only approved attestor references are allowed",
       "attribute_path": ["attestor"],
       "values": [
-        "projects/my-secure-project/attestors/australia-southeast1",
-        "projects/my-secure-project/attestors/us-central1-attestor1",
-        "projects/my-secure-project/attestors/us-central1-attestor2"
+        "projects/*/attestors/*",
+        [
+          ["my-secure-project"],
+          ["australia-southeast1", "us-central1-attestor1", "us-central1-attestor2"]
+        ]
       ],
-      "policy_type": "whitelist"
+      "policy_type": "pattern whitelist"
     }
   ]
 ]

--- a/policies/gcp/Binary Authorization/google_binary_authorization_attestor_iam_member/member.rego
+++ b/policies/gcp/Binary Authorization/google_binary_authorization_attestor_iam_member/member.rego
@@ -15,9 +15,10 @@ conditions := [
       "condition": "`member` must be set to an approved identity",
       "attribute_path": ["member"],
       "values": [
-        "serviceAccount:valid-sa@my-secure-project.iam.gserviceaccount.com"
+        "*:*@*",
+        [["serviceAccount"], ["valid-sa"], ["my-secure-project.iam.gserviceaccount.com"]]
       ],
-      "policy_type": "whitelist"
+      "policy_type": "pattern whitelist"
     }
   ]
 ]

--- a/policies/gcp/Certificate Manager/google_certificate_manager_certificate/managed.issuance_config.rego
+++ b/policies/gcp/Certificate Manager/google_certificate_manager_certificate/managed.issuance_config.rego
@@ -11,8 +11,11 @@ conditions := [[
 	{
 		"condition": "Certificate managed issuance config should use an approved value.",
 		"attribute_path": ["managed", 0, "issuance_config"],
-		"values": ["projects/sit764-policy-project/locations/global/certificateIssuanceConfigs/approved-issuance-config"],
-		"policy_type": "whitelist",
+		"values": [
+			"projects/*/locations/*/certificateIssuanceConfigs/*",
+			[["sit764-policy-project"], ["global"], ["approved-issuance-config"]],
+		],
+		"policy_type": "pattern whitelist",
 	},
 ]]
 

--- a/policies/gcp/Certificate Manager/google_certificate_manager_certificate_issuance_config/certificate_authority_config.certificate_authority_service_config.ca_pool.rego
+++ b/policies/gcp/Certificate Manager/google_certificate_manager_certificate_issuance_config/certificate_authority_config.certificate_authority_service_config.ca_pool.rego
@@ -12,8 +12,11 @@ conditions := [
 		{
 			"condition": "Certificate issuance config should use an approved CA pool.",
 			"attribute_path": ["certificate_authority_config", 0, "certificate_authority_service_config", 0, "ca_pool"],
-			"values": ["projects/sit764-policy-project/locations/us-central1/caPools/approved-ca-pool"],
-			"policy_type": "whitelist"
+			"values": [
+				"projects/*/locations/*/caPools/*",
+				[["sit764-policy-project"], ["us-central1"], ["approved-ca-pool"]]
+			],
+			"policy_type": "pattern whitelist"
 		}
 	]
 ]

--- a/policies/gcp/Chronicle/google_chronicle_data_access_label/udm_query.rego
+++ b/policies/gcp/Chronicle/google_chronicle_data_access_label/udm_query.rego
@@ -13,12 +13,21 @@ conditions := [
       "condition": "Only specific values are allowed in UDM query",
       "attribute_path": ["udm_query"],
       "values": [
-        "principal.hostname=\"malicious.com\"",
-        "principal.user_email=\"admin@malicious.com\"",
         "principal.hostname=\"malicious.com\""
-        
       ],
       "policy_type": "blacklist"
+    }
+  ],
+  [
+    {
+      "situation_description": "UDM query scopes access by an email address at a known-bad domain.",
+      "remedies": ["Do not scope data access by an address at an untrusted domain."]
+    },
+    {
+      "condition": "UDM query must not select on an email at a blacklisted domain",
+      "attribute_path": ["udm_query"],
+      "values": ["principal.user_email=\"*@*\"", [[], ["malicious.com"]]],
+      "policy_type": "pattern blacklist"
     }
   ],
 ]

--- a/policies/gcp/Chronicle/google_chronicle_rule/scope.rego
+++ b/policies/gcp/Chronicle/google_chronicle_rule/scope.rego
@@ -33,7 +33,10 @@ conditions := [
     {
       "condition": "Invalid or disallowed 'location' value",
       "attribute_path": ["scope"],
-      "values": ["projects/fake-project/locations/*/instances/audit-log-activity/dataAccessScopes/legitimatescope", 
+      # Anchored on the location segment only: a pattern target constrains the
+      # segments it captures, so naming the project and instance here would pin
+      # them without checking them.
+      "values": ["locations/*/instances/",
       [["australia-southeast1"]]],
       "policy_type": "pattern whitelist"
     }

--- a/policies/gcp/Cloud Asset Inventory/google_cloud_asset_folder_feed/feed_output_config.pubsub_destination.topic.rego
+++ b/policies/gcp/Cloud Asset Inventory/google_cloud_asset_folder_feed/feed_output_config.pubsub_destination.topic.rego
@@ -3,6 +3,12 @@ package terraform.gcp.security.cloud_asset_inventory.google_cloud_asset_folder_f
 import data.terraform.helpers
 import data.terraform.gcp.security.cloud_asset_inventory.google_cloud_asset_folder_feed.vars
 
+# policy_lint reports hard-coded-value on the value below, and the finding stands.
+# A pattern whitelist only judges values that MATCH its target: one that does not
+# match the shape is never flagged at all. This argument's non-compliant example
+# is a bare topic name with no "projects/.../topics/" path, so converting would make the fixture pass for the wrong
+# reason. Either _helpers needs a pattern whitelist that fails a non-matching
+# value, or the fixture needs a wrongly-scoped (not malformed) example.
 conditions := [
     [
         {

--- a/policies/gcp/Cloud Billing/google_billing_account_iam_member/member.rego
+++ b/policies/gcp/Cloud Billing/google_billing_account_iam_member/member.rego
@@ -9,8 +9,8 @@ conditions := [
     {
         "condition": "Only approved and verified IAM members are allowed",
         "attribute_path" : ["member"],
-        "values" : ["user:jane@organization.org"],
-        "policy_type" : "whitelist" 
+        "values" : ["*:*@*", [["user"], ["jane"], ["organization.org"]]],
+        "policy_type" : "pattern whitelist" 
     }
     
     ]

--- a/policies/gcp/Cloud Build v2/google_cloudbuildv2_repository/_vars.rego
+++ b/policies/gcp/Cloud Build v2/google_cloudbuildv2_repository/_vars.rego
@@ -1,7 +1,7 @@
 package terraform.gcp.security.cloudbuildv2.google_cloudbuildv2_repository.vars
 
 variables := {
-    "friendly_resource_name": "google_cloudbuildv2_repository",
+    "friendly_resource_name": "Cloud Build v2 Repository",
     "resource_type": "google_cloudbuildv2_repository",
     "resource_value_name": "project",
 }

--- a/policies/gcp/Cloud Composer/google_composer_user_workloads_config_map/_vars.rego
+++ b/policies/gcp/Cloud Composer/google_composer_user_workloads_config_map/_vars.rego
@@ -1,7 +1,7 @@
 package terraform.gcp.security.cloud_composer.google_composer_user_workloads_config_map.vars
 
 variables := {
-  "friendly_resource_name": "Cloud Composer Environment",
+  "friendly_resource_name": "Cloud Composer User Workloads Config Map",
   "resource_type": "google_composer_user_workloads_config_map",
   "resource_value_name": "name"
 }

--- a/policies/gcp/Cloud Deploy/google_clouddeploy_automation/service_account.rego
+++ b/policies/gcp/Cloud Deploy/google_clouddeploy_automation/service_account.rego
@@ -9,8 +9,8 @@ conditions := [
         {
             "condition": "Automation uses dedicated service account",
             "attribute_path": ["service_account"],
-            "values": ["dedicated-automation-sa@my-project.iam.gserviceaccount.com"],
-            "policy_type": "whitelist"
+            "values": ["*@*", [["dedicated-automation-sa"], ["my-project.iam.gserviceaccount.com"]]],
+            "policy_type": "pattern whitelist"
         }
     ]
 ]

--- a/policies/gcp/Cloud Domains/google_clouddomains_registration/contact_settings.registrant_contact.email.rego
+++ b/policies/gcp/Cloud Domains/google_clouddomains_registration/contact_settings.registrant_contact.email.rego
@@ -12,8 +12,8 @@ conditions := [
         {
             "condition": "Check registrant contact email",
             "attribute_path": ["contact_settings", 0, "registrant_contact", 0, "email"],
-            "values": ["admin@example.com"],
-            "policy_type": "whitelist"
+            "values": ["*@*", [["admin"], ["example.com"]]],
+            "policy_type": "pattern whitelist"
         }
     ]
 ]

--- a/policies/gcp/Cloud Domains/google_clouddomains_registration/domain_notices.rego
+++ b/policies/gcp/Cloud Domains/google_clouddomains_registration/domain_notices.rego
@@ -11,6 +11,14 @@ conditions := [
         },
         {
             "condition": "Check if HSTS_PRELOADED notice is acknowledged",
+            # policy_lint reports index-path here, and the trailing index is
+            # deliberate: this is a "the list must CONTAIN this value" check, and
+            # none of the six policy types can express it over a whole list.
+            # Dropping the index makes an empty domain_notices vacuously
+            # compliant (whitelist over an array is a subset test, and the empty
+            # set is a subset of everything), which is exactly the case the
+            # non-compliant fixture is testing. Needs a new policy type in
+            # _helpers, not a change here.
             "attribute_path": ["domain_notices", 0],
             "values": ["HSTS_PRELOADED"],
             "policy_type": "whitelist"

--- a/policies/gcp/Cloud Endpoints/google_endpoints_service_consumers_iam_binding/members.rego
+++ b/policies/gcp/Cloud Endpoints/google_endpoints_service_consumers_iam_binding/members.rego
@@ -16,7 +16,7 @@ conditions := [
            {
                 
                 "condition": "Google Cloud Endpoints consumers IAM members must not include public principals.",
-                "attribute_path": ["members", 0],
+                "attribute_path": ["members"],
                 "values": ["allUsers", "allAuthenticatedUsers"],
                 "policy_type": "blacklist"
 

--- a/policies/gcp/Cloud Functions (2nd gen)/google_cloudfunctions2_function/service_config.vpc_connector.rego
+++ b/policies/gcp/Cloud Functions (2nd gen)/google_cloudfunctions2_function/service_config.vpc_connector.rego
@@ -3,6 +3,12 @@ package terraform.gcp.security.google_cloudfunction.google_cloudfunctions2_funct
 import data.terraform.helpers
 import data.terraform.gcp.security.google_cloudfunction.google_cloudfunctions2_function.vars
 
+# policy_lint reports hard-coded-value on the value below, and the finding stands.
+# A pattern whitelist only judges values that MATCH its target: one that does not
+# match the shape is never flagged at all. This argument's non-compliant example
+# is the empty string, so converting would make the fixture pass for the wrong
+# reason. Either _helpers needs a pattern whitelist that fails a non-matching
+# value, or the fixture needs a wrongly-scoped (not malformed) example.
 conditions := [
   [
     {

--- a/policies/gcp/Cloud Functions/google_cloudfunctions_function/vpc_connector_egress_settings.rego
+++ b/policies/gcp/Cloud Functions/google_cloudfunctions_function/vpc_connector_egress_settings.rego
@@ -11,7 +11,8 @@ conditions := [
     {
       "condition": "checks that vpc connector resides in approved Australian regions",
       "attribute_path": ["vpc_connector"],
-      "values": ["projects/my-project/locations/*/connectors/my-connector",[["australia-southeast1", "australia-southeast2"]]],
+      "values": ["projects/*/locations/*/connectors/*",
+                 [["my-project"], ["australia-southeast1", "australia-southeast2"], ["my-connector"]]],
       "policy_type": "pattern whitelist"
     }
     ],

--- a/policies/gcp/Cloud Platform/google_folder_organization_policy/constraint.rego
+++ b/policies/gcp/Cloud Platform/google_folder_organization_policy/constraint.rego
@@ -9,7 +9,7 @@ conditions := [
      "remedies": ["Deny risky services using list_policy.deny.values (e.g., cloudresourcemanager.googleapis.com)."]},
     {
       "condition": "Deny risky services",
-      "attribute_path": ["list_policy",0,"deny",0,"values",0],
+      "attribute_path": ["list_policy",0,"deny",0,"values"],
       "values": ["cloudresourcemanager.googleapis.com"],
       "policy_type": "blacklist"
     }

--- a/policies/gcp/Cloud Platform/google_organization_iam_custom_role/stage.rego
+++ b/policies/gcp/Cloud Platform/google_organization_iam_custom_role/stage.rego
@@ -9,7 +9,7 @@ conditions := [
    "remedies": ["Remove admin-level permissions such as iam.roles.delete or resourcemanager.*"]},
   {
     "condition": "Blacklist risky permissions",
-    "attribute_path": ["permissions",0],
+    "attribute_path": ["permissions"],
     "values": ["iam.roles.delete", "resourcemanager.*"],
     "policy_type": "blacklist"
   }

--- a/policies/gcp/Cloud Run (v2 API)/google_cloud_run_v2_job/template.template.encryption_key.rego
+++ b/policies/gcp/Cloud Run (v2 API)/google_cloud_run_v2_job/template.template.encryption_key.rego
@@ -9,7 +9,7 @@ conditions := [
     {
         "condition": "Ensure the encryption key is from an approved KMS key ring and location",
         "attribute_path" : ["template",0,"template",0,"encryption_key"], 
-        "values" : ["projects/my-project/locations/*/keyRings/*/cryptoKeys/*", [["australia-southeast1","australia-southeast2"],["run-keys"],["job-key"]]], 
+        "values" : ["projects/*/locations/*/keyRings/*/cryptoKeys/*", [["my-project"],["australia-southeast1","australia-southeast2"],["run-keys"],["job-key"]]], 
         "policy_type" : "pattern whitelist" 
     }
     ]

--- a/policies/gcp/Cloud Run (v2 API)/google_cloud_run_v2_service/template.encryption_key.rego
+++ b/policies/gcp/Cloud Run (v2 API)/google_cloud_run_v2_service/template.encryption_key.rego
@@ -9,7 +9,7 @@ conditions := [
     {
         "condition": "Ensure the encryption key is from an approved KMS key ring and location",
         "attribute_path" : ["template",0,"encryption_key"], 
-        "values" : ["projects/my-project/locations/*/keyRings/*/cryptoKeys/*", [["australia-southeast1","australia-southeast2"],["my-keyring"],["my-key"]]], 
+        "values" : ["projects/*/locations/*/keyRings/*/cryptoKeys/*", [["my-project"],["australia-southeast1","australia-southeast2"],["my-keyring"],["my-key"]]], 
         "policy_type" : "pattern whitelist" 
     }
     ]

--- a/policies/gcp/Cloud Run (v2 API)/google_cloud_run_v2_worker_pool/template.encryption_key.rego
+++ b/policies/gcp/Cloud Run (v2 API)/google_cloud_run_v2_worker_pool/template.encryption_key.rego
@@ -9,7 +9,7 @@ conditions := [
     {
         "condition": "Ensure the encryption key is from an approved KMS key ring and location",
         "attribute_path" : ["template",0,"encryption_key"], 
-        "values" : ["projects/my-project/locations/*/keyRings/*/cryptoKeys/*", [["australia-southeast1","australia-southeast2"],["my-keyring"],["my-key"]]], 
+        "values" : ["projects/*/locations/*/keyRings/*/cryptoKeys/*", [["my-project"],["australia-southeast1","australia-southeast2"],["my-keyring"],["my-key"]]], 
         "policy_type" : "pattern whitelist" 
     }
     ]

--- a/policies/gcp/Cloud Run/google_cloud_run_service/template.metadata.annotations.rego
+++ b/policies/gcp/Cloud Run/google_cloud_run_service/template.metadata.annotations.rego
@@ -86,9 +86,10 @@ conditions := [
       "condition": "Encryption key annotation must match the approved KMS key path",
       "attribute_path": ["template", 0, "metadata", 0, "annotations", "run.googleapis.com/encryption-key"],
       "values": [
-        "projects/my-gcp-project/locations/australia-southeast1/keyRings/prod-keyring/cryptoKeys/cloudrun-key"
+        "projects/*/locations/*/keyRings/*/cryptoKeys/*",
+        [["my-gcp-project"], ["australia-southeast1"], ["prod-keyring"], ["cloudrun-key"]]
       ],
-      "policy_type": "whitelist"
+      "policy_type": "pattern whitelist"
     }
   ],
   [
@@ -103,9 +104,10 @@ conditions := [
       "condition": "VPC access connector annotation must use an approved connector",
       "attribute_path": ["template", 0, "metadata", 0, "annotations", "run.googleapis.com/vpc-access-connector"],
       "values": [
-        "projects/my-gcp-project/locations/australia-southeast1/connectors/prod-vpc-connector"
+        "projects/*/locations/*/connectors/*",
+        [["my-gcp-project"], ["australia-southeast1"], ["prod-vpc-connector"]]
       ],
-      "policy_type": "whitelist"
+      "policy_type": "pattern whitelist"
     }
   ],
   [

--- a/policies/gcp/Cloud Run/google_cloud_run_service/template.spec.service_account_name.rego
+++ b/policies/gcp/Cloud Run/google_cloud_run_service/template.spec.service_account_name.rego
@@ -15,8 +15,26 @@ conditions := [
     {
       "condition": "Service account must be approved",
       "attribute_path": ["template", 0, "spec", 0, "service_account_name"],
-      "values": ["secure-sa@my-gcp-project.iam.gserviceaccount.com"],
-      "policy_type": "whitelist"
+      "values": ["*@*", [["secure-sa"], ["my-gcp-project.iam.gserviceaccount.com"]]],
+      "policy_type": "pattern whitelist"
+    }
+  ],
+  [
+    {
+      "situation_description": "Cloud Run service runs as the Compute Engine default service account",
+      "remedies": [
+        "Create a dedicated least-privilege service account for this service",
+        "Set service_account_name to that account instead of leaving it unset"
+      ]
+    },
+    {
+      # The pattern whitelist above can only judge a value that looks like an
+      # email address, so "default" -- the runtime's own fallback -- has to be
+      # named here or nothing catches it.
+      "condition": "Service account must not be the runtime default",
+      "attribute_path": ["template", 0, "spec", 0, "service_account_name"],
+      "values": ["default"],
+      "policy_type": "blacklist"
     }
   ]
 ]

--- a/policies/gcp/Cloud Run/google_cloud_run_service_iam_policy/policy_data.rego
+++ b/policies/gcp/Cloud Run/google_cloud_run_service_iam_policy/policy_data.rego
@@ -4,6 +4,12 @@ import data.terraform.helpers
 import data.terraform.gcp.security.cloud_run.google_cloud_run_service_iam_policy.vars
 
 # Merged policy for `policy_data` — 3 independent scenarios.
+# policy_lint reports hard-coded-value on the address inside the JSON below, and
+# the finding stands. policy_data is compared as a whole rendered IAM policy
+# document; a pattern target is used as a regex, and a JSON document's { [ ] "
+# characters are regex metacharacters, while roles/... contains a "/" that the
+# "*" wildcard ([^/]+) cannot cross. The address is part of the document being
+# matched, so a wildcard cannot replace it without the match failing.
 conditions := [
 [
     {

--- a/policies/gcp/Cloud Scheduler/google_cloud_scheduler_job/_vars.rego
+++ b/policies/gcp/Cloud Scheduler/google_cloud_scheduler_job/_vars.rego
@@ -1,7 +1,7 @@
 package terraform.gcp.security.cloud_scheduler.google_cloud_scheduler_job.vars
 
 variables := {
-    "friendly_resource_name": "google_cloud_scheduler_job", 
+    "friendly_resource_name": "Cloud Scheduler Job", 
     "resource_type":  "google_cloud_scheduler_job",  
     "resource_value_name" : "name" 
 }

--- a/policies/gcp/Cloud Source Repositories/google_sourcerepo_repository/_vars.rego
+++ b/policies/gcp/Cloud Source Repositories/google_sourcerepo_repository/_vars.rego
@@ -1,7 +1,7 @@
 package terraform.gcp.security.cloud_source_repositories.google_sourcerepo_repository.vars
 
 variables := {
-	"friendly_resource_name": "google_sourcerepo",
+	"friendly_resource_name": "Cloud Source Repository",
 	"resource_type": "google_sourcerepo_repository",
 	"resource_value_name": "name",
 }

--- a/policies/gcp/Cloud Source Repositories/google_sourcerepo_repository/pubsub_configs.service_account_email.rego
+++ b/policies/gcp/Cloud Source Repositories/google_sourcerepo_repository/pubsub_configs.service_account_email.rego
@@ -3,6 +3,13 @@ package terraform.gcp.security.cloud_source_repositories.google_sourcerepo_repos
 import data.terraform.helpers
 import data.terraform.gcp.security.cloud_source_repositories.google_sourcerepo_repository.vars
 
+# policy_lint reports hard-coded-value on the address(es) below, and the finding
+# stands. This attribute is a LIST, and the pattern policy types read the value as
+# a single string (shared.get_target_list regex-matches it), so pointing one at an
+# array makes it undefined -- which reads as "no violation", not as an error, and
+# the non-compliant example would silently stop being flagged. There is no
+# "element whitelist" type in policies/_helpers to check every element of a list
+# against an allowed pattern; adding one is what would unblock this.
 conditions := [[
 	{
 		"situation_description": "The service_account_email does not have a dedicated service account email provided.",

--- a/policies/gcp/Cloud Source Repositories/google_sourcerepo_repository_iam_member/_vars.rego
+++ b/policies/gcp/Cloud Source Repositories/google_sourcerepo_repository_iam_member/_vars.rego
@@ -1,7 +1,7 @@
 package terraform.gcp.security.cloud_source_repositories.google_sourcerepo_repository_iam_member.vars
 
 variables := {
-	"friendly_resource_name": "google_sourcerepo",
+	"friendly_resource_name": "Cloud Source Repository IAM Member",
 	"resource_type": "google_sourcerepo_repository_iam_member",
 	"resource_value_name": "name",
 }

--- a/policies/gcp/Cloud Storage/google_storage_bucket/ip_filter.public_network_source.allowed_ip_cidr_ranges.rego
+++ b/policies/gcp/Cloud Storage/google_storage_bucket/ip_filter.public_network_source.allowed_ip_cidr_ranges.rego
@@ -11,7 +11,7 @@ conditions := [
         },
         {
             "condition": "Check if all ips are allowed.",
-            "attribute_path": ["ip_filter",0,"public_network_source",0,"allowed_ip_cidr_ranges",0],
+            "attribute_path": ["ip_filter",0,"public_network_source",0,"allowed_ip_cidr_ranges"],
             "values": ["0.0.0.0/0"],
             "policy_type": "blacklist"
         }

--- a/policies/gcp/Cloud Storage/google_storage_bucket_acl/role_entity.rego
+++ b/policies/gcp/Cloud Storage/google_storage_bucket_acl/role_entity.rego
@@ -14,7 +14,7 @@ conditions := [
     },
     {
       "condition": "Disallow OWNER or WRITER roles for wildcard entities",
-      "attribute_path": ["role_entity",0],
+      "attribute_path": ["role_entity"],
       "policy_type": "blacklist",
       "values": [
         "OWNER:allUsers",

--- a/policies/gcp/Cloud Storage/google_storage_bucket_iam_binding/members.rego
+++ b/policies/gcp/Cloud Storage/google_storage_bucket_iam_binding/members.rego
@@ -14,7 +14,7 @@ conditions := [
 
     {
       "condition": "Public access should be prohibited.",
-      "attribute_path": ["members",0],
+      "attribute_path": ["members"],
       "values": ["allUsers","allAuthenticatedUsers"],
       "policy_type": "blacklist"
     }

--- a/policies/gcp/Cloud Storage/google_storage_default_object_acl/role_entity.rego
+++ b/policies/gcp/Cloud Storage/google_storage_default_object_acl/role_entity.rego
@@ -14,9 +14,12 @@ conditions := [
 
     {
       "condition": "Public access to objects should be prohibited.",
-      "attribute_path": ["role_entity",0],
-      "values": ["*:*",[[],["allUsers","allAuthenticatedUsers"]]],
-      "policy_type": "pattern blacklist"
+      # Every entry in role_entity, not just the first. "element blacklist"
+      # matches by substring, so it catches the public entity in any
+      # "<ROLE>:<entity>" pair without having to enumerate the roles.
+      "attribute_path": ["role_entity"],
+      "values": ["allUsers","allAuthenticatedUsers"],
+      "policy_type": "element blacklist"
     }
   ]
 ]

--- a/policies/gcp/Cloud Storage/google_storage_managed_folder_iam_binding/members.rego
+++ b/policies/gcp/Cloud Storage/google_storage_managed_folder_iam_binding/members.rego
@@ -14,7 +14,7 @@ conditions := [
 
     {
       "condition": "Public access should be prohibited.",
-      "attribute_path": ["members",0],
+      "attribute_path": ["members"],
       "values": ["allUsers","allAuthenticatedUsers"],
       "policy_type": "blacklist"
     }

--- a/policies/gcp/Cloud Storage/google_storage_object_acl/role_entity.rego
+++ b/policies/gcp/Cloud Storage/google_storage_object_acl/role_entity.rego
@@ -14,9 +14,12 @@ conditions := [
 
     {
       "condition": "Public access to objects should be prohibited.",
-      "attribute_path": ["role_entity",0],
-      "values": ["*:*",[[],["allUsers","allAuthenticatedUsers"]]],
-      "policy_type": "pattern blacklist"
+      # Every entry in role_entity, not just the first. "element blacklist"
+      # matches by substring, so it catches the public entity in any
+      # "<ROLE>:<entity>" pair without having to enumerate the roles.
+      "attribute_path": ["role_entity"],
+      "values": ["allUsers","allAuthenticatedUsers"],
+      "policy_type": "element blacklist"
     }
   ]
 ]

--- a/policies/gcp/Cloud Workstations/google_workstations_workstation_config_iam_policy/policy_data.rego
+++ b/policies/gcp/Cloud Workstations/google_workstations_workstation_config_iam_policy/policy_data.rego
@@ -4,6 +4,12 @@ import data.terraform.helpers
 import data.terraform.gcp.security.cloud_workstations.google_workstations_workstation_config_iam_policy.vars
 
 # Merged policy for `policy_data` — 2 independent scenarios.
+# policy_lint reports hard-coded-value on the address inside the JSON below, and
+# the finding stands. policy_data is compared as a whole rendered IAM policy
+# document; a pattern target is used as a regex, and a JSON document's { [ ] "
+# characters are regex metacharacters, while roles/... contains a "/" that the
+# "*" wildcard ([^/]+) cannot cross. The address is part of the document being
+# matched, so a wildcard cannot replace it without the match failing.
 conditions := [
 [
     {"situation_description" : "policy_data grants access to broad IAM principals ",

--- a/policies/gcp/ContainerAttached/google_container_attached_cluster/authorization.admin_groups.rego
+++ b/policies/gcp/ContainerAttached/google_container_attached_cluster/authorization.admin_groups.rego
@@ -3,6 +3,13 @@ package terraform.gcp.security.container_attached.google_container_attached_clus
 import data.terraform.helpers
 import data.terraform.gcp.security.container_attached.google_container_attached_cluster.vars
 
+# policy_lint reports hard-coded-value on the address(es) below, and the finding
+# stands. This attribute is a LIST, and the pattern policy types read the value as
+# a single string (shared.get_target_list regex-matches it), so pointing one at an
+# array makes it undefined -- which reads as "no violation", not as an error, and
+# the non-compliant example would silently stop being flagged. There is no
+# "element whitelist" type in policies/_helpers to check every element of a list
+# against an allowed pattern; adding one is what would unblock this.
 conditions := [
     [
         {

--- a/policies/gcp/ContainerAws/google_container_aws_cluster/authorization.admin_groups.group.rego
+++ b/policies/gcp/ContainerAws/google_container_aws_cluster/authorization.admin_groups.group.rego
@@ -11,8 +11,8 @@ conditions := [[
   {
     "condition": "admin_groups group must use an approved organisation-managed email address",
     "attribute_path": ["authorization", 0, "admin_groups", 0, "group"],
-    "values": ["group@deakin.edu.au"],
-    "policy_type": "whitelist",
+    "values": ["*@*", [["group"], ["deakin.edu.au"]]],
+    "policy_type": "pattern whitelist",
   },
 ]]
 

--- a/policies/gcp/ContainerAws/google_container_aws_cluster/authorization.admin_users.username.rego
+++ b/policies/gcp/ContainerAws/google_container_aws_cluster/authorization.admin_users.username.rego
@@ -11,8 +11,8 @@ conditions := [[
   {
     "condition": "admin_users username must use an approved organisation-managed email address",
     "attribute_path": ["authorization", 0, "admin_users", 0, "username"],
-    "values": ["user@deakin.edu.au"],
-    "policy_type": "whitelist",
+    "values": ["*@*", [["user"], ["deakin.edu.au"]]],
+    "policy_type": "pattern whitelist",
   },
 ]]
 

--- a/policies/gcp/DataPipeline/google_data_pipeline_pipeline/_vars.rego
+++ b/policies/gcp/DataPipeline/google_data_pipeline_pipeline/_vars.rego
@@ -1,7 +1,7 @@
 package terraform.gcp.security.data_pipeline.google_data_pipeline_pipeline.vars
 
 variables := {
-	"friendly_resource_name": "google_data_pipeline_pipeline",
+	"friendly_resource_name": "Data Pipeline",
 	"resource_type": "google_data_pipeline_pipeline",
 	"resource_value_name": "name",
 }

--- a/policies/gcp/DatabaseMigrationService/google_database_migration_service_connection_profile/cloudsql.settings.ip_config.private_network.rego
+++ b/policies/gcp/DatabaseMigrationService/google_database_migration_service_connection_profile/cloudsql.settings.ip_config.private_network.rego
@@ -2,6 +2,12 @@ package terraform.gcp.security.database_migration_service.google_database_migrat
 import data.terraform.helpers
 import data.terraform.gcp.security.database_migration_service.google_database_migration_service_connection_profile.vars
 
+# policy_lint reports hard-coded-value on the value below, and the finding stands.
+# A pattern whitelist only judges values that MATCH its target: one that does not
+# match the shape is never flagged at all. This argument's non-compliant example
+# is the attribute left unset, so converting would make the fixture pass for the wrong
+# reason. Either _helpers needs a pattern whitelist that fails a non-matching
+# value, or the fixture needs a wrongly-scoped (not malformed) example.
 conditions := [
     [
     {

--- a/policies/gcp/Dataproc Metastore/google_dataproc_metastore_federation/backend_metastores.name.rego
+++ b/policies/gcp/Dataproc Metastore/google_dataproc_metastore_federation/backend_metastores.name.rego
@@ -13,8 +13,11 @@ conditions := [
     {
       "condition": "Test version of Apache Hive metastore",
       "attribute_path": ["backend_metastores", 0, "name"],
-      "values": ["projects/acme-data-01/locations/australia-southeast1/services/test", "projects/acme-data-01/locations/australia-southeast2/services/test"],
-      "policy_type": "whitelist"
+      "values": [
+        "projects/*/locations/*/services/*",
+        [["acme-data-01"], ["australia-southeast1", "australia-southeast2"], ["test"]]
+      ],
+      "policy_type": "pattern whitelist"
     }
   ]
 ]

--- a/policies/gcp/Discovery Engine/google_discovery_engine_cmek_config/single_region_keys.kms_key.rego
+++ b/policies/gcp/Discovery Engine/google_discovery_engine_cmek_config/single_region_keys.kms_key.rego
@@ -6,6 +6,12 @@ import data.terraform.gcp.security.discovery_engine.google_discovery_engine_cmek
 
 #Pattern whitelist wouldnt work, too many arguments
 
+# policy_lint reports hard-coded-value on the value below, and the finding stands.
+# A pattern whitelist only judges values that MATCH its target: one that does not
+# match the shape is never flagged at all. This argument's non-compliant example
+# is the empty string, so converting would make the fixture pass for the wrong
+# reason. Either _helpers needs a pattern whitelist that fails a non-matching
+# value, or the fixture needs a wrongly-scoped (not malformed) example.
 conditions := [
     [
     {

--- a/policies/gcp/Discovery Engine/google_discovery_engine_data_connector/_vars.rego
+++ b/policies/gcp/Discovery Engine/google_discovery_engine_data_connector/_vars.rego
@@ -3,7 +3,7 @@ package terraform.gcp.security.discovery_engine.google_discovery_engine_data_con
 #This is for the data_connector
 
 variables := {
-    "friendly_resource_name": "google_discovery_engine_data_connector",
+    "friendly_resource_name": "Discovery Engine Data Connector",
     "resource_type":  "google_discovery_engine_data_connector",
     "resource_value_name" : "collection_id"
 }

--- a/policies/gcp/GKEHub/google_gke_hub_feature_iam_binding/members.rego
+++ b/policies/gcp/GKEHub/google_gke_hub_feature_iam_binding/members.rego
@@ -8,14 +8,8 @@ conditions := [[
     "remedies": ["Remove any public principals,use org service accounts"]
   },
   {
-    "condition": "members[0] must NOT be public",
-    "attribute_path": ["members", 0],
-    "values": ["allUsers","allAuthenticatedUsers"],
-    "policy_type": "blacklist"
-  },
-  {
-    "condition": "members[1] must NOT be public",
-    "attribute_path": ["members", 1],
+    "condition": "no member may be public",
+    "attribute_path": ["members"],
     "values": ["allUsers","allAuthenticatedUsers"],
     "policy_type": "blacklist"
   }

--- a/policies/gcp/GKEHub/google_gke_hub_membership/_vars.rego
+++ b/policies/gcp/GKEHub/google_gke_hub_membership/_vars.rego
@@ -1,7 +1,7 @@
 package terraform.gcp.security.gke_hub.google_gke_hub_membership.vars
 
 variables := {
-  "friendly_resource_name": "GKE Hub Feature Membership",
+  "friendly_resource_name": "GKE Hub Membership",
   "resource_type": "google_gke_hub_membership",
   "resource_value_name": "membership_id"
 }

--- a/policies/gcp/GKEHub/google_gke_hub_scope_iam_binding/members.rego
+++ b/policies/gcp/GKEHub/google_gke_hub_scope_iam_binding/members.rego
@@ -9,8 +9,8 @@ conditions := [
       "remedies": ["Remove public/broad principals like allUsers/allAuthenticatedUsers/project*"]
     },
     {
-      "condition": "members[0] must NOT be public/broad",
-      "attribute_path": ["members", 0],
+      "condition": "no member may be public/broad",
+      "attribute_path": ["members"],
       "values": ["allUsers", "allAuthenticatedUsers"],
       "policy_type": "blacklist"
     }

--- a/policies/gcp/Google Cloud NetApp Volumes/google_netapp_active_directory/_vars.rego
+++ b/policies/gcp/Google Cloud NetApp Volumes/google_netapp_active_directory/_vars.rego
@@ -2,7 +2,7 @@ package terraform.gcp.security.google_cloud_netapp_volumes.google_netapp_active_
 
 
 variables := {
-    "friendly_resource_name": "netapps_volumes", 
+    "friendly_resource_name": "NetApp Active Directory", 
     "resource_type":  "google_netapp_active_directory",
     "resource_value_name" : "name" 
 }

--- a/policies/gcp/Google Cloud NetApp Volumes/google_netapp_backup/_vars.rego
+++ b/policies/gcp/Google Cloud NetApp Volumes/google_netapp_backup/_vars.rego
@@ -2,7 +2,7 @@ package terraform.gcp.security.google_cloud_netapp_volumes.google_netapp_backup.
 
 
 variables := {
-    "friendly_resource_name": "netapps_volumes", 
+    "friendly_resource_name": "NetApp Backup", 
     "resource_type":  "google_netapp_backup",
     "resource_value_name" : "name" 
 }

--- a/policies/gcp/Google Cloud NetApp Volumes/google_netapp_backup/source_volume.rego
+++ b/policies/gcp/Google Cloud NetApp Volumes/google_netapp_backup/source_volume.rego
@@ -3,6 +3,12 @@ package terraform.gcp.security.google_cloud_netapp_volumes.google_netapp_backup.
 import data.terraform.helpers
 import data.terraform.gcp.security.google_cloud_netapp_volumes.google_netapp_backup.vars
 
+# policy_lint reports hard-coded-value on the value below, and the finding stands.
+# A pattern whitelist only judges values that MATCH its target: one that does not
+# match the shape is never flagged at all. This argument's non-compliant example
+# is the empty string, so converting would make the fixture pass for the wrong
+# reason. Either _helpers needs a pattern whitelist that fails a non-matching
+# value, or the fixture needs a wrongly-scoped (not malformed) example.
 conditions := [
   [
     {

--- a/policies/gcp/Google Cloud NetApp Volumes/google_netapp_backup_policy/_vars.rego
+++ b/policies/gcp/Google Cloud NetApp Volumes/google_netapp_backup_policy/_vars.rego
@@ -2,7 +2,7 @@ package terraform.gcp.security.google_cloud_netapp_volumes.google_netapp_backup_
 
 
 variables := {
-    "friendly_resource_name": "netapps_volumes", 
+    "friendly_resource_name": "NetApp Backup Policy", 
     "resource_type":  "google_netapp_backup_policy",
     "resource_value_name" : "name" 
 }

--- a/policies/gcp/Google Cloud NetApp Volumes/google_netapp_backup_vault/_vars.rego
+++ b/policies/gcp/Google Cloud NetApp Volumes/google_netapp_backup_vault/_vars.rego
@@ -2,7 +2,7 @@ package terraform.gcp.security.google_cloud_netapp_volumes.google_netapp_backup_
 
 
 variables := {
-    "friendly_resource_name": "netapps_volumes", 
+    "friendly_resource_name": "NetApp Backup Vault", 
     "resource_type":  "google_netapp_backup_vault",
     "resource_value_name" : "name" 
 }

--- a/policies/gcp/Google Cloud NetApp Volumes/google_netapp_kmsconfig/_vars.rego
+++ b/policies/gcp/Google Cloud NetApp Volumes/google_netapp_kmsconfig/_vars.rego
@@ -2,7 +2,7 @@ package terraform.gcp.security.google_cloud_netapp_volumes.google_netapp_kmsconf
 
 
 variables := {
-    "friendly_resource_name": "netapps_volumes", 
+    "friendly_resource_name": "NetApp KMS Config", 
     "resource_type":  "google_netapp_kmsconfig",
     "resource_value_name" : "name" 
 }

--- a/policies/gcp/Google Cloud NetApp Volumes/google_netapp_kmsconfig/crypto_key_name.rego
+++ b/policies/gcp/Google Cloud NetApp Volumes/google_netapp_kmsconfig/crypto_key_name.rego
@@ -15,10 +15,15 @@ conditions := [
       "condition": "crypto_key_name equals an approved key",
       "attribute_path": ["crypto_key_name"],
       "values": [
-        "projects/deakin-lab-123/locations/australia-southeast1/keyRings/netapp-kr/cryptoKeys/netapp-cmek",
-        "projects/deakin-lab-123/locations/australia-southeast2/keyRings/netapp-kr/cryptoKeys/netapp-cmek"
+        "projects/*/locations/*/keyRings/*/cryptoKeys/*",
+        [
+          ["deakin-lab-123"],
+          ["australia-southeast1", "australia-southeast2"],
+          ["netapp-kr"],
+          ["netapp-cmek"]
+        ]
       ],
-      "policy_type": "whitelist"
+      "policy_type": "pattern whitelist"
     }
   ]
 ]

--- a/policies/gcp/Google Cloud NetApp Volumes/google_netapp_storage_pool/_vars.rego
+++ b/policies/gcp/Google Cloud NetApp Volumes/google_netapp_storage_pool/_vars.rego
@@ -2,7 +2,7 @@ package terraform.gcp.security.google_cloud_netapp_volumes.google_netapp_storage
 
 
 variables := {
-    "friendly_resource_name": "netapps_volumes", 
+    "friendly_resource_name": "NetApp Storage Pool", 
     "resource_type":  "google_netapp_storage_pool",
     "resource_value_name" : "name" 
 }

--- a/policies/gcp/Google Cloud NetApp Volumes/google_netapp_storage_pool/network.rego
+++ b/policies/gcp/Google Cloud NetApp Volumes/google_netapp_storage_pool/network.rego
@@ -15,10 +15,10 @@ conditions := [
       "condition": "network equals an approved VPC",
       "attribute_path": ["network"],
       "values": [
-        "projects/deakin-lab-123/global/networks/nondefault-vpc",
-        "projects/deakin-lab-123/global/networks/prod-vpc"
+        "projects/*/global/networks/*",
+        [["deakin-lab-123"], ["nondefault-vpc", "prod-vpc"]]
       ],
-      "policy_type": "whitelist"
+      "policy_type": "pattern whitelist"
     }
   ]
 ]

--- a/policies/gcp/Google Cloud NetApp Volumes/google_netapp_volume/_vars.rego
+++ b/policies/gcp/Google Cloud NetApp Volumes/google_netapp_volume/_vars.rego
@@ -2,7 +2,7 @@ package terraform.gcp.security.google_cloud_netapp_volumes.google_netapp_volume.
 
 
 variables := {
-    "friendly_resource_name": "netapps_volumes", 
+    "friendly_resource_name": "NetApp Volume", 
     "resource_type":  "google_netapp_volume",
     "resource_value_name" : "name" 
 }

--- a/policies/gcp/Google Cloud NetApp Volumes/google_netapp_volume/protocols.rego
+++ b/policies/gcp/Google Cloud NetApp Volumes/google_netapp_volume/protocols.rego
@@ -9,7 +9,7 @@ conditions := [
          "remedies":[ "Remove NFSv3 or SMB from the list"]},
         {
         "condition": "protocols must not include NFSv3 or SMB",
-        "attribute_path" : ["protocols", 0], 
+        "attribute_path" : ["protocols"], 
         "values" : ["NFSV3", "SMB"], 
         "policy_type" : "blacklist" 
         }

--- a/policies/gcp/Google Cloud NetApp Volumes/google_netapp_volume_quota_rule/_vars.rego
+++ b/policies/gcp/Google Cloud NetApp Volumes/google_netapp_volume_quota_rule/_vars.rego
@@ -2,7 +2,7 @@ package terraform.gcp.security.google_cloud_netapp_volumes.google_netapp_volume_
 
 
 variables := {
-    "friendly_resource_name": "netapps_volumes", 
+    "friendly_resource_name": "NetApp Volume Quota Rule", 
     "resource_type":  "google_netapp_volume_quota_rule",
     "resource_value_name" : "name" 
 }

--- a/policies/gcp/Google Cloud NetApp Volumes/google_netapp_volume_replication/_vars.rego
+++ b/policies/gcp/Google Cloud NetApp Volumes/google_netapp_volume_replication/_vars.rego
@@ -2,7 +2,7 @@ package terraform.gcp.security.google_cloud_netapp_volumes.google_netapp_volume_
 
 
 variables := {
-    "friendly_resource_name": "netapps_volumes", 
+    "friendly_resource_name": "NetApp Volume Replication", 
     "resource_type":  "google_netapp_volume_replication",
     "resource_value_name" : "name" 
 }

--- a/policies/gcp/Google Cloud NetApp Volumes/google_netapp_volume_snapshot/_vars.rego
+++ b/policies/gcp/Google Cloud NetApp Volumes/google_netapp_volume_snapshot/_vars.rego
@@ -2,7 +2,7 @@ package terraform.gcp.security.google_cloud_netapp_volumes.google_netapp_volume_
 
 
 variables := {
-    "friendly_resource_name": "netapps_volumes", 
+    "friendly_resource_name": "NetApp Volume Snapshot", 
     "resource_type":  "google_netapp_volume_snapshot",
     "resource_value_name" : "name" 
 }

--- a/policies/gcp/Identity-Aware Proxy/google_iap_app_engine_service_iam_member/member.rego
+++ b/policies/gcp/Identity-Aware Proxy/google_iap_app_engine_service_iam_member/member.rego
@@ -48,8 +48,8 @@ conditions := [
     {
       "condition": "member must use allowed prefix",
       "attribute_path": ["member"],
-      "values": ["users:jane@example.com"],
-      "policy_type": "blacklist"
+      "values": ["*:*@*", [["users"], [], []]],
+      "policy_type": "pattern blacklist"
     }
   ],
 
@@ -64,8 +64,8 @@ conditions := [
     {
       "condition": "member must not contain whitespace",
       "attribute_path": ["member"],
-      "values": [" user:jane@example.com "],
-      "policy_type": "blacklist"
+      "values": ["*:*@*", [[" user"], [], []]],
+      "policy_type": "pattern blacklist"
     }
   ],
 
@@ -80,8 +80,8 @@ conditions := [
     {
       "condition": "member must be a corporate email",
       "attribute_path": ["member"],
-      "values": ["user:jane@gmail.com"],
-      "policy_type": "blacklist"
+      "values": ["*:*@*", [[], [], ["gmail.com"]]],
+      "policy_type": "pattern blacklist"
     }
   ],
 

--- a/policies/gcp/Identity-Aware Proxy/google_iap_app_engine_service_iam_member/role.rego
+++ b/policies/gcp/Identity-Aware Proxy/google_iap_app_engine_service_iam_member/role.rego
@@ -40,10 +40,25 @@ conditions := [
         "roles/editor",
         "roles/viewer",
         "roles/iap.admin",
-        "roles/run.invoker",
-        "projects/my-gcp-project/roles/CustomBroadRole"
+        "roles/run.invoker"
       ],
       "policy_type": "blacklist"
+    }
+  ],
+
+  # 3) The same broad custom role, in whichever project it was defined
+  [
+    {
+      "situation_description": "Broad custom project roles are not allowed on IAP",
+      "remedies": [
+        "Replace with roles/iap.httpsResourceAccessor"
+      ]
+    },
+    {
+      "condition": "role must not be a broad custom project role",
+      "attribute_path": ["role"],
+      "values": ["projects/*/roles/*", [[], ["CustomBroadRole"]]],
+      "policy_type": "pattern blacklist"
     }
   ]
 ]

--- a/policies/gcp/Identity-Aware Proxy/google_iap_brand/support_email.rego
+++ b/policies/gcp/Identity-Aware Proxy/google_iap_brand/support_email.rego
@@ -18,8 +18,8 @@ conditions := [
     {
       "condition": "support_email must be corporate",
       "attribute_path": ["support_email"],
-      "values": ["support@example.com"],
-      "policy_type": "whitelist"
+      "values": ["*@*", [["support"], ["example.com"]]],
+      "policy_type": "pattern whitelist"
     }
   ],
   [
@@ -32,8 +32,10 @@ conditions := [
     {
       "condition": "support_email must not be public/external/malformed",
       "attribute_path": ["support_email"],
-      "values": ["support@gmail.com", "help@vendor.io", "support@example.com "],
-      "policy_type": "blacklist"
+      # By domain, not by address: the trailing space is the "example.com "
+      # entry, which is how the whitespace case is caught.
+      "values": ["*@*", [[], ["gmail.com", "vendor.io", "example.com "]]],
+      "policy_type": "pattern blacklist"
     }
   ]
 ]

--- a/policies/gcp/Model Armor/google_model_armor_floorsetting/filter_config.malicious_uri_filter_settings.filter_enforcement.rego
+++ b/policies/gcp/Model Armor/google_model_armor_floorsetting/filter_config.malicious_uri_filter_settings.filter_enforcement.rego
@@ -12,7 +12,7 @@ conditions := [
     },
     {
       "condition": "filter_config must not be completely empty",
-      "attribute_path": ["filter_config",0],
+      "attribute_path": ["filter_config"],
       "values": [
         {"malicious_uri_filter_settings":[],"pi_and_jailbreak_filter_settings":[],"rai_settings":[],"sdp_settings":[]}
       ],

--- a/policies/gcp/Model Armor/google_model_armor_template/filter_config.malicious_uri_filter_settings.filter_enforcement.rego
+++ b/policies/gcp/Model Armor/google_model_armor_template/filter_config.malicious_uri_filter_settings.filter_enforcement.rego
@@ -12,7 +12,7 @@ conditions := [
     },
     {
       "condition": "When create the model armor template filter_config must not be completely empty",
-      "attribute_path": ["filter_config",0],
+      "attribute_path": ["filter_config"],
       "values": [
         {"malicious_uri_filter_settings":[],"pi_and_jailbreak_filter_settings":[],"rai_settings":[],"sdp_settings":[]}
       ],

--- a/policies/gcp/Privileged Access Manager/google_privileged_access_manager_entitlement/eligible_users.principals.rego
+++ b/policies/gcp/Privileged Access Manager/google_privileged_access_manager_entitlement/eligible_users.principals.rego
@@ -3,6 +3,13 @@ package terraform.gcp.security.privileged_access_manager.google_privileged_acces
 import data.terraform.helpers
 import data.terraform.gcp.security.privileged_access_manager.google_privileged_access_manager_entitlement.vars
 
+# policy_lint reports hard-coded-value on the address(es) below, and the finding
+# stands. This attribute is a LIST, and the pattern policy types read the value as
+# a single string (shared.get_target_list regex-matches it), so pointing one at an
+# array makes it undefined -- which reads as "no violation", not as an error, and
+# the non-compliant example would silently stop being flagged. There is no
+# "element whitelist" type in policies/_helpers to check every element of a list
+# against an allowed pattern; adding one is what would unblock this.
 conditions := [
     [
         {

--- a/policies/gcp/Security Command Center (SCC)/google_scc_notification_config/organization.rego
+++ b/policies/gcp/Security Command Center (SCC)/google_scc_notification_config/organization.rego
@@ -12,8 +12,8 @@ conditions := [
     {
       "condition": "Organization allowlist.",
       "attribute_path": ["organization"],
-      "values": ["organizations/123456789012"],
-      "policy_type": "whitelist"
+      "values": ["organizations/*", [["123456789012"]]],
+      "policy_type": "pattern whitelist"
     }
   ]
 ]

--- a/policies/gcp/Security Command Center (SCC)/google_scc_notification_config/pubsub_topic.rego
+++ b/policies/gcp/Security Command Center (SCC)/google_scc_notification_config/pubsub_topic.rego
@@ -16,10 +16,10 @@ conditions := [
       "condition": "Pub/Sub topic must be from the allowlist.",
       "attribute_path": ["pubsub_topic"],
       "values": [
-        "projects/security-core/topics/scc-findings",
-        "projects/sec-ops/topics/scc-high"
+        "projects/*/topics/*",
+        [["security-core", "sec-ops"], ["scc-findings", "scc-high"]]
       ],
-      "policy_type": "whitelist"
+      "policy_type": "pattern whitelist"
     }
   ]
 ]

--- a/policies/gcp/Security Command Center (SCC)/google_scc_organization_scc_big_query_export/dataset.rego
+++ b/policies/gcp/Security Command Center (SCC)/google_scc_organization_scc_big_query_export/dataset.rego
@@ -3,6 +3,12 @@ package terraform.gcp.security.scc.google_scc_organization_scc_big_query_export.
 import data.terraform.helpers
 import data.terraform.gcp.security.scc.google_scc_organization_scc_big_query_export.vars
 
+# policy_lint reports hard-coded-value on the value below, and the finding stands.
+# A pattern whitelist only judges values that MATCH its target: one that does not
+# match the shape is never flagged at all. This argument's non-compliant example
+# is a bare name with no "projects/.../datasets/" path, so converting would make the fixture pass for the wrong
+# reason. Either _helpers needs a pattern whitelist that fails a non-matching
+# value, or the fixture needs a wrongly-scoped (not malformed) example.
 conditions := [
   [
     {

--- a/policies/gcp/Security Command Center (SCC)/google_scc_source_iam_binding/members.rego
+++ b/policies/gcp/Security Command Center (SCC)/google_scc_source_iam_binding/members.rego
@@ -3,6 +3,13 @@ package terraform.gcp.security.scc.google_scc_source_iam_binding.members
 import data.terraform.helpers
 import data.terraform.gcp.security.scc.google_scc_source_iam_binding.vars
 
+# policy_lint reports hard-coded-value on the address(es) below, and the finding
+# stands. This attribute is a LIST, and the pattern policy types read the value as
+# a single string (shared.get_target_list regex-matches it), so pointing one at an
+# array makes it undefined -- which reads as "no violation", not as an error, and
+# the non-compliant example would silently stop being flagged. There is no
+# "element whitelist" type in policies/_helpers to check every element of a list
+# against an allowed pattern; adding one is what would unblock this.
 conditions := [
   [
     {

--- a/policies/gcp/Security Command Center (SCC)/google_scc_source_iam_binding/members.rego
+++ b/policies/gcp/Security Command Center (SCC)/google_scc_source_iam_binding/members.rego
@@ -14,7 +14,7 @@ conditions := [
     },
     {
       "condition": "Members must belong to the approved list.",
-      "attribute_path": ["members", 0],
+      "attribute_path": ["members"],
       "values": [
         "group:secops@deakin.edu.au",
         "user:admin@deakin.edu.au",

--- a/policies/gcp/Workflows/google_workflows_workflow/service_account.rego
+++ b/policies/gcp/Workflows/google_workflows_workflow/service_account.rego
@@ -12,7 +12,7 @@ conditions := [
         {
             "condition": "Prevents service_account from using the editor role default service account",
             "attribute_path": ["service_account"],
-            "values": ["-*", [["compute@developer.gserviceaccount.com"]]],
+            "values": ["-*@*", [["compute"], ["developer.gserviceaccount.com"]]],
             "policy_type": "pattern blacklist"
         }
     ],


### PR DESCRIPTION
| rule | dev | branch |
|---|---:|---:|
| **hard-coded-value** | 79 | **28** |
| **vars-friendly-name** | 55 | **0** |
| **index-path** | 21 | **1** |
| everything else | 574 | 574 |
| **total** | **729** | **603** |

**`auto_test`: 1023/1023 pass**, before and after every commit. 129 files, all under `policies/gcp/`. `opa check` clean, 209 tests pass.

## ⛔ The most important thing here is not the diff

**`element whitelist` does not exist, and using it fails OPEN.** `policies/_helpers/helpers.rego` dispatches exactly six policy types. An unknown type hits a fallback returning `{{"error": ...}}` — an object with no `name` key — so `find_failing_resources` builds an empty set and **the policy passes everything, silently**. Confirmed with an OPA probe.

Both `Guide/Policy_writing_tutorial/policy-lint.md#index-path` and `POLICY_DESCRIPTIONS["index-path"]` in `scripts/linters/policy_lint.py` recommend it: *"use `element blacklist` (or `element whitelist`)"*. **A contributor following our own documentation ships a policy that catches nothing and still goes green on lint.** Both files are outside `policies/`, so they are not fixed here — they need their own change.

## Why the index-path fix isn't what the doc says

`element blacklist` matches by **substring**. `Apikeys/google_apikeys_key/restrictions.browser_key_restrictions.allowed_referrers` blacklists `"*"`, and the compliant fixture's referrer `"https://example.com/*"` contains it — converting flags the compliant example. Same trap on CIDRs, where `"10.0.0.0/0"` contains `"0.0.0.0/0"`.

So the general fix is: **drop the trailing index and keep the policy type.** `blacklist.rego` and `whitelist.rego` already do element-wise set logic on arrays (blacklist = any element in the forbidden set; whitelist = `object.subset`). That is the whole-list check the rule asks for, with the exact-match semantics the condition already had. `element blacklist` was used only for the two `role_entity` files, where substring is genuinely the right tool.

One policy was worse than an index bug: `google_gke_hub_feature_iam_binding/members.rego` had conditions for `members[0]` and `members[1]` in the **same situation**. Conditions inside a situation are AND-ed, so a binding was flagged only when *both* were public, and `members[2]` onward was never read at all. Now one condition over the whole list.

`google_clouddomains_registration/domain_notices` is reverted with a comment: it is a "the list must CONTAIN this value" check, and as a whitelist over the array the non-compliant fixture's `domain_notices = []` becomes vacuously compliant. auto_test caught it. None of the six policy types can express required-membership over a list.

## The 28 remaining hard-coded values

Each has an in-file comment. Three causes, none fixable inside `policies/gcp/`:

- **The attribute is a list** (13 findings) — `shared.get_target_list` regex-matches a single string; aimed at an array it goes undefined, i.e. "no violation".
- **The non-compliant example is empty or unset** (9) — a `pattern whitelist` only judges values that **match** its target, so a non-matching value is never flagged and the fixture would pass for the wrong reason.
- **`policy_data` is a whole rendered IAM policy document** (6) — a pattern target is used as a regex, where `{ [ ] "` are metacharacters and `*` → `([^/]+)` cannot cross the `/` in `roles/...`.

## Naming

Strip `google_`, split, title-case, with a token table for acronyms (`IAM API GKE KMS CMEK SCC VPC DNS`) and product names (`apihub` → API Hub, `gkeonprem` → GKE On-Prem, `cloudbuildv2` → Cloud Build v2). Verified globally unique across all 372 `_vars.rego`.

`google_apihub_plugin_instance`: `API Hub` → **API Hub Plugin Instance**. `google_netapp_kmsconfig`: `netapps_volumes` → **NetApp KMS Config**. `google_cloudbuildv2_repository`: the raw type name → **Cloud Build v2 Repository**.

## Worth a reviewer's eye

- **Some conversions launder the literal rather than remove it**: `["user:jane@organization.org"]` → `["*:*@*", [["user"],["jane"],["organization.org"]]]`. Behaviourally identical, and it is the convention the tree already uses — but the rule can be satisfied without the policy becoming deployment-independent.
- **One genuine widening**: `google_scc_notification_config/pubsub_topic` allowed two specific topics; the per-position cross-product now also permits their recombination. Per-position lists cannot express "these two pairs".

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015uFmZRNFNqoTccW58Kbs4b