### PR TITLE
A policy type the engine can't dispatch must fail loudly, not pass everything

### DIFF
--- a/Guide/Policy_writing_tutorial/policy-lint.md
+++ b/Guide/Policy_writing_tutorial/policy-lint.md
@@ -48,6 +48,44 @@ of the local test loop.
 Each rule below is its own anchored section (`policy-lint.md#<rule-id>`) — the portal links a
 finding straight to it.
 
+## unknown-policy-type
+
+`policy_type` is not one of the six values the engine can dispatch, so the whole condition is
+never evaluated. This is the worst thing a policy can do quietly: the condition is not weak, it
+is *absent*, and the policy passes every resource you point it at.
+
+The six, exactly as the engine spells them:
+
+    blacklist, whitelist, range, pattern blacklist, pattern whitelist, element blacklist
+
+They are **lowercase**, and the two-word ones use a **space, not an underscore**. Writing
+`pattern_whitelist` is the mistake this rule exists to catch. `element whitelist` is not a type
+either — for allowing a list, a plain `whitelist` already requires every element to be allowed
+(see [policy.rego](policy-rego.md#top) for what each type does).
+
+Bad:
+
+    {
+      "attribute_path": ["location"],
+      "values": ["australia-southeast1"],
+      "policy_type": "pattern_whitelist"
+    }
+
+Good:
+
+    {
+      "attribute_path": ["location"],
+      "values": ["australia-southeast1"],
+      "policy_type": "whitelist"
+    }
+
+If none of the six expresses what you need, that is worth saying out loud rather than working
+around — raise it, so the type can be added to the helpers instead of a broken one shipping.
+
+Miss this and the test catches it too: the helper refuses to evaluate the policy at all and
+`auto_test` fails it with `POLICY ERROR: unknown policy_type '<what you wrote>'`. The linter just
+tells you at the point you write it rather than at the point you test it.
+
 ## hard-coded-value
 
 A value in `values` is a team-specific literal (project id, email address, bucket/key/folder

--- a/Guide/Policy_writing_tutorial/policy-lint.md
+++ b/Guide/Policy_writing_tutorial/policy-lint.md
@@ -75,8 +75,16 @@ Good:
 ## index-path
 
 `attribute_path` ends in a bare list index (e.g. `["allowed_ips", 0]`). That checks only the
-first element of an array and silently ignores the rest — use `element blacklist` (or
-`element whitelist`) to check the whole list instead.
+first element of an array and silently ignores the rest. Drop the index and check the whole
+list instead — with which `policy_type` depends on which way round the check goes:
+
+- **Allowing a list** — plain **`whitelist`** already handles it. Given an array value it
+  requires *every* element to be in your `values` set, so `["allowed_ips"]` under a `whitelist`
+  is a complete check. There is **no `element whitelist`**; do not reach for one.
+- **Forbidding a list** — use **`element blacklist`**. A plain `blacklist` compares the whole
+  array against your `values`, which is almost never what you want, and forbidden things
+  usually appear *inside* an element (`"*.googleapis.com"` contains `"*"`) rather than as the
+  whole element. `element blacklist` does that substring match per element.
 
 Bad:
 

--- a/Guide/Policy_writing_tutorial/policy-rego.md
+++ b/Guide/Policy_writing_tutorial/policy-rego.md
@@ -92,11 +92,35 @@ The attribute path would be:
 
 ### Different ways to write your policy
 
+The engine dispatches on `policy_type`, and it knows **exactly six** values:
+
+| `policy_type` | Use it when |
+|---|---|
+| `blacklist` | The attribute must not be one of these values |
+| `whitelist` | The attribute must be one of these values (arrays: **every** element must be) |
+| `range` | A number must be above / below / between bounds |
+| `pattern blacklist` | A wildcard-extracted part of the value must not be one of these |
+| `pattern whitelist` | A wildcard-extracted part of the value must be one of these |
+| `element blacklist` | No element of an array may **contain** one of these substrings |
+
+Write them **lowercase, with a space** — `pattern whitelist`, never `pattern_whitelist`. Anything
+else is not a policy type: the engine cannot dispatch it, so it stops and reports
+`POLICY ERROR: unknown policy_type ...` and your test goes red. `policy_lint`'s
+[`unknown-policy-type`](policy-lint.md#unknown-policy-type) rule catches it before you get that far.
+
+There is no `element whitelist`, and you do not need one — see the Whitelist note below.
+
 ---
 
 ### Whitelist
 
 Whitelist allows only specific values and blocks everything else.
+
+> **Whitelist already handles lists.** When the attribute is an array, the helper requires
+> *every* element to be in your `values` set (it is a subset test), so
+> `"attribute_path": ["allowed_ips"]` under a `whitelist` is a complete check — you do not need,
+> and will not find, an `element whitelist`. `element blacklist` exists as a separate type only
+> because *forbidding* a list needs substring matching, which the plain `blacklist` does not do.
 
 ```rego
 
@@ -199,7 +223,17 @@ Ensures a value falls within a specific range.
 
 ### Pattern Whitelist
 
-Allows only values that match a defined pattern.
+Allows only values that match a defined pattern. `values` is **two** entries: a target string
+whose `*` wildcards mark the parts you care about, then a list of allowed values *per wildcard
+position* (first list for the first `*`, and so on). It is a wildcard match, not a regex — a
+regex in `values[0]` will not do what you expect.
+
+> **A value that does not match the target is never flagged.** The helper extracts the wildcard
+> parts out of the value first; if the value does not fit the target shape at all, there is
+> nothing to extract and the resource passes. So `"project/*/gcp/*"` says "*if* it looks like
+> this, the parts must be allowed" — it does **not** say "it must look like this". If the shape
+> itself is the control, check the shape with a `whitelist` (or a `pattern blacklist` on the
+> bad shape) as a second condition.
 ```rego
     [
       {
@@ -239,6 +273,12 @@ Blocks values that match a defined pattern.
 
 Blocks **array** attributes whose elements contain any blacklisted **substring** (simple
 `contains` matching, not regex). `values` is a flat array of forbidden substrings.
+
+> **It matches substrings, so it catches more than the exact value.** Blacklisting `"*"` also
+> flags `"https://example.com/*"` and `"*.googleapis.com"`, because both *contain* a `*`. That
+> is usually what you want for a wildcard check — but it means a short substring like `"dev"`
+> will also flag `"developer-portal"`. Pick substrings that cannot appear innocently, or anchor
+> them with a separator (`"dev-"`, `"-sandbox"`).
 ```rego
     [
       {

--- a/policies/_helpers/helpers.rego
+++ b/policies/_helpers/helpers.rego
@@ -47,6 +47,18 @@ import data.terraform.helpers.policies.element_blacklist
 # Logic:
 #   Resources must fail ALL conditions within a situation to be non-compliant (AND logic)
 get_multi_summary(conditions, tf_variables) = summary if {
+    # An unrecognised policy_type is a BROKEN policy, not a permissive one. This
+    # branch runs before any evaluation so it cannot be swallowed: select_policy_logic
+    # is only reached from a comprehension, and a comprehension silently DROPS an
+    # iteration whose body is undefined, which is how an unknown type used to make a
+    # policy pass everything in silence. Refuse the whole summary instead.
+    problems := policy_type_problems(conditions)
+    count(problems) > 0
+    summary := {
+        "message": [policy_type_error_message(problems)],
+        "details": []
+    }
+} else = summary if {
     # Count resources without storing them
     resource_count := count([r |
         r := input.planned_values.root_module.resources[_]
@@ -154,6 +166,82 @@ find_failing_resources(condition_results) = failing_resources if {
 # Routes evaluation to appropriate policy module based on policy_type string
 # Each policy type implements its own violation detection logic
 
+# The complete set of policy_type values select_policy_logic can dispatch. Every
+# entry here must have a matching select_policy_logic rule below, and vice versa:
+# this list is what get_multi_summary validates against and what the error message
+# offers the author. Keep it in step with policies/_helpers/policies/.
+valid_policy_types := [
+    "blacklist",
+    "whitelist",
+    "range",
+    "pattern blacklist",
+    "pattern whitelist",
+    "element blacklist",
+]
+
+# Every reason `conditions` cannot be dispatched, as human-readable phrases. Two
+# kinds, because evaluate_conditions drops both in the same silent way:
+#   - a policy_type dispatch does not know;
+#   - a condition with no policy_type at all (line "condition_obj.policy_type"
+#     there skips it, which is right for the situation_description/remedies
+#     entries and wrong for a real check that simply forgot the key).
+policy_type_problems(conditions) := problems if {
+    problems := _unknown_type_problems(conditions) | _missing_type_problems(conditions)
+}
+
+# Normalised the same way evaluate_conditions normalises it (lowercased), so
+# "Whitelist" and "whitelist" are one type. A non-string policy_type is reported
+# verbatim rather than dropped — lower() is undefined for it, which would
+# otherwise make it invisible here and silently unevaluated there.
+_unknown_type_problems(conditions) := problems if {
+    problems := {sprintf("unknown policy_type '%s'", [t]) |
+        some condition_group in conditions
+        some condition_entry in condition_group
+        raw := condition_entry.policy_type
+        t := _normalise_policy_type(raw)
+        not t in valid_policy_types
+    }
+}
+
+# A condition is anything carrying an attribute_path; the metadata entries carry
+# situation_description/remedies instead and are meant to have no policy_type.
+_missing_type_problems(conditions) := problems if {
+    problems := {sprintf("no policy_type on the condition reading '%s'",
+                         [shared.format_attribute_path(condition_entry.attribute_path)]) |
+        some condition_group in conditions
+        some condition_entry in condition_group
+        condition_entry.attribute_path
+        not "policy_type" in object.keys(condition_entry)
+    }
+}
+
+_normalise_policy_type(raw) := lower(raw) if {
+    is_string(raw)
+}
+
+_normalise_policy_type(raw) := sprintf("%v", [raw]) if {
+    not is_string(raw)
+}
+
+# The message the author sees. It names what they wrote, what the valid values
+# are, and what to do about it — a bare "unsupported" tells a student nothing.
+# auto_test.py keys off the "POLICY ERROR:" prefix to fail the check with this
+# text as the reason (see find_policy_error there).
+policy_type_error_message(problems) := msg if {
+    named := concat("; ", sort(problems))
+    msg := sprintf(
+        concat("", [
+            "POLICY ERROR: %s. ",
+            "Nothing in this policy was checked. ",
+            "Valid values are: %s. ",
+            "Edit the \"policy_type\" in this policy's conditions to one of those ",
+            "- they are lowercase and use a SPACE, not an underscore ",
+            "(\"pattern whitelist\", not \"pattern_whitelist\") - then run the test again.",
+        ]),
+        [named, concat(", ", valid_policy_types)]
+    )
+}
+
 select_policy_logic(tf_variables, attribute_path, values_formatted, "blacklist") = results if {
     results := blacklist.get_violations(tf_variables, attribute_path, values_formatted)
 }
@@ -178,13 +266,11 @@ select_policy_logic(tf_variables, attribute_path, values_formatted, "element bla
     results := element_blacklist.get_violations(tf_variables, attribute_path, values_formatted)
 }
 
-# Fallback for unknown policy types
-select_policy_logic(_, _, _, policy_type) = results if {
-    not policy_type in ["blacklist", "whitelist", "range", "pattern blacklist", "pattern whitelist", "element blacklist"]
-    results := {
-        {"error": sprintf("Unknown policy type: '%s'. Valid types: blacklist, whitelist, range, pattern blacklist, pattern whitelist, element blacklist", [policy_type])}
-    }
-}
+# There is deliberately NO fallback rule for an unknown policy_type. One used to
+# exist and returned {"error": ...} — an object with no "name" key, which
+# find_failing_resources then intersected into the empty set, so the policy passed
+# everything and the diagnosis was thrown away. The type is validated up front in
+# get_multi_summary instead, where the error can actually reach the surface.
 
 ################################################################################
 # Output Formatting

--- a/scripts/auto_test/_tests/test_unknown_policy_type.py
+++ b/scripts/auto_test/_tests/test_unknown_policy_type.py
@@ -1,0 +1,71 @@
+"""An unrecognised policy_type must fail the check loudly, naming the bad type.
+
+`policies/_helpers/helpers.rego` dispatches exactly six policy types. A policy
+naming a seventh used to build an error object and then throw it away, so the
+policy evaluated to "None - All passed" and the check went green whenever some
+*other* condition in the file happened to flag the fixture. The helper now
+refuses the whole summary and emits a POLICY ERROR message instead; these tests
+cover the auto_test half of that contract.
+"""
+
+import sys
+from pathlib import Path
+
+project_root = Path(__file__).parent.parent.parent.parent
+sys.path.insert(0, str(project_root))
+
+from scripts.auto_test import auto_test
+
+
+ERROR_MESSAGE = (
+    "POLICY ERROR: unknown policy_type 'pattern_whitelist'. Nothing in this policy "
+    "was checked. Valid values are: blacklist, whitelist, range, pattern blacklist, "
+    "pattern whitelist, element blacklist. Edit the \"policy_type\" in this policy's "
+    "conditions to one of those - they are lowercase and use a SPACE, not an "
+    "underscore (\"pattern whitelist\", not \"pattern_whitelist\") - then run the "
+    "test again."
+)
+
+
+def test_find_policy_error_returns_none_for_an_ordinary_summary():
+    messages = [
+        "Total Storage Bucket detected: 2 ",
+        "['Situation 1: force_destroy is enabled', "
+        "'Non-Compliant Resources: non_compliant_example_1']",
+    ]
+    assert auto_test.find_policy_error(messages) is None
+
+
+def test_find_policy_error_reads_the_marker_out_of_a_stringified_list():
+    # OPA returns `message` as a nested array; normalize_messages stringifies it,
+    # so the marker can sit inside a Python repr rather than at position 0.
+    assert auto_test.find_policy_error([f"['{ERROR_MESSAGE}']"]) == ERROR_MESSAGE
+
+
+def test_validate_policy_output_fails_with_the_helper_text_as_the_reason(tmp_path):
+    # The plan is never read: the error is detected before any name matching, so a
+    # policy the engine refused to evaluate cannot be rescued by the fixture's shape.
+    result = auto_test.validate_policy_output(
+        "location", "google_storage_bucket", tmp_path / "no-such-plan.json",
+        [ERROR_MESSAGE], False, "Cloud Storage", "google_storage_bucket")
+
+    assert result["passed"] is False
+    assert result["failure"]["reason"] == ERROR_MESSAGE
+    assert "pattern_whitelist" in result["failure"]["reason"]
+
+
+def test_a_bogus_type_fails_even_when_the_fixture_has_no_non_compliant_example(tmp_path):
+    # The regression this guards: name matching alone would report "nothing missing"
+    # for an all-compliant fixture, so the check would go GREEN on a policy that was
+    # never evaluated. The marker check runs first and is independent of the plan.
+    plan = tmp_path / "plan.json"
+    plan.write_text('{"planned_values": {"root_module": {"resources": ['
+                    '{"type": "google_storage_bucket", "values": '
+                    '{"name": "compliant_example_1"}}]}}}')
+
+    result = auto_test.validate_policy_output(
+        "location", "google_storage_bucket", plan, [ERROR_MESSAGE], False,
+        "Cloud Storage", "google_storage_bucket", "name")
+
+    assert result["passed"] is False
+    assert "unknown policy_type" in result["failure"]["reason"]

--- a/scripts/auto_test/auto_test.py
+++ b/scripts/auto_test/auto_test.py
@@ -368,6 +368,28 @@ def match_names_in_messages(messages: list[str], candidate_names: set[str]) -> s
     return matched
 
 
+# policies/_helpers/helpers.rego refuses to evaluate a policy whose conditions name
+# a policy_type it cannot dispatch, and says so with a message carrying this prefix.
+# Treating that as a plain summary would leave it to chance whether the check went
+# red (it would depend on whether the fixture happened to have compliant examples),
+# and the reported reason would be the wrong one, so it is matched explicitly.
+POLICY_ERROR_PREFIX = "POLICY ERROR:"
+
+
+def find_policy_error(messages: list[str]) -> str | None:
+    """The helper's own hard-error text, if the policy declared something unevaluatable.
+
+    Searched for anywhere in a message rather than only at the start: OPA returns the
+    message rule as a nested array and normalize_messages stringifies it, so the marker
+    can sit inside a Python repr rather than at position 0.
+    """
+    for message in messages:
+        index = message.find(POLICY_ERROR_PREFIX)
+        if index != -1:
+            return message[index:].strip().rstrip("]'\"")
+    return None
+
+
 def normalize_messages(messages_value) -> list[str]:
     if isinstance(messages_value, list):
         return [str(m) for m in messages_value]
@@ -473,6 +495,16 @@ def thread_safe_print(*args, **kwargs):
 def validate_policy_output(attribute: str, resource_type: str | None, plan_path: Path, messages: list[str],
                            verbose: bool, service: str, resource: str,
                            resource_value_name: str | None = None) -> dict:
+    # A policy the engine refused to evaluate fails outright, with the helper's own
+    # text as the reason. This must come first: without it the run would fall through
+    # to name-matching against an error string, and report "non-compliant resources
+    # were not flagged" — true, but it hides why, and it would report nothing at all
+    # for a fixture that has no non-compliant examples.
+    policy_error = find_policy_error(messages)
+    if policy_error:
+        thread_safe_print(f"Check failed: {policy_error}\n")
+        return make_failure(attribute, policy_error, service, resource)
+
     # Map each label to the identifier the OPA message uses (the resource_value_name
     # value). A label counts as flagged if EITHER the label OR its identifier appears
     # in the messages — so fixtures whose id field rejects the underscore example-name

--- a/scripts/linters/_tests/fixtures/policy_smells/policies/gcp/Backup for GKE/google_gke_backup_restore_channel/bogus_type.rego
+++ b/scripts/linters/_tests/fixtures/policy_smells/policies/gcp/Backup for GKE/google_gke_backup_restore_channel/bogus_type.rego
@@ -1,0 +1,27 @@
+package terraform.gcp.security.backup_for_gke.google_gke_backup_restore_channel.bogus_type
+
+import data.terraform.helpers
+import data.terraform.gcp.security.backup_for_gke.google_gke_backup_restore_channel.vars
+
+# unknown-policy-type: "pattern_whitelist" is the underscored spelling of a real
+# type, which is the mistake seen in the wild. Everything else here is clean, so
+# this file must produce exactly one finding.
+conditions := [
+    [
+        {
+            "situation_description": "Restore channels must follow the naming standard.",
+            "remedies": ["Rename the channel to match the standard."]
+        },
+        {
+            "condition": "Name must match the standard.",
+            "attribute_path": ["bogus_type"],
+            "values": ["approved-*", [["approved-"]]],
+            "policy_type": "pattern_whitelist"
+        }
+    ]
+]
+
+result := helpers.get_multi_summary(conditions, vars.variables)
+
+message := result.message
+details := result.details

--- a/scripts/linters/_tests/fixtures/policy_smells/policies/gcp/Backup for GKE/google_gke_backup_restore_channel/no_type.rego
+++ b/scripts/linters/_tests/fixtures/policy_smells/policies/gcp/Backup for GKE/google_gke_backup_restore_channel/no_type.rego
@@ -1,0 +1,26 @@
+package terraform.gcp.security.backup_for_gke.google_gke_backup_restore_channel.no_type
+
+import data.terraform.helpers
+import data.terraform.gcp.security.backup_for_gke.google_gke_backup_restore_channel.vars
+
+# unknown-policy-type: the condition simply has no policy_type. helpers.rego
+# skips such an entry (that is how it tells a check apart from the
+# situation_description/remedies metadata), so the check never runs.
+conditions := [
+    [
+        {
+            "situation_description": "Restore channels must declare an owner.",
+            "remedies": ["Add an owner label to the channel."]
+        },
+        {
+            "condition": "An owner must be recorded.",
+            "attribute_path": ["no_type"],
+            "values": ["team-platform"]
+        }
+    ]
+]
+
+result := helpers.get_multi_summary(conditions, vars.variables)
+
+message := result.message
+details := result.details

--- a/scripts/linters/_tests/test_policy_lint.py
+++ b/scripts/linters/_tests/test_policy_lint.py
@@ -10,6 +10,7 @@ version changes — the sha is recomputed from the same function the pipeline us
 """
 
 import json
+import re
 import shutil
 import subprocess
 import sys
@@ -80,7 +81,65 @@ def test_policy_body_rules_fire_exactly_once_each(tmp_path):
         ("short", "trivial-message"),
         ("legacy", "legacy-assign"),
         ("badcase", "package-case"),
+        ("bogus_type", "unknown-policy-type"),
+        ("no_type", "unknown-policy-type"),
     }
+
+
+def test_unknown_policy_type_names_what_was_written_and_the_valid_values(tmp_path):
+    # The finding has to be actionable on its own: a student reading it in CI
+    # needs the offending spelling and the list to pick a replacement from.
+    root = build_tree(tmp_path, "policy_smells")
+    findings = policy_lint.lint_resource(
+        root, "gcp", "Backup for GKE", "google_gke_backup_restore_channel")
+    by_policy = {f.policy: f.message
+                 for f in findings if f.rule == "unknown-policy-type"}
+
+    assert "'pattern_whitelist'" in by_policy["bogus_type"]
+    assert "declares no policy_type" in by_policy["no_type"]
+    for message in by_policy.values():
+        for valid in policy_lint.VALID_POLICY_TYPES:
+            assert valid in message, f"{valid!r} missing from: {message}"
+
+
+def test_unknown_policy_type_is_an_error_not_a_warning(tmp_path):
+    # By the owner's call: a condition that is never evaluated is not a style
+    # question, so it must fail a build rather than be surfaced for review.
+    root = build_tree(tmp_path, "policy_smells")
+    findings = policy_lint.lint_resource(
+        root, "gcp", "Backup for GKE", "google_gke_backup_restore_channel")
+    unknown = [f for f in findings if f.rule == "unknown-policy-type"]
+    assert unknown
+    assert {f.severity for f in unknown} == {"error"}
+    assert "unknown-policy-type" not in policy_lint.WARN_RULES
+
+
+def test_unknown_policy_type_is_silent_on_every_valid_type(tmp_path):
+    # The rule must accept all six, including the two-word ones — flagging a
+    # valid type would block every pattern/element policy in the tree.
+    root = build_tree(tmp_path, "policy_smells")
+    template = (root / "policies" / "gcp" / "Backup for GKE"
+                / "google_gke_backup_restore_channel" / "bogus_type.rego")
+    body = template.read_text(encoding="utf-8")
+    for valid in policy_lint.VALID_POLICY_TYPES:
+        template.write_text(body.replace('"pattern_whitelist"', f'"{valid}"'),
+                            encoding="utf-8")
+        policy_lint.clear_caches()
+        findings = policy_lint.lint_resource(
+            root, "gcp", "Backup for GKE", "google_gke_backup_restore_channel")
+        assert not [f for f in findings
+                    if f.policy == "bogus_type" and f.rule == "unknown-policy-type"], \
+            f"{valid!r} is a valid policy_type and must not be flagged"
+
+
+def test_unknown_policy_type_matches_what_the_helpers_dispatch(tmp_path):
+    # The linter's list and helpers.rego's `valid_policy_types` are two copies of
+    # one fact. If they drift, the linter either passes a policy the engine will
+    # refuse, or blocks one it would have run.
+    helpers = (project_root / "policies" / "_helpers" / "helpers.rego").read_text(
+        encoding="utf-8")
+    declared = helpers.split("valid_policy_types := [", 1)[1].split("]", 1)[0]
+    assert set(re.findall(r'"([^"]+)"', declared)) == set(policy_lint.VALID_POLICY_TYPES)
 
 
 def test_trivial_message_flags_short_text_and_empty_remedies_separately(tmp_path):
@@ -371,6 +430,8 @@ def test_cli_json_output_and_exit_code(tmp_path, capsys):
         ("short", "trivial-message"),
         ("legacy", "legacy-assign"),
         ("badcase", "package-case"),
+        ("bogus_type", "unknown-policy-type"),
+        ("no_type", "unknown-policy-type"),
     }
 
 
@@ -385,7 +446,8 @@ def test_cli_exits_zero_on_a_clean_resource(tmp_path, capsys):
 def test_cli_exits_zero_when_only_warnings_are_found(tmp_path, capsys):
     # A tree whose only findings are warn-severity must not fail the build.
     root = build_tree(tmp_path, "policy_smells")
-    for name in ("destination_project", "members", "constraint", "brief", "short"):
+    for name in ("destination_project", "members", "constraint", "brief", "short",
+                 "bogus_type", "no_type"):
         (root / "policies" / "gcp" / "Backup for GKE"
          / "google_gke_backup_restore_channel" / f"{name}.rego").unlink()
     rc = policy_lint.main([

--- a/scripts/linters/policy_lint.py
+++ b/scripts/linters/policy_lint.py
@@ -77,6 +77,10 @@ RULES = {
     "index-path": (
         "`attribute_path` ends in a list index; check the whole list with "
         "`element blacklist`."),
+    "unknown-policy-type": (
+        "`policy_type` is not one of the six the engine dispatches, so the condition "
+        "is never evaluated. Set it to a valid type (lowercase, spaces not "
+        "underscores)."),
     "presence-only": (
         "`values` is only null/\"\": presence is the whole check. Acceptable when the "
         "rationale says presence is the control — the reviewer decides; pair with a "
@@ -194,6 +198,15 @@ FIXTURE_LABEL_RE = re.compile(r"^(compliant|non_compliant)_example_(\d+)$")
 FIXTURE_IGNORED_KEYS = {
     "name", "labels", "label", "effective_labels", "terraform_labels",
 }
+
+# The policy types `policies/_helpers/helpers.rego` can dispatch, in the order its
+# error message lists them (so the two read identically to a student who hits both).
+# Anything else is refused at evaluation time; this rule catches it at authoring
+# time instead. Keep in step with `valid_policy_types` there.
+VALID_POLICY_TYPES = (
+    "blacklist", "whitelist", "range",
+    "pattern blacklist", "pattern whitelist", "element blacklist",
+)
 
 # Blacklist/whitelist only — a pattern or range policy with empty values means
 # something else entirely.
@@ -707,6 +720,25 @@ def _lint_policy_file(root, platform, service, resource_type, rego_path, policie
             policy_type = (check.get("policy_type") or "").strip().lower()
             path_text = ".".join(str(p) for p in attribute_path)
             joined_paths.append(".".join(_path_segments(attribute_path)))
+
+            # --- unknown-policy-type ---------------------------------------- #
+            # First in the block on purpose: if the engine cannot dispatch the
+            # type, the condition is never evaluated, so every other reading of
+            # it (what it checks, against which values) is beside the point.
+            if policy_type not in VALID_POLICY_TYPES:
+                declared = check.get("policy_type")
+                wrote = (f"declares policy_type {declared!r}"
+                         if declared not in (None, "")
+                         else "declares no policy_type")
+                # Keyed on the path as well as the type, so every offending
+                # condition is reported at once rather than the next one
+                # surfacing each time the author fixes the previous.
+                add_once("unknown-policy-type", (str(declared), path_text),
+                         f"'{path_text}' {wrote}, which the engine cannot dispatch "
+                         f"— the condition is never evaluated and the policy passes "
+                         f"everything. Set policy_type to one of: "
+                         f"{', '.join(VALID_POLICY_TYPES)} (lowercase, and a space "
+                         f"rather than an underscore).")
 
             # --- index-path ------------------------------------------------ #
             if attribute_path and _is_index(attribute_path[-1]):

--- a/tests/_helpers/helpers_test.rego
+++ b/tests/_helpers/helpers_test.rego
@@ -1,0 +1,143 @@
+package terraform.helpers_test
+
+# Policy Orchestration Test Suite — unknown policy_type handling
+#
+# helpers.rego dispatches exactly six policy types. A policy naming a seventh
+# used to build an {"error": ...} object and discard it: the object has no
+# "name" key, so find_failing_resources intersected it into the empty set and
+# the condition reported "None - All passed". These tests pin the replacement —
+# get_multi_summary refuses the whole summary before evaluating anything.
+
+import data.terraform.helpers
+import rego.v1
+
+# ==============================================================================
+# MOCK DATA
+# ==============================================================================
+# Two buckets, one of which a working condition would flag. Deliberately shaped
+# so a broken policy has something it *could* have caught: the point of these
+# tests is that it reports an error rather than "All passed".
+
+mock_variables := {
+	"resource_type": "google_storage_bucket",
+	"friendly_resource_name": "Storage Bucket",
+	"resource_value_name": "name",
+}
+
+mock_input := {"planned_values": {"root_module": {"resources": [
+	{"type": "google_storage_bucket", "values": {"name": "compliant_example_1", "location": "australia-southeast1"}},
+	{"type": "google_storage_bucket", "values": {"name": "non_compliant_example_1", "location": "us-central1"}},
+]}}}
+
+meta := {"situation_description": "Buckets must be in an approved region.", "remedies": ["Move the bucket."]}
+
+valid_condition := {
+	"condition": "Location must be australia-southeast1",
+	"attribute_path": ["location"],
+	"values": ["australia-southeast1"],
+	"policy_type": "whitelist",
+}
+
+# ==============================================================================
+# UNIT TESTS: policy_type_problems
+# ==============================================================================
+
+test_no_problems_when_every_type_is_valid if {
+	count(helpers.policy_type_problems([[meta, valid_condition]])) == 0
+}
+
+test_every_valid_type_is_accepted if {
+	every t in helpers.valid_policy_types {
+		count(helpers.policy_type_problems([[meta, {"attribute_path": ["x"], "values": ["y"], "policy_type": t}]])) == 0
+	}
+}
+
+# The dispatch table and the accepted set must be the same six: a type listed as
+# valid but with no select_policy_logic rule would evaluate to nothing at all.
+test_valid_policy_types_is_exactly_the_six if {
+	{t | some t in helpers.valid_policy_types} == {
+		"blacklist", "whitelist", "range",
+		"pattern blacklist", "pattern whitelist", "element blacklist",
+	}
+}
+
+test_case_is_normalised_like_evaluate_conditions_does if {
+	count(helpers.policy_type_problems([[meta, {"attribute_path": ["x"], "policy_type": "Pattern Whitelist"}]])) == 0
+}
+
+# The real offender shape found on dev: an underscore instead of a space.
+test_underscored_type_is_a_problem if {
+	helpers.policy_type_problems([[meta, {"attribute_path": ["x"], "policy_type": "pattern_whitelist"}]]) == {"unknown policy_type 'pattern_whitelist'"}
+}
+
+# The type the guide used to recommend, which never existed.
+test_element_whitelist_is_a_problem if {
+	helpers.policy_type_problems([[meta, {"attribute_path": ["x"], "policy_type": "element whitelist"}]]) == {"unknown policy_type 'element whitelist'"}
+}
+
+# lower() is undefined for a non-string, which would drop it from the set and
+# leave it silently unevaluated by evaluate_conditions.
+test_non_string_type_is_reported_not_dropped if {
+	helpers.policy_type_problems([[meta, {"attribute_path": ["x"], "policy_type": 7}]]) == {"unknown policy_type '7'"}
+}
+
+# A check that forgot the key is skipped by evaluate_conditions just as silently.
+test_missing_type_is_a_problem if {
+	helpers.policy_type_problems([[meta, {"attribute_path": ["labels", "owner"], "values": ["a"]}]]) == {"no policy_type on the condition reading 'labels.owner'"}
+}
+
+# The metadata entry legitimately has no policy_type and no attribute_path.
+test_metadata_entry_is_not_mistaken_for_an_untyped_condition if {
+	count(helpers.policy_type_problems([[meta, valid_condition]])) == 0
+}
+
+# ==============================================================================
+# INTEGRATION TESTS: get_multi_summary
+# ==============================================================================
+
+# The regression itself. A working condition alongside a broken one used to make
+# the whole file pass: the working one flagged the non-compliant bucket, which
+# was all auto_test looked for, and the broken one reported "All passed".
+test_one_bad_type_refuses_the_whole_summary if {
+	summary := helpers.get_multi_summary(
+		[[meta, valid_condition], [meta, {"attribute_path": ["location"], "values": ["^.+$"], "policy_type": "pattern_whitelist"}]],
+		mock_variables,
+	) with input as mock_input
+
+	count(summary.message) == 1
+	startswith(summary.message[0], "POLICY ERROR:")
+	contains(summary.message[0], "pattern_whitelist")
+	summary.details == []
+}
+
+# The message must be actionable: what is wrong, what is allowed, what to do.
+test_error_message_names_all_six_valid_types if {
+	summary := helpers.get_multi_summary(
+		[[meta, {"attribute_path": ["location"], "policy_type": "nonsense"}]],
+		mock_variables,
+	) with input as mock_input
+
+	every t in helpers.valid_policy_types {
+		contains(summary.message[0], t)
+	}
+}
+
+# Every distinct bad type is listed, so fixing one does not just reveal the next.
+test_multiple_bad_types_are_all_reported if {
+	summary := helpers.get_multi_summary(
+		[[meta, {"attribute_path": ["a"], "policy_type": "element whitelist"}, {"attribute_path": ["b"], "policy_type": "pattern_blacklist"}]],
+		mock_variables,
+	) with input as mock_input
+
+	contains(summary.message[0], "element whitelist")
+	contains(summary.message[0], "pattern_blacklist")
+}
+
+# The guard must not disturb a healthy policy.
+test_valid_policy_still_produces_a_normal_summary if {
+	summary := helpers.get_multi_summary([[meta, valid_condition]], mock_variables) with input as mock_input
+
+	not startswith(summary.message[0], "POLICY ERROR:")
+	summary.message[0] == "Total Storage Bucket detected: 2 "
+	summary.details[0].non_compliant_resources == {"non_compliant_example_1"}
+}


### PR DESCRIPTION
⚠️ **Merging this turns 4 policies red on `dev` (auto_test 1023/1023 → 1019/1023). That is the point — they are checking nothing today.** Neither affected resource type is assigned to a student.

## What was wrong

`helpers.rego` dispatches six policy types. An unrecognised one fell through to a branch that *built* an error object but could never surface it: `select_policy_logic` is only reached from a comprehension in `evaluate_conditions`, and a Rego comprehension **silently drops** an iteration whose body is undefined. The missing `name` key was the visible symptom; unreachability was the real defect. So an unknown type meant "no violations found".

## The blast radius: 4 files, 7 conditions, one typo

```
665 whitelist   296 blacklist   82 pattern whitelist   46 range
 40 pattern blacklist    9 element blacklist
  7 pattern_whitelist   ← not a type
```

All seven are `pattern_whitelist` — underscore instead of space — in `Backup for GKE`:

| File | Conditions never evaluated |
|---|---|
| `google_gke_backup_backup_channel/labels.rego` | `labels.owner`, `labels.cost-center`, `labels.bandwidth-limit` |
| `google_gke_backup_backup_channel/location.rego` | `location` region-format check |
| `google_gke_backup_restore_channel/labels.rego` | `labels.owner`, `labels.cost-center` |
| `google_gke_backup_restore_channel/location.rego` | `location` region-format check |

**Each file also has a working condition beside the broken one**, which is exactly why nobody noticed: the working one flagged the non-compliant fixture, `auto_test` only checks that, and the file went green while half of it did nothing.

## The fix

An `else`-chained guard at the top of `get_multi_summary`, before any condition is evaluated — the one place the result is not a comprehension element. It catches both silent-drop cases (unknown type, and `attribute_path` with no `policy_type` at all — currently 0), and refuses the whole summary with one `POLICY ERROR:` message naming the bad type and the six valid ones. `auto_test.validate_policy_output` matches that marker **first**, which matters: relying on the existing name-matching would still go green for an all-compliant fixture.

Plus an `unknown-policy-type` lint rule at error severity, so it is caught when written rather than when tested, and the `element whitelist` reference is gone from the tutorial.

## ⛔ Fixing the typo does NOT fix these policies

I tried it. Changing `pattern_whitelist` → `pattern whitelist` leaves the condition reporting *"None - All passed"*, because `pattern whitelist` is a **positional wildcard matcher** — `values` must be `[target_with_*, [[allowed…], …]]` — and these policies pass a bare regex (`"^[a-z]+-[a-z]+\\d$"`, `"^.+$"`). `get_target_list` extracts nothing, so no violation is possible.

What their authors wanted is a **regex whitelist** and a **required-label presence check**. The engine has neither. That is the "improve our code to accommodate new types" case, and I did not rewrite student content to keep CI green — doing so would recreate the exact failure mode this PR exists to end.

## The bigger hole this does NOT close

Only a wrong type *name* is caught. A **valid** type given a `values` shape it cannot consume still silently checks nothing — proved above with `pattern whitelist`. The same applies to `element blacklist` on a non-array attribute and `range` with a non-numeric bound. A per-type `values`-shape lint rule is the natural follow-up and is probably worth more than this one.

## Also found

`tests/_helpers/*.rego` has rotted — 10 of 77 tests already fail on `dev`, identically before and after this change, and `opa test` appears in no workflow. A helper test suite nobody runs reads as coverage while providing none. There was no `helpers_test.rego` at all until this branch (+13 tests, all passing).

## Verification

`policy_lint` 189 → 196 (exactly the 7 new findings, nothing else moved); 217 Python tests pass; `opa check` clean; structural lint clean; `git grep -in "autocapstone"` → 0.

Note: the `policy_check_ALL` job will go red on push to `dev` until those 4 are fixed. The `policy-results` artifact the portal consumes still publishes (written before the exit, uploaded with `if: always()`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015uFmZRNFNqoTccW58Kbs4b