### PR TITLE
Complete GCP service perimeter security policies

### DIFF
--- a/docs/gcp/Access Context Manager (VPC Service Controls)/google_access_context_manager_service_perimeter.json
+++ b/docs/gcp/Access Context Manager (VPC Service Controls)/google_access_context_manager_service_perimeter.json
@@ -6,50 +6,50 @@
       "description": "Whether Terraform will be prevented from destroying the instance. Defaults to \"DELETE\".\nWhen a 'terraform destroy' or 'terraform apply' would delete the instance,\nthe command will fail if this field is set to \"PREVENT\" in Terraform state.\nWhen set to \"ABANDON\", the command will remove the resource from Terraform\nmanagement without updating or deleting the resource in the API.\nWhen set to \"DELETE\", deleting the resource is allowed.\n",
       "required": false,
       "type": "string",
-      "security_impact": "true/false",
-      "rationale": ""
+      "security_impact": true,
+      "rationale": "This argument has a security impact because it controls whether the Service Perimeter can be deleted, abandoned, or protected from deletion. Preventing accidental or unauthorized deletion helps maintain security boundaries and protects resources within the perimeter."
     },
     "description": {
       "description": "Description of the ServicePerimeter and its use. Does not affect\nbehavior.",
       "required": false,
       "type": "string",
-      "security_impact": "true/false",
-      "rationale": ""
+      "security_impact": false,
+      "rationale": "This argument does not have a security impact because it is used only to describe the Service Perimeter and does not affect its behavior or security configuration."
     },
     "name": {
       "description": "Resource name for the ServicePerimeter. The short_name component must\nbegin with a letter and only include alphanumeric and '_'.\nFormat: accessPolicies/{policy_id}/servicePerimeters/{short_name}",
       "required": true,
       "type": "string",
-      "security_impact": "true/false",
-      "rationale": ""
+      "security_impact": false,
+      "rationale": "This argument does not have a security impact because it only specifies the name and format of the Service Perimeter resource. It identifies the resource but does not affect its security behavior or configuration."
     },
     "parent": {
       "description": "The AccessPolicy this ServicePerimeter lives in.\nFormat: accessPolicies/{policy_id}",
       "required": true,
       "type": "string",
-      "security_impact": "true/false",
-      "rationale": ""
+      "security_impact": false,
+      "rationale": "This argument does not have a security impact because it is a reference to the Access Policy that contains the Service Perimeter. The specific Access Policy is a team-managed resource choice and is not a generic platform-level security policy target."
     },
     "perimeter_type": {
       "description": "Specifies the type of the Perimeter. There are two types: regular and\nbridge. Regular Service Perimeter contains resources, access levels,\nand restricted services. Every resource can be in at most\nONE regular Service Perimeter.\n\nIn addition to being in a regular service perimeter, a resource can also\nbe in zero or more perimeter bridges. A perimeter bridge only contains\nresources. Cross project operations are permitted if all effected\nresources share some perimeter (whether bridge or regular). Perimeter\nBridge does not contain access levels or services: those are governed\nentirely by the regular perimeter that resource is in.\n\nPerimeter Bridges are typically useful when building more complex\ntopologies with many independent perimeters that need to share some data\nwith a common perimeter, but should not be able to share data among\nthemselves. Default value: \"PERIMETER_TYPE_REGULAR\" Possible values: [\"PERIMETER_TYPE_REGULAR\", \"PERIMETER_TYPE_BRIDGE\"]",
       "required": false,
       "type": "string",
-      "security_impact": "true/false",
-      "rationale": ""
+      "security_impact": true,
+      "rationale": "This argument has a security impact because it determines the type of Service Perimeter. The selected perimeter type controls how resources are isolated, how access is managed, and whether cross-project communication is permitted."
     },
     "title": {
       "description": "Human readable title. Must be unique within the Policy.",
       "required": true,
       "type": "string",
-      "security_impact": "true/false",
-      "rationale": ""
+      "security_impact": false,
+      "rationale": "This argument does not have a security impact because it is a human-readable title used to identify the Service Perimeter within the policy and does not affect its security behavior or configuration."
     },
     "use_explicit_dry_run_spec": {
       "description": "Use explicit dry run spec flag. Ordinarily, a dry-run spec implicitly exists\nfor all Service Perimeters, and that spec is identical to the status for those\nService Perimeters. When this flag is set, it inhibits the generation of the\nimplicit spec, thereby allowing the user to explicitly provide a\nconfiguration (\"spec\") to use in a dry-run version of the Service Perimeter.\nThis allows the user to test changes to the enforced config (\"status\") without\nactually enforcing them. This testing is done through analyzing the differences\nbetween currently enforced and suggested restrictions. useExplicitDryRunSpec must\nbet set to True if any of the fields in the spec are set to non-default values.",
       "required": false,
       "type": "bool",
-      "security_impact": "true/false",
-      "rationale": ""
+      "security_impact": false,
+      "rationale": "This argument does not have a security impact because it controls whether the dry-run Service Perimeter configuration is explicitly defined or inherited. This is an operational staging and configuration preference rather than a direct security baseline or vulnerability control, so it does not require a platform-level security policy."
     },
     "spec": {
       "type": "block",
@@ -60,22 +60,22 @@
       "description": "A list of AccessLevel resource names that allow resources within\nthe ServicePerimeter to be accessed from the internet.\nAccessLevels listed must be in the same policy as this\nServicePerimeter. Referencing a nonexistent AccessLevel is a\nsyntax error. If no AccessLevel names are listed, resources within\nthe perimeter can only be accessed via GCP calls with request\norigins within the perimeter. For Service Perimeter Bridge, must\nbe empty.\n\nFormat: accessPolicies/{policy_id}/accessLevels/{access_level_name}",
       "required": false,
       "type": "set(string)",
-      "security_impact": "true/false",
-      "rationale": ""
+      "security_impact": false,
+      "rationale": "This argument does not have a security impact because it references specific Access Level resources. These references are team-managed configuration choices and are not appropriate generic platform-level security policy targets."
     },
     "spec.resources": {
       "description": "A list of GCP resources that are inside of the service perimeter.\nCurrently only projects are allowed.\nFormat: projects/{project_number}",
       "required": false,
       "type": "set(string)",
-      "security_impact": "true/false",
-      "rationale": ""
+      "security_impact": false,
+      "rationale": "This argument does not have a security impact because it references specific GCP projects included within the Service Perimeter. These resource references are team-managed configuration choices and are not appropriate generic platform-level security policy targets."
     },
     "spec.restricted_services": {
       "description": "GCP services that are subject to the Service Perimeter\nrestrictions. Must contain a list of services. For example, if\n'storage.googleapis.com' is specified, access to the storage\nbuckets inside the perimeter must meet the perimeter's access\nrestrictions.",
       "required": false,
       "type": "set(string)",
-      "security_impact": "true/false",
-      "rationale": ""
+      "security_impact": false,
+      "rationale": "This argument does not have a security impact because it specifies particular Google Cloud services for the perimeter. Selecting specific services is an architectural choice for each team and is not an appropriate generic platform-level policy target."
     },
     "spec.egress_policies": {
       "type": "block",
@@ -86,8 +86,8 @@
       "description": "Human readable title. Must be unique within the perimeter. Does not affect behavior.",
       "required": false,
       "type": "string",
-      "security_impact": "true/false",
-      "rationale": ""
+      "security_impact": false,
+      "rationale": "This argument does not have a security impact because it is a human-readable title used to identify the egress policy and does not affect its behavior or security configuration."
     },
     "spec.egress_policies.egress_from": {
       "type": "block",
@@ -98,22 +98,22 @@
       "description": "A list of identities that are allowed access through this 'EgressPolicy'.\nShould be in the format of email address. The email address should\nrepresent individual user or service account only.",
       "required": false,
       "type": "set(string)",
-      "security_impact": "true/false",
-      "rationale": ""
+      "security_impact": true,
+      "rationale": "This argument has a security impact because it defines the identities that are allowed access through the egress policy. Configuring these identities determines which users or service accounts are permitted to access resources outside the Service Perimeter."
     },
     "spec.egress_policies.egress_from.identity_type": {
       "description": "Specifies the type of identities that are allowed access to outside the\nperimeter. If left unspecified, then members of 'identities' field will\nbe allowed access. Possible values: [\"IDENTITY_TYPE_UNSPECIFIED\", \"ANY_IDENTITY\", \"ANY_USER_ACCOUNT\", \"ANY_SERVICE_ACCOUNT\"]",
       "required": false,
       "type": "string",
-      "security_impact": "true/false",
-      "rationale": ""
+      "security_impact": true,
+      "rationale": "This argument has a security impact because it defines the types of identities that are allowed access through the egress policy. The selected identity type determines which users or service accounts are authorized to access resources outside the Service Perimeter."
     },
     "spec.egress_policies.egress_from.source_restriction": {
       "description": "Whether to enforce traffic restrictions based on 'sources' field. If the 'sources' field is non-empty, then this field must be set to 'SOURCE_RESTRICTION_ENABLED'. Possible values: [\"SOURCE_RESTRICTION_UNSPECIFIED\", \"SOURCE_RESTRICTION_ENABLED\", \"SOURCE_RESTRICTION_DISABLED\"]",
       "required": false,
       "type": "string",
-      "security_impact": "true/false",
-      "rationale": ""
+      "security_impact": true,
+      "rationale": "This argument has a security impact because it controls whether source-based traffic restrictions are enforced for the egress policy. Enabling or disabling these restrictions affects which requests are permitted to access resources outside the Service Perimeter."
     },
     "spec.egress_policies.egress_from.sources": {
       "type": "block",
@@ -124,15 +124,15 @@
       "description": "An AccessLevel resource name that allows resources outside the ServicePerimeter to be accessed from the inside.",
       "required": false,
       "type": "string",
-      "security_impact": "true/false",
-      "rationale": ""
+      "security_impact": false,
+      "rationale": "This argument does not have a security impact because it references a specific Access Level resource. Access Level references are team-specific configuration choices and are not appropriate generic platform-level policy targets."
     },
     "spec.egress_policies.egress_from.sources.resource": {
       "description": "A Google Cloud resource that is allowed to egress the perimeter.\nRequests from these resources are allowed to access data outside the perimeter.\nCurrently only projects are allowed. Project format: 'projects/{project_number}'.\nThe resource may be in any Google Cloud organization, not just the\norganization that the perimeter is defined in. '*' is not allowed, the\ncase of allowing all Google Cloud resources only is not supported.",
       "required": false,
       "type": "string",
-      "security_impact": "true/false",
-      "rationale": ""
+      "security_impact": false,
+      "rationale": "This argument does not have a security impact because it references specific Google Cloud resources or projects. These resource references are team-specific configuration choices and are not appropriate generic platform-level policy targets."
     },
     "spec.egress_policies.egress_to": {
       "type": "block",
@@ -143,22 +143,22 @@
       "description": "A list of external resources that are allowed to be accessed. A request\nmatches if it contains an external resource in this list (Example:\ns3://bucket/path). Currently '*' is not allowed.",
       "required": false,
       "type": "set(string)",
-      "security_impact": "true/false",
-      "rationale": ""
+      "security_impact": false,
+      "rationale": "This argument does not have a security impact because it references specific external resources or destinations. These references are team-specific configuration choices and are not appropriate generic platform-level policy targets."
     },
     "spec.egress_policies.egress_to.resources": {
       "description": "A list of resources, currently only projects in the form\n'projects/<projectnumber>', that match this to stanza. A request matches\nif it contains a resource in this list. If * is specified for resources,\nthen this 'EgressTo' rule will authorize access to all resources outside\nthe perimeter.",
       "required": false,
       "type": "set(string)",
-      "security_impact": "true/false",
-      "rationale": ""
+      "security_impact": false,
+      "rationale": "This argument does not have a security impact because it references specific target resources or projects. These resource references are team-specific configuration choices and are not appropriate generic platform-level policy targets."
     },
     "spec.egress_policies.egress_to.roles": {
       "description": "A list of IAM roles that represent the set of operations that the sources\nspecified in the corresponding 'EgressFrom'\nare allowed to perform.",
       "required": false,
       "type": "list(string)",
-      "security_impact": "true/false",
-      "rationale": ""
+      "security_impact": false,
+      "rationale": "This argument does not have a security impact because IAM role selection is a team-specific architectural choice. Dictating which roles teams may assign would overreach the scope of a generic platform-level security policy."
     },
     "spec.egress_policies.egress_to.operations": {
       "type": "block",
@@ -169,8 +169,8 @@
       "description": "The name of the API whose methods or permissions the 'IngressPolicy' or\n'EgressPolicy' want to allow. A single 'ApiOperation' with serviceName\nfield set to '*' will allow all methods AND permissions for all services.",
       "required": false,
       "type": "string",
-      "security_impact": "true/false",
-      "rationale": ""
+      "security_impact": true,
+      "rationale": "This argument has a security impact because overly broad service selection can significantly expand egress access. A platform policy can prevent wildcard service names such as '*' while allowing teams to explicitly select the services required by their workloads."
     },
     "spec.egress_policies.egress_to.operations.method_selectors": {
       "type": "block",
@@ -181,15 +181,15 @@
       "description": "Value for 'method' should be a valid method name for the corresponding\n'serviceName' in 'ApiOperation'. If '*' used as value for method,\nthen ALL methods and permissions are allowed.",
       "required": false,
       "type": "string",
-      "security_impact": "true/false",
-      "rationale": ""
+      "security_impact": true,
+      "rationale": "This argument has a security impact because wildcard method selectors can permit unrestricted API operations. A platform policy can prevent the use of '*' for methods while allowing teams to explicitly select the methods required by their workloads."
     },
     "spec.egress_policies.egress_to.operations.method_selectors.permission": {
       "description": "Value for permission should be a valid Cloud IAM permission for the\ncorresponding 'serviceName' in 'ApiOperation'.",
       "required": false,
       "type": "string",
-      "security_impact": "true/false",
-      "rationale": ""
+      "security_impact": true,
+      "rationale": "This argument has a security impact because overly broad permissions can grant excessive access through the egress policy. A platform policy can prevent wildcard or overly permissive permissions while allowing teams to explicitly select the permissions required by their workloads."
     },
     "spec.ingress_policies": {
       "type": "block",
@@ -200,8 +200,8 @@
       "description": "Human readable title. Must be unique within the perimeter. Does not affect behavior.",
       "required": false,
       "type": "string",
-      "security_impact": "true/false",
-      "rationale": ""
+      "security_impact": false,
+      "rationale": "This argument has no security impact because it is a human-readable title used to identify the ingress policy. It does not affect the behavior or security configuration of the Service Perimeter."
     },
     "spec.ingress_policies.ingress_from": {
       "type": "block",
@@ -212,15 +212,15 @@
       "description": "A list of identities that are allowed access through this ingress policy.\nShould be in the format of email address. The email address should represent\nindividual user or service account only.",
       "required": false,
       "type": "set(string)",
-      "security_impact": "true/false",
-      "rationale": ""
+      "security_impact": true,
+      "rationale": "This argument has a security impact because overly broad or public principals can allow unauthorized ingress access. A platform policy can prevent wildcard or public principal patterns while allowing teams to configure specific users and service accounts required by their workloads."
     },
     "spec.ingress_policies.ingress_from.identity_type": {
       "description": "Specifies the type of identities that are allowed access from outside the\nperimeter. If left unspecified, then members of 'identities' field will be\nallowed access. Possible values: [\"IDENTITY_TYPE_UNSPECIFIED\", \"ANY_IDENTITY\", \"ANY_USER_ACCOUNT\", \"ANY_SERVICE_ACCOUNT\"]",
       "required": false,
       "type": "string",
-      "security_impact": "true/false",
-      "rationale": ""
+      "security_impact": true,
+      "rationale": "This argument has a security impact because broad identity types can allow overly permissive ingress access. A platform policy can prevent unrestricted identity types such as ANY_IDENTITY while allowing teams to configure appropriately scoped identity types for their workloads."
     },
     "spec.ingress_policies.ingress_from.sources": {
       "type": "block",
@@ -231,15 +231,15 @@
       "description": "An 'AccessLevel' resource name that allow resources within the\n'ServicePerimeters' to be accessed from the internet. 'AccessLevels' listed\nmust be in the same policy as this 'ServicePerimeter'. Referencing a nonexistent\n'AccessLevel' will cause an error. If no 'AccessLevel' names are listed,\nresources within the perimeter can only be accessed via Google Cloud calls\nwith request origins within the perimeter.\nExample 'accessPolicies/MY_POLICY/accessLevels/MY_LEVEL.'\nIf * is specified, then all IngressSources will be allowed.",
       "required": false,
       "type": "string",
-      "security_impact": "true/false",
-      "rationale": ""
+      "security_impact": true,
+      "rationale": "This argument has a security impact because overly permissive or unconstrained access levels can broaden ingress access to resources within the Service Perimeter. A platform policy can require access levels to be explicitly constrained and prevent overly permissive configurations."
     },
     "spec.ingress_policies.ingress_from.sources.resource": {
       "description": "A Google Cloud resource that is allowed to ingress the perimeter.\nRequests from these resources will be allowed to access perimeter data.\nCurrently only projects are allowed. Format 'projects/{project_number}'\nThe project may be in any Google Cloud organization, not just the\norganization that the perimeter is defined in. '*' is not allowed, the case\nof allowing all Google Cloud resources only is not supported.",
       "required": false,
       "type": "string",
-      "security_impact": "true/false",
-      "rationale": ""
+      "security_impact": false,
+      "rationale": "This argument does not have a security impact because it references a specific Google Cloud resource or project. These resource references are team-specific configuration choices and are not appropriate generic platform-level policy targets."
     },
     "spec.ingress_policies.ingress_to": {
       "type": "block",
@@ -250,15 +250,15 @@
       "description": "A list of resources, currently only projects in the form\n'projects/<projectnumber>', protected by this 'ServicePerimeter'\nthat are allowed to be accessed by sources defined in the\ncorresponding 'IngressFrom'. A request matches if it contains\na resource in this list. If '*' is specified for resources,\nthen this 'IngressTo' rule will authorize access to all\nresources inside the perimeter, provided that the request\nalso matches the 'operations' field.",
       "required": false,
       "type": "set(string)",
-      "security_impact": "true/false",
-      "rationale": ""
+      "security_impact": true,
+      "rationale": "This argument has a security impact because overly broad resource targets can expand the ingress attack surface. A platform policy can prevent wildcard resource targets such as '*' while allowing teams to explicitly select the protected resources required by their workloads."
     },
     "spec.ingress_policies.ingress_to.roles": {
       "description": "A list of IAM roles that represent the set of operations that the sources\nspecified in the corresponding 'IngressFrom'\nare allowed to perform.",
       "required": false,
       "type": "list(string)",
-      "security_impact": "true/false",
-      "rationale": ""
+      "security_impact": false,
+      "rationale": "This argument does not have a security impact because IAM role selection is a team-specific architectural choice. Dictating which roles teams may assign would overreach the scope of a generic platform-level security policy."
     },
     "spec.ingress_policies.ingress_to.operations": {
       "type": "block",
@@ -269,8 +269,8 @@
       "description": "The name of the API whose methods or permissions the 'IngressPolicy' or\n'EgressPolicy' want to allow. A single 'ApiOperation' with 'serviceName'\nfield set to '*' will allow all methods AND permissions for all services.",
       "required": false,
       "type": "string",
-      "security_impact": "true/false",
-      "rationale": ""
+      "security_impact": true,
+      "rationale": "This argument has a security impact because overly broad service selection can significantly expand ingress access. A platform policy can prevent wildcard service names such as '*' while allowing teams to explicitly select the services required by their workloads."
     },
     "spec.ingress_policies.ingress_to.operations.method_selectors": {
       "type": "block",
@@ -281,15 +281,15 @@
       "description": "Value for method should be a valid method name for the corresponding\nserviceName in 'ApiOperation'. If '*' used as value for 'method', then\nALL methods and permissions are allowed.",
       "required": false,
       "type": "string",
-      "security_impact": "true/false",
-      "rationale": ""
+      "security_impact": true,
+      "rationale": "This argument has a security impact because wildcard method selectors can permit unrestricted API operations. A platform policy can prevent the use of '*' for methods while allowing teams to explicitly select the methods required by their workloads."
     },
     "spec.ingress_policies.ingress_to.operations.method_selectors.permission": {
       "description": "Value for permission should be a valid Cloud IAM permission for the\ncorresponding 'serviceName' in 'ApiOperation'.",
       "required": false,
       "type": "string",
-      "security_impact": "true/false",
-      "rationale": ""
+      "security_impact": true,
+      "rationale": "This argument has a security impact because overly broad permissions can grant excessive access through the ingress policy. A platform policy can prevent wildcard or overly permissive permissions while allowing teams to explicitly select the permissions required by their workloads."
     },
     "spec.vpc_accessible_services": {
       "type": "block",
@@ -300,15 +300,15 @@
       "description": "The list of APIs usable within the Service Perimeter.\nMust be empty unless 'enableRestriction' is True.",
       "required": false,
       "type": "set(string)",
-      "security_impact": "true/false",
-      "rationale": ""
+      "security_impact": true,
+      "rationale": "This argument has a security impact because it acts as an API exposure allowlist that controls which services can be accessed within the Service Perimeter. A platform policy can constrain the allowlist to prevent overly broad API exposure without requiring specific services to be hardcoded."
     },
     "spec.vpc_accessible_services.enable_restriction": {
       "description": "Whether to restrict API calls within the Service Perimeter to the\nlist of APIs specified in 'allowedServices'.",
       "required": false,
       "type": "bool",
-      "security_impact": "true/false",
-      "rationale": ""
+      "security_impact": true,
+      "rationale": "This argument has a security impact because enabling the restriction enforces API access constraints within the Service Perimeter. A platform policy should require this restriction to be enabled so that API access is limited according to the configured allowed services."
     },
     "status": {
       "type": "block",
@@ -319,22 +319,22 @@
       "description": "A list of AccessLevel resource names that allow resources within\nthe ServicePerimeter to be accessed from the internet.\nAccessLevels listed must be in the same policy as this\nServicePerimeter. Referencing a nonexistent AccessLevel is a\nsyntax error. If no AccessLevel names are listed, resources within\nthe perimeter can only be accessed via GCP calls with request\norigins within the perimeter. For Service Perimeter Bridge, must\nbe empty.\n\nFormat: accessPolicies/{policy_id}/accessLevels/{access_level_name}",
       "required": false,
       "type": "set(string)",
-      "security_impact": "true/false",
-      "rationale": ""
+      "security_impact": true,
+      "rationale": "This argument has a security impact because Access Levels define contextual security requirements for accessing resources within the Service Perimeter. A platform policy can enforce appropriate access-level constraints without hardcoding specific team-managed Access Level names."
     },
     "status.resources": {
       "description": "A list of GCP resources that are inside of the service perimeter.\nCurrently only projects are allowed.\nFormat: projects/{project_number}",
       "required": false,
       "type": "set(string)",
-      "security_impact": "true/false",
-      "rationale": ""
+      "security_impact": false,
+      "rationale": "This argument does not have a security impact because it references specific Google Cloud projects protected by the Service Perimeter. These resource references are team-specific configuration choices and are not appropriate generic platform-level policy targets."
     },
     "status.restricted_services": {
       "description": "GCP services that are subject to the Service Perimeter\nrestrictions. Must contain a list of services. For example, if\n'storage.googleapis.com' is specified, access to the storage\nbuckets inside the perimeter must meet the perimeter's access\nrestrictions.",
       "required": false,
       "type": "set(string)",
-      "security_impact": "true/false",
-      "rationale": ""
+      "security_impact": true,
+      "rationale": "This argument has a security impact because it defines which Google Cloud services receive Service Perimeter protection. A platform policy can require appropriate perimeter coverage and prevent critical services from being omitted, while allowing each team to select the specific services required by its workload."
     },
     "status.egress_policies": {
       "type": "block",
@@ -345,8 +345,8 @@
       "description": "Human readable title. Must be unique within the perimeter. Does not affect behavior.",
       "required": false,
       "type": "string",
-      "security_impact": "true/false",
-      "rationale": ""
+      "security_impact": false,
+      "rationale": "This argument does not have a security impact because it is a human-readable identifier used to distinguish the egress policy. It is cosmetic and does not affect the policy's security behavior or enforcement."
     },
     "status.egress_policies.egress_from": {
       "type": "block",
@@ -357,22 +357,22 @@
       "description": "Identities can be an individual user, service account, Google group,\nor third-party identity. For third-party identity, only single identities\nare supported and other identity types are not supported.The v1 identities\nthat have the prefix user, group and serviceAccount in\nhttps://cloud.google.com/iam/docs/principal-identifiers#v1 are supported.",
       "required": false,
       "type": "set(string)",
-      "security_impact": "true/false",
-      "rationale": ""
+      "security_impact": true,
+      "rationale": "This argument has a security impact because it controls which identities can perform operations that allow data to leave the Service Perimeter. A platform policy should prevent wildcard or overly broad principal grants while allowing appropriately scoped identities."
     },
     "status.egress_policies.egress_from.identity_type": {
       "description": "Specifies the type of identities that are allowed access to outside the\nperimeter. If left unspecified, then members of 'identities' field will\nbe allowed access. Possible values: [\"IDENTITY_TYPE_UNSPECIFIED\", \"ANY_IDENTITY\", \"ANY_USER_ACCOUNT\", \"ANY_SERVICE_ACCOUNT\"]",
       "required": false,
       "type": "string",
-      "security_impact": "true/false",
-      "rationale": ""
+      "security_impact": true,
+      "rationale": "This argument has a security impact because it defines category-level identity grants for egress access. A platform policy should prevent overly permissive identity types such as ANY_IDENTITY from bypassing Service Perimeter boundaries."
     },
     "status.egress_policies.egress_from.source_restriction": {
       "description": "Whether to enforce traffic restrictions based on 'sources' field. If the 'sources' field is non-empty, then this field must be set to 'SOURCE_RESTRICTION_ENABLED'. Possible values: [\"SOURCE_RESTRICTION_UNSPECIFIED\", \"SOURCE_RESTRICTION_ENABLED\", \"SOURCE_RESTRICTION_DISABLED\"]",
       "required": false,
       "type": "string",
-      "security_impact": "true/false",
-      "rationale": ""
+      "security_impact": true,
+      "rationale": "This argument has a security impact because it determines whether source-based traffic restrictions are enforced for egress. A platform policy should require source restrictions to be enabled when sources are configured and prevent unrestricted egress caused by disabled source restrictions."
     },
     "status.egress_policies.egress_from.sources": {
       "type": "block",
@@ -383,15 +383,15 @@
       "description": "An AccessLevel resource name that allows resources outside the ServicePerimeter to be accessed from the inside.",
       "required": false,
       "type": "string",
-      "security_impact": "true/false",
-      "rationale": ""
+      "security_impact": false,
+      "rationale": "This argument does not have a security impact because it references a specific Access Level resource. Access Level references are team-specific configuration choices and are not appropriate generic platform-level policy targets."
     },
     "status.egress_policies.egress_from.sources.resource": {
       "description": "A Google Cloud resource that is allowed to egress the perimeter.\nRequests from these resources are allowed to access data outside the perimeter.\nCurrently only projects are allowed. Project format: 'projects/{project_number}'.\nThe resource may be in any Google Cloud organization, not just the\norganization that the perimeter is defined in. '*' is not allowed, the\ncase of allowing all Google Cloud resources only is not supported.",
       "required": false,
       "type": "string",
-      "security_impact": "true/false",
-      "rationale": ""
+      "security_impact": false,
+      "rationale": "This argument does not have a security impact because it references specific Google Cloud resources or projects. These resource references are team-specific configuration choices and are not appropriate generic platform-level policy targets."
     },
     "status.egress_policies.egress_to": {
       "type": "block",
@@ -402,22 +402,22 @@
       "description": "A list of external resources that are allowed to be accessed. A request\nmatches if it contains an external resource in this list (Example:\ns3://bucket/path). Currently '*' is not allowed.",
       "required": false,
       "type": "set(string)",
-      "security_impact": "true/false",
-      "rationale": ""
+      "security_impact": false,
+      "rationale": "This argument does not have a security impact because it references specific external resources or destinations. These destinations are team-specific configuration choices and are not appropriate generic platform-level policy targets."
     },
     "status.egress_policies.egress_to.resources": {
       "description": "A list of resources, currently only projects in the form\n'projects/<projectnumber>', that match this to stanza. A request matches\nif it contains a resource in this list. If * is specified for resources,\nthen this 'EgressTo' rule will authorize access to all resources outside\nthe perimeter.",
       "required": false,
       "type": "set(string)",
-      "security_impact": "true/false",
-      "rationale": ""
+      "security_impact": false,
+      "rationale": "This argument does not have a security impact because it references specific target resources or projects. These resource references are team-specific configuration choices and are not appropriate generic platform-level policy targets."
     },
     "status.egress_policies.egress_to.roles": {
       "description": "A list of IAM roles that represent the set of operations that the sources\nspecified in the corresponding 'EgressFrom'\nare allowed to perform.",
       "required": false,
       "type": "list(string)",
-      "security_impact": "true/false",
-      "rationale": ""
+      "security_impact": false,
+      "rationale": "This argument does not have a security impact because it specifies IAM roles selected according to the team's workload requirements. Restricting specific roles at the generic platform level would overreach team-specific access requirements."
     },
     "status.egress_policies.egress_to.operations": {
       "type": "block",
@@ -428,8 +428,8 @@
       "description": "The name of the API whose methods or permissions the 'IngressPolicy' or\n'EgressPolicy' want to allow. A single 'ApiOperation' with serviceName\nfield set to '*' will allow all methods AND permissions for all services.",
       "required": false,
       "type": "string",
-      "security_impact": "true/false",
-      "rationale": ""
+      "security_impact": false,
+      "rationale": "This argument does not have a security impact because API service names are functional references selected according to the team's application architecture. A generic platform policy should not dictate which specific Google Cloud APIs a workload may use."
     },
     "status.egress_policies.egress_to.operations.method_selectors": {
       "type": "block",
@@ -440,15 +440,15 @@
       "description": "Value for 'method' should be a valid method name for the corresponding\n'serviceName' in 'ApiOperation'. If '*' used as value for method,\nthen ALL methods and permissions are allowed.",
       "required": false,
       "type": "string",
-      "security_impact": "true/false",
-      "rationale": ""
+      "security_impact": false,
+      "rationale": "This argument does not have a security impact because specific API methods are functional implementation details selected according to workload requirements. They are not appropriate generic platform-level policy targets."
     },
     "status.egress_policies.egress_to.operations.method_selectors.permission": {
       "description": "Value for permission should be a valid Cloud IAM permission for the\ncorresponding 'serviceName' in 'ApiOperation'.",
       "required": false,
       "type": "string",
-      "security_impact": "true/false",
-      "rationale": ""
+      "security_impact": false,
+      "rationale": "This argument does not have a security impact because it references specific IAM permissions required by individual workloads. These permissions depend on application requirements and are not appropriate generic platform-level policy targets."
     },
     "status.ingress_policies": {
       "type": "block",
@@ -459,8 +459,8 @@
       "description": "Human readable title. Must be unique within the perimeter. Does not affect behavior.",
       "required": false,
       "type": "string",
-      "security_impact": "true/false",
-      "rationale": ""
+      "security_impact": false,
+      "rationale": "This argument has no security impact because it is a human-readable title used to identify the ingress policy. It does not affect the behavior or security configuration of the Service Perimeter."
     },
     "status.ingress_policies.ingress_from": {
       "type": "block",
@@ -471,15 +471,15 @@
       "description": "Identities can be an individual user, service account, Google group,\nor third-party identity. For third-party identity, only single identities\nare supported and other identity types are not supported.The v1 identities\nthat have the prefix user, group and serviceAccount in\nhttps://cloud.google.com/iam/docs/principal-identifiers#v1 are supported.",
       "required": false,
       "type": "set(string)",
-      "security_impact": "true/false",
-      "rationale": ""
+      "security_impact": true,
+      "rationale": "This argument has a security impact because overly broad or public principals can permit unauthorized ingress access. A platform policy should prevent wildcard or public principal patterns such as allUsers while allowing teams to configure appropriately scoped identities."
     },
     "status.ingress_policies.ingress_from.identity_type": {
       "description": "Specifies the type of identities that are allowed access from outside the\nperimeter. If left unspecified, then members of 'identities' field will be\nallowed access. Possible values: [\"IDENTITY_TYPE_UNSPECIFIED\", \"ANY_IDENTITY\", \"ANY_USER_ACCOUNT\", \"ANY_SERVICE_ACCOUNT\"]",
       "required": false,
       "type": "string",
-      "security_impact": "true/false",
-      "rationale": ""
+      "security_impact": true,
+      "rationale": "This argument has a security impact because overly broad identity types can permit unrestricted ingress access. A platform policy should prevent permissive identity types such as ANY_IDENTITY while allowing appropriately scoped identity configurations."
     },
     "status.ingress_policies.ingress_from.sources": {
       "type": "block",
@@ -490,15 +490,15 @@
       "description": "An 'AccessLevel' resource name that allow resources within the\n'ServicePerimeters' to be accessed from the internet. 'AccessLevels' listed\nmust be in the same policy as this 'ServicePerimeter'. Referencing a nonexistent\n'AccessLevel' will cause an error. If no 'AccessLevel' names are listed,\nresources within the perimeter can only be accessed via Google Cloud calls\nwith request origins within the perimeter.\nExample 'accessPolicies/MY_POLICY/accessLevels/MY_LEVEL.'\nIf * is specified, then all IngressSources will be allowed.",
       "required": false,
       "type": "string",
-      "security_impact": "true/false",
-      "rationale": ""
+      "security_impact": false,
+      "rationale": "This argument does not have a security impact because it references a specific Access Level resource. Access Level references are team-specific architectural choices and are not appropriate generic platform-level policy targets."
     },
     "status.ingress_policies.ingress_from.sources.resource": {
       "description": "A Google Cloud resource that is allowed to ingress the perimeter.\nRequests from these resources will be allowed to access perimeter data.\nCurrently only projects and VPCs are allowed.\nProject format: 'projects/{projectNumber}'\nVPC network format:\n'//compute.googleapis.com/projects/{PROJECT_ID}/global/networks/{NAME}'.\nThe project may be in any Google Cloud organization, not just the\norganization that the perimeter is defined in. '*' is not allowed, the case\nof allowing all Google Cloud resources only is not supported.",
       "required": false,
       "type": "string",
-      "security_impact": "true/false",
-      "rationale": ""
+      "security_impact": false,
+      "rationale": "This argument does not have a security impact because it references specific external Google Cloud projects or network resources. These resource references are team-specific configuration choices and are not appropriate generic platform-level policy targets."
     },
     "status.ingress_policies.ingress_to": {
       "type": "block",
@@ -509,15 +509,15 @@
       "description": "A list of resources, currently only projects in the form\n'projects/<projectnumber>', protected by this 'ServicePerimeter'\nthat are allowed to be accessed by sources defined in the\ncorresponding 'IngressFrom'. A request matches if it contains\na resource in this list. If '*' is specified for resources,\nthen this 'IngressTo' rule will authorize access to all\nresources inside the perimeter, provided that the request\nalso matches the 'operations' field.",
       "required": false,
       "type": "set(string)",
-      "security_impact": "true/false",
-      "rationale": ""
+      "security_impact": false,
+      "rationale": "This argument does not have a security impact because it references specific protected resources within the Service Perimeter. These resource references are team-specific configuration choices and are not appropriate generic platform-level policy targets."
     },
     "status.ingress_policies.ingress_to.roles": {
       "description": "A list of IAM roles that represent the set of operations that the sources\nspecified in the corresponding 'IngressFrom'\nare allowed to perform.",
       "required": false,
       "type": "list(string)",
-      "security_impact": "true/false",
-      "rationale": ""
+      "security_impact": false,
+      "rationale": "This argument does not have a security impact because it specifies IAM roles selected according to the team's workload requirements. Restricting specific roles at the generic platform level would overreach team-specific access requirements."
     },
     "status.ingress_policies.ingress_to.operations": {
       "type": "block",
@@ -528,8 +528,8 @@
       "description": "The name of the API whose methods or permissions the 'IngressPolicy' or\n'EgressPolicy' want to allow. A single 'ApiOperation' with 'serviceName'\nfield set to '*' will allow all methods AND permissions for all services.",
       "required": false,
       "type": "string",
-      "security_impact": "true/false",
-      "rationale": ""
+      "security_impact": false,
+      "rationale": "This argument does not have a security impact because API service names are functional references selected according to the team's application requirements. A generic platform policy should not dictate which specific Google Cloud APIs a workload may target."
     },
     "status.ingress_policies.ingress_to.operations.method_selectors": {
       "type": "block",
@@ -540,15 +540,15 @@
       "description": "Value for method should be a valid method name for the corresponding\nserviceName in 'ApiOperation'. If '*' used as value for 'method', then\nALL methods and permissions are allowed.",
       "required": false,
       "type": "string",
-      "security_impact": "true/false",
-      "rationale": ""
+      "security_impact": false,
+      "rationale": "This argument does not have a security impact because individual API method names are functional references selected according to application requirements. These workload-specific methods are not appropriate generic platform-level policy targets."
     },
     "status.ingress_policies.ingress_to.operations.method_selectors.permission": {
       "description": "Value for permission should be a valid Cloud IAM permission for the\ncorresponding 'serviceName' in 'ApiOperation'.",
       "required": false,
       "type": "string",
-      "security_impact": "true/false",
-      "rationale": ""
+      "security_impact": false,
+      "rationale": "This argument does not have a security impact because it references specific IAM permissions required by individual workloads. These permissions depend on application requirements and are not appropriate generic platform-level policy targets."
     },
     "status.vpc_accessible_services": {
       "type": "block",
@@ -559,15 +559,20 @@
       "description": "The list of APIs usable within the Service Perimeter.\nMust be empty unless 'enableRestriction' is True.",
       "required": false,
       "type": "set(string)",
-      "security_impact": "true/false",
-      "rationale": ""
+      "security_impact": false,
+      "rationale": "This argument does not have a security impact because the required Google Cloud services depend on each team's application architecture and workload. A generic platform policy cannot prescribe a specific list of allowed services without overreaching team-specific requirements."
     },
     "status.vpc_accessible_services.enable_restriction": {
       "description": "Whether to restrict API calls within the Service Perimeter to the\nlist of APIs specified in 'allowedServices'.",
       "required": false,
       "type": "bool",
-      "security_impact": "true/false",
-      "rationale": ""
+      "security_impact": true,
+      "rationale": "This argument has a security impact because it determines whether API calls within the Service Perimeter are restricted to the configured allowed services. Enabling or disabling this restriction directly affects which APIs can be accessed."
     }
   }
 }
+
+
+
+
+

--- a/inputs/gcp/Access Context Manager (VPC Service Controls)/google_access_context_manager_service_perimeter/deletion_policy/compliant.tf
+++ b/inputs/gcp/Access Context Manager (VPC Service Controls)/google_access_context_manager_service_perimeter/deletion_policy/compliant.tf
@@ -1,0 +1,7 @@
+resource "google_access_context_manager_service_perimeter" "compliant_example_1" {
+  parent = "accessPolicies/123456789"
+  name   = "compliant_deletion_policy"
+  title  = "service_perimeter"
+
+  deletion_policy = "PREVENT"
+}

--- a/inputs/gcp/Access Context Manager (VPC Service Controls)/google_access_context_manager_service_perimeter/deletion_policy/config.tf
+++ b/inputs/gcp/Access Context Manager (VPC Service Controls)/google_access_context_manager_service_perimeter/deletion_policy/config.tf
@@ -1,0 +1,9 @@
+terraform {
+  required_providers {
+    google = {
+      source = "hashicorp/google"
+    }
+  }
+}
+
+provider "google" {}

--- a/inputs/gcp/Access Context Manager (VPC Service Controls)/google_access_context_manager_service_perimeter/deletion_policy/nonCompliant.tf
+++ b/inputs/gcp/Access Context Manager (VPC Service Controls)/google_access_context_manager_service_perimeter/deletion_policy/nonCompliant.tf
@@ -1,0 +1,8 @@
+# deletion_policy allows deletion
+resource "google_access_context_manager_service_perimeter" "non_compliant_example_1" {
+  parent = "accessPolicies/123456789"
+  name   = "non_compliant_deletion_policy"
+  title  = "service_perimeter"
+
+  deletion_policy = "DELETE"
+}

--- a/inputs/gcp/Access Context Manager (VPC Service Controls)/google_access_context_manager_service_perimeter/perimeter_type/compliant.tf
+++ b/inputs/gcp/Access Context Manager (VPC Service Controls)/google_access_context_manager_service_perimeter/perimeter_type/compliant.tf
@@ -1,0 +1,7 @@
+resource "google_access_context_manager_service_perimeter" "compliant_example_1" {
+  parent = "accessPolicies/123456789"
+  name   = "compliant_perimeter_type"
+  title  = "service_perimeter"
+
+  perimeter_type = "PERIMETER_TYPE_REGULAR"
+}

--- a/inputs/gcp/Access Context Manager (VPC Service Controls)/google_access_context_manager_service_perimeter/perimeter_type/config.tf
+++ b/inputs/gcp/Access Context Manager (VPC Service Controls)/google_access_context_manager_service_perimeter/perimeter_type/config.tf
@@ -1,0 +1,11 @@
+##### DO NOT EDIT ######
+
+terraform {
+  required_providers {
+    google = {
+      source = "hashicorp/google"
+    }
+  }
+}
+
+provider "google" {}

--- a/inputs/gcp/Access Context Manager (VPC Service Controls)/google_access_context_manager_service_perimeter/perimeter_type/nonCompliant.tf
+++ b/inputs/gcp/Access Context Manager (VPC Service Controls)/google_access_context_manager_service_perimeter/perimeter_type/nonCompliant.tf
@@ -1,0 +1,7 @@
+resource "google_access_context_manager_service_perimeter" "non_compliant_example_1" {
+  parent = "accessPolicies/123456789"
+  name   = "non_compliant_perimeter_type"
+  title  = "service_perimeter"
+
+  perimeter_type = "PERIMETER_TYPE_BRIDGE"
+}

--- a/inputs/gcp/Access Context Manager (VPC Service Controls)/google_access_context_manager_service_perimeter/spec.egress_policies.egress_from.identities/compliant.tf
+++ b/inputs/gcp/Access Context Manager (VPC Service Controls)/google_access_context_manager_service_perimeter/spec.egress_policies.egress_from.identities/compliant.tf
@@ -1,0 +1,19 @@
+resource "google_access_context_manager_service_perimeter" "compliant_example_1" {
+  parent = "accessPolicies/123456789"
+  name   = "compliant_egress_identities"
+  title  = "service_perimeter"
+
+  spec {
+    restricted_services = ["storage.googleapis.com"]
+
+    egress_policies {
+      egress_from {
+        identities = [
+          "serviceAccount:approved@example.iam.gserviceaccount.com"
+        ]
+      }
+    }
+  }
+
+  use_explicit_dry_run_spec = true
+}

--- a/inputs/gcp/Access Context Manager (VPC Service Controls)/google_access_context_manager_service_perimeter/spec.egress_policies.egress_from.identities/config.tf
+++ b/inputs/gcp/Access Context Manager (VPC Service Controls)/google_access_context_manager_service_perimeter/spec.egress_policies.egress_from.identities/config.tf
@@ -1,0 +1,11 @@
+##### DO NOT EDIT #####
+
+terraform {
+  required_providers {
+    google = {
+      source = "hashicorp/google"
+    }
+  }
+}
+
+provider "google" {}

--- a/inputs/gcp/Access Context Manager (VPC Service Controls)/google_access_context_manager_service_perimeter/spec.egress_policies.egress_from.identities/nonCompliant.tf
+++ b/inputs/gcp/Access Context Manager (VPC Service Controls)/google_access_context_manager_service_perimeter/spec.egress_policies.egress_from.identities/nonCompliant.tf
@@ -1,0 +1,19 @@
+resource "google_access_context_manager_service_perimeter" "non_compliant_example_1" {
+  parent = "accessPolicies/123456789"
+  name   = "non_compliant_egress_identities"
+  title  = "service_perimeter"
+
+  spec {
+    restricted_services = ["storage.googleapis.com"]
+
+    egress_policies {
+      egress_from {
+        identities = [
+          "*"
+        ]
+      }
+    }
+  }
+
+  use_explicit_dry_run_spec = true
+}

--- a/inputs/gcp/Access Context Manager (VPC Service Controls)/google_access_context_manager_service_perimeter/spec.egress_policies.egress_from.identity_type/compliant.tf
+++ b/inputs/gcp/Access Context Manager (VPC Service Controls)/google_access_context_manager_service_perimeter/spec.egress_policies.egress_from.identity_type/compliant.tf
@@ -1,0 +1,17 @@
+resource "google_access_context_manager_service_perimeter" "compliant_example_1" {
+  parent = "accessPolicies/123456789"
+  name   = "compliant_egress_identity_type"
+  title  = "service_perimeter"
+
+  spec {
+    restricted_services = ["storage.googleapis.com"]
+
+    egress_policies {
+      egress_from {
+        identity_type = "ANY_SERVICE_ACCOUNT"
+      }
+    }
+  }
+
+  use_explicit_dry_run_spec = true
+}

--- a/inputs/gcp/Access Context Manager (VPC Service Controls)/google_access_context_manager_service_perimeter/spec.egress_policies.egress_from.identity_type/config.tf
+++ b/inputs/gcp/Access Context Manager (VPC Service Controls)/google_access_context_manager_service_perimeter/spec.egress_policies.egress_from.identity_type/config.tf
@@ -1,0 +1,11 @@
+##### DO NOT EDIT #####
+
+terraform {
+  required_providers {
+    google = {
+      source = "hashicorp/google"
+    }
+  }
+}
+
+provider "google" {}

--- a/inputs/gcp/Access Context Manager (VPC Service Controls)/google_access_context_manager_service_perimeter/spec.egress_policies.egress_from.identity_type/nonCompliant.tf
+++ b/inputs/gcp/Access Context Manager (VPC Service Controls)/google_access_context_manager_service_perimeter/spec.egress_policies.egress_from.identity_type/nonCompliant.tf
@@ -1,0 +1,17 @@
+resource "google_access_context_manager_service_perimeter" "non_compliant_example_1" {
+  parent = "accessPolicies/123456789"
+  name   = "non_compliant_egress_identity_type"
+  title  = "service_perimeter"
+
+  spec {
+    restricted_services = ["storage.googleapis.com"]
+
+    egress_policies {
+      egress_from {
+        identity_type = "ANY_IDENTITY"
+      }
+    }
+  }
+
+  use_explicit_dry_run_spec = true
+}

--- a/inputs/gcp/Access Context Manager (VPC Service Controls)/google_access_context_manager_service_perimeter/spec.egress_policies.egress_from.source_restriction/compliant.tf
+++ b/inputs/gcp/Access Context Manager (VPC Service Controls)/google_access_context_manager_service_perimeter/spec.egress_policies.egress_from.source_restriction/compliant.tf
@@ -1,0 +1,17 @@
+resource "google_access_context_manager_service_perimeter" "compliant_example_1" {
+  parent = "accessPolicies/123456789"
+  name   = "compliant_source_restriction"
+  title  = "service_perimeter"
+
+  spec {
+    restricted_services = ["storage.googleapis.com"]
+
+    egress_policies {
+      egress_from {
+        source_restriction = "SOURCE_RESTRICTION_ENABLED"
+      }
+    }
+  }
+
+  use_explicit_dry_run_spec = true
+}

--- a/inputs/gcp/Access Context Manager (VPC Service Controls)/google_access_context_manager_service_perimeter/spec.egress_policies.egress_from.source_restriction/config.tf
+++ b/inputs/gcp/Access Context Manager (VPC Service Controls)/google_access_context_manager_service_perimeter/spec.egress_policies.egress_from.source_restriction/config.tf
@@ -1,0 +1,11 @@
+##### DO NOT EDIT #####
+
+terraform {
+  required_providers {
+    google = {
+      source = "hashicorp/google"
+    }
+  }
+}
+
+provider "google" {}

--- a/inputs/gcp/Access Context Manager (VPC Service Controls)/google_access_context_manager_service_perimeter/spec.egress_policies.egress_from.source_restriction/nonCompliant.tf
+++ b/inputs/gcp/Access Context Manager (VPC Service Controls)/google_access_context_manager_service_perimeter/spec.egress_policies.egress_from.source_restriction/nonCompliant.tf
@@ -1,0 +1,17 @@
+resource "google_access_context_manager_service_perimeter" "non_compliant_example_1" {
+  parent = "accessPolicies/123456789"
+  name   = "non_compliant_source_restriction"
+  title  = "service_perimeter"
+
+  spec {
+    restricted_services = ["storage.googleapis.com"]
+
+    egress_policies {
+      egress_from {
+        source_restriction = "SOURCE_RESTRICTION_DISABLED"
+      }
+    }
+  }
+
+  use_explicit_dry_run_spec = true
+}

--- a/inputs/gcp/Access Context Manager (VPC Service Controls)/google_access_context_manager_service_perimeter/spec.egress_policies.egress_to.operations.method_selectors.method/compliant.tf
+++ b/inputs/gcp/Access Context Manager (VPC Service Controls)/google_access_context_manager_service_perimeter/spec.egress_policies.egress_to.operations.method_selectors.method/compliant.tf
@@ -1,0 +1,23 @@
+resource "google_access_context_manager_service_perimeter" "compliant_example_1" {
+  parent = "accessPolicies/123456789"
+  name   = "compliant_egress_method"
+  title  = "service_perimeter"
+
+  spec {
+    restricted_services = ["storage.googleapis.com"]
+
+    egress_policies {
+      egress_to {
+        operations {
+          service_name = "storage.googleapis.com"
+
+          method_selectors {
+            method = "google.storage.objects.get"
+          }
+        }
+      }
+    }
+  }
+
+  use_explicit_dry_run_spec = true
+}

--- a/inputs/gcp/Access Context Manager (VPC Service Controls)/google_access_context_manager_service_perimeter/spec.egress_policies.egress_to.operations.method_selectors.method/config.tf
+++ b/inputs/gcp/Access Context Manager (VPC Service Controls)/google_access_context_manager_service_perimeter/spec.egress_policies.egress_to.operations.method_selectors.method/config.tf
@@ -1,0 +1,11 @@
+##### DO NOT EDIT #####
+
+terraform {
+  required_providers {
+    google = {
+      source = "hashicorp/google"
+    }
+  }
+}
+
+provider "google" {}

--- a/inputs/gcp/Access Context Manager (VPC Service Controls)/google_access_context_manager_service_perimeter/spec.egress_policies.egress_to.operations.method_selectors.method/nonCompliant.tf
+++ b/inputs/gcp/Access Context Manager (VPC Service Controls)/google_access_context_manager_service_perimeter/spec.egress_policies.egress_to.operations.method_selectors.method/nonCompliant.tf
@@ -1,0 +1,23 @@
+resource "google_access_context_manager_service_perimeter" "non_compliant_example_1" {
+  parent = "accessPolicies/123456789"
+  name   = "non_compliant_egress_method"
+  title  = "service_perimeter"
+
+  spec {
+    restricted_services = ["storage.googleapis.com"]
+
+    egress_policies {
+      egress_to {
+        operations {
+          service_name = "storage.googleapis.com"
+
+          method_selectors {
+            method = "*"
+          }
+        }
+      }
+    }
+  }
+
+  use_explicit_dry_run_spec = true
+}

--- a/inputs/gcp/Access Context Manager (VPC Service Controls)/google_access_context_manager_service_perimeter/spec.egress_policies.egress_to.operations.method_selectors.permission/compliant.tf
+++ b/inputs/gcp/Access Context Manager (VPC Service Controls)/google_access_context_manager_service_perimeter/spec.egress_policies.egress_to.operations.method_selectors.permission/compliant.tf
@@ -1,0 +1,23 @@
+resource "google_access_context_manager_service_perimeter" "compliant_example_1" {
+  parent = "accessPolicies/123456789"
+  name   = "compliant_egress_permission"
+  title  = "service_perimeter"
+
+  spec {
+    restricted_services = ["storage.googleapis.com"]
+
+    egress_policies {
+      egress_to {
+        operations {
+          service_name = "storage.googleapis.com"
+
+          method_selectors {
+            permission = "storage.objects.get"
+          }
+        }
+      }
+    }
+  }
+
+  use_explicit_dry_run_spec = true
+}

--- a/inputs/gcp/Access Context Manager (VPC Service Controls)/google_access_context_manager_service_perimeter/spec.egress_policies.egress_to.operations.method_selectors.permission/config.tf
+++ b/inputs/gcp/Access Context Manager (VPC Service Controls)/google_access_context_manager_service_perimeter/spec.egress_policies.egress_to.operations.method_selectors.permission/config.tf
@@ -1,0 +1,11 @@
+##### DO NOT EDIT #####
+
+terraform {
+  required_providers {
+    google = {
+      source = "hashicorp/google"
+    }
+  }
+}
+
+provider "google" {}

--- a/inputs/gcp/Access Context Manager (VPC Service Controls)/google_access_context_manager_service_perimeter/spec.egress_policies.egress_to.operations.method_selectors.permission/nonCompliant.tf
+++ b/inputs/gcp/Access Context Manager (VPC Service Controls)/google_access_context_manager_service_perimeter/spec.egress_policies.egress_to.operations.method_selectors.permission/nonCompliant.tf
@@ -1,0 +1,23 @@
+resource "google_access_context_manager_service_perimeter" "non_compliant_example_1" {
+  parent = "accessPolicies/123456789"
+  name   = "non_compliant_egress_permission"
+  title  = "service_perimeter"
+
+  spec {
+    restricted_services = ["storage.googleapis.com"]
+
+    egress_policies {
+      egress_to {
+        operations {
+          service_name = "storage.googleapis.com"
+
+          method_selectors {
+            permission = "*"
+          }
+        }
+      }
+    }
+  }
+
+  use_explicit_dry_run_spec = true
+}

--- a/inputs/gcp/Access Context Manager (VPC Service Controls)/google_access_context_manager_service_perimeter/spec.egress_policies.egress_to.operations.service_name/compliant.tf
+++ b/inputs/gcp/Access Context Manager (VPC Service Controls)/google_access_context_manager_service_perimeter/spec.egress_policies.egress_to.operations.service_name/compliant.tf
@@ -1,0 +1,19 @@
+resource "google_access_context_manager_service_perimeter" "compliant_example_1" {
+  parent = "accessPolicies/123456789"
+  name   = "compliant_egress_service_name"
+  title  = "service_perimeter"
+
+  spec {
+    restricted_services = ["storage.googleapis.com"]
+
+    egress_policies {
+      egress_to {
+        operations {
+          service_name = "storage.googleapis.com"
+        }
+      }
+    }
+  }
+
+  use_explicit_dry_run_spec = true
+}

--- a/inputs/gcp/Access Context Manager (VPC Service Controls)/google_access_context_manager_service_perimeter/spec.egress_policies.egress_to.operations.service_name/config.tf
+++ b/inputs/gcp/Access Context Manager (VPC Service Controls)/google_access_context_manager_service_perimeter/spec.egress_policies.egress_to.operations.service_name/config.tf
@@ -1,0 +1,11 @@
+##### DO NOT EDIT #####
+
+terraform {
+  required_providers {
+    google = {
+      source = "hashicorp/google"
+    }
+  }
+}
+
+provider "google" {}

--- a/inputs/gcp/Access Context Manager (VPC Service Controls)/google_access_context_manager_service_perimeter/spec.egress_policies.egress_to.operations.service_name/nonCompliant.tf
+++ b/inputs/gcp/Access Context Manager (VPC Service Controls)/google_access_context_manager_service_perimeter/spec.egress_policies.egress_to.operations.service_name/nonCompliant.tf
@@ -1,0 +1,19 @@
+resource "google_access_context_manager_service_perimeter" "non_compliant_example_1" {
+  parent = "accessPolicies/123456789"
+  name   = "non_compliant_egress_service_name"
+  title  = "service_perimeter"
+
+  spec {
+    restricted_services = ["storage.googleapis.com"]
+
+    egress_policies {
+      egress_to {
+        operations {
+          service_name = "*"
+        }
+      }
+    }
+  }
+
+  use_explicit_dry_run_spec = true
+}

--- a/inputs/gcp/Access Context Manager (VPC Service Controls)/google_access_context_manager_service_perimeter/spec.ingress_policies.ingress_from.identities/compliant.tf
+++ b/inputs/gcp/Access Context Manager (VPC Service Controls)/google_access_context_manager_service_perimeter/spec.ingress_policies.ingress_from.identities/compliant.tf
@@ -1,0 +1,19 @@
+resource "google_access_context_manager_service_perimeter" "compliant_example_1" {
+  parent = "accessPolicies/123456789"
+  name   = "compliant_ingress_identities"
+  title  = "service_perimeter"
+
+  spec {
+    restricted_services = ["storage.googleapis.com"]
+
+    ingress_policies {
+      ingress_from {
+        identities = [
+          "serviceAccount:app@example-project.iam.gserviceaccount.com"
+        ]
+      }
+    }
+  }
+
+  use_explicit_dry_run_spec = true
+}

--- a/inputs/gcp/Access Context Manager (VPC Service Controls)/google_access_context_manager_service_perimeter/spec.ingress_policies.ingress_from.identities/config.tf
+++ b/inputs/gcp/Access Context Manager (VPC Service Controls)/google_access_context_manager_service_perimeter/spec.ingress_policies.ingress_from.identities/config.tf
@@ -1,0 +1,11 @@
+##### DO NOT EDIT #####
+
+terraform {
+  required_providers {
+    google = {
+      source = "hashicorp/google"
+    }
+  }
+}
+
+provider "google" {}

--- a/inputs/gcp/Access Context Manager (VPC Service Controls)/google_access_context_manager_service_perimeter/spec.ingress_policies.ingress_from.identities/nonCompliant.tf
+++ b/inputs/gcp/Access Context Manager (VPC Service Controls)/google_access_context_manager_service_perimeter/spec.ingress_policies.ingress_from.identities/nonCompliant.tf
@@ -1,0 +1,19 @@
+resource "google_access_context_manager_service_perimeter" "non_compliant_example_1" {
+  parent = "accessPolicies/123456789"
+  name   = "non_compliant_ingress_identities"
+  title  = "service_perimeter"
+
+  spec {
+    restricted_services = ["storage.googleapis.com"]
+
+    ingress_policies {
+      ingress_from {
+        identities = [
+          "allUsers"
+        ]
+      }
+    }
+  }
+
+  use_explicit_dry_run_spec = true
+}

--- a/inputs/gcp/Access Context Manager (VPC Service Controls)/google_access_context_manager_service_perimeter/spec.ingress_policies.ingress_from.identity_type/compliant.tf
+++ b/inputs/gcp/Access Context Manager (VPC Service Controls)/google_access_context_manager_service_perimeter/spec.ingress_policies.ingress_from.identity_type/compliant.tf
@@ -1,0 +1,17 @@
+resource "google_access_context_manager_service_perimeter" "compliant_example_1" {
+  parent = "accessPolicies/123456789"
+  name   = "compliant_ingress_identity_type"
+  title  = "service_perimeter"
+
+  spec {
+    restricted_services = ["storage.googleapis.com"]
+
+    ingress_policies {
+      ingress_from {
+        identity_type = "ANY_SERVICE_ACCOUNT"
+      }
+    }
+  }
+
+  use_explicit_dry_run_spec = true
+}

--- a/inputs/gcp/Access Context Manager (VPC Service Controls)/google_access_context_manager_service_perimeter/spec.ingress_policies.ingress_from.identity_type/config.tf
+++ b/inputs/gcp/Access Context Manager (VPC Service Controls)/google_access_context_manager_service_perimeter/spec.ingress_policies.ingress_from.identity_type/config.tf
@@ -1,0 +1,11 @@
+##### DO NOT EDIT #####
+
+terraform {
+  required_providers {
+    google = {
+      source = "hashicorp/google"
+    }
+  }
+}
+
+provider "google" {}

--- a/inputs/gcp/Access Context Manager (VPC Service Controls)/google_access_context_manager_service_perimeter/spec.ingress_policies.ingress_from.identity_type/nonCompliant.tf
+++ b/inputs/gcp/Access Context Manager (VPC Service Controls)/google_access_context_manager_service_perimeter/spec.ingress_policies.ingress_from.identity_type/nonCompliant.tf
@@ -1,0 +1,17 @@
+resource "google_access_context_manager_service_perimeter" "non_compliant_example_1" {
+  parent = "accessPolicies/123456789"
+  name   = "non_compliant_ingress_identity_type"
+  title  = "service_perimeter"
+
+  spec {
+    restricted_services = ["storage.googleapis.com"]
+
+    ingress_policies {
+      ingress_from {
+        identity_type = "ANY_IDENTITY"
+      }
+    }
+  }
+
+  use_explicit_dry_run_spec = true
+}

--- a/inputs/gcp/Access Context Manager (VPC Service Controls)/google_access_context_manager_service_perimeter/spec.ingress_policies.ingress_from.sources.access_level/compliant.tf
+++ b/inputs/gcp/Access Context Manager (VPC Service Controls)/google_access_context_manager_service_perimeter/spec.ingress_policies.ingress_from.sources.access_level/compliant.tf
@@ -1,0 +1,19 @@
+resource "google_access_context_manager_service_perimeter" "compliant_example_1" {
+  parent = "accessPolicies/123456789"
+  name   = "compliant_ingress_access_level"
+  title  = "service_perimeter"
+
+  spec {
+    restricted_services = ["storage.googleapis.com"]
+
+    ingress_policies {
+      ingress_from {
+        sources {
+          access_level = "accessPolicies/123456789/accessLevels/restricted_access"
+        }
+      }
+    }
+  }
+
+  use_explicit_dry_run_spec = true
+}

--- a/inputs/gcp/Access Context Manager (VPC Service Controls)/google_access_context_manager_service_perimeter/spec.ingress_policies.ingress_from.sources.access_level/config.tf
+++ b/inputs/gcp/Access Context Manager (VPC Service Controls)/google_access_context_manager_service_perimeter/spec.ingress_policies.ingress_from.sources.access_level/config.tf
@@ -1,0 +1,11 @@
+##### DO NOT EDIT #####
+
+terraform {
+  required_providers {
+    google = {
+      source = "hashicorp/google"
+    }
+  }
+}
+
+provider "google" {}

--- a/inputs/gcp/Access Context Manager (VPC Service Controls)/google_access_context_manager_service_perimeter/spec.ingress_policies.ingress_from.sources.access_level/nonCompliant.tf
+++ b/inputs/gcp/Access Context Manager (VPC Service Controls)/google_access_context_manager_service_perimeter/spec.ingress_policies.ingress_from.sources.access_level/nonCompliant.tf
@@ -1,0 +1,19 @@
+resource "google_access_context_manager_service_perimeter" "non_compliant_example_1" {
+  parent = "accessPolicies/123456789"
+  name   = "non_compliant_ingress_access_level"
+  title  = "service_perimeter"
+
+  spec {
+    restricted_services = ["storage.googleapis.com"]
+
+    ingress_policies {
+      ingress_from {
+        sources {
+          access_level = "*"
+        }
+      }
+    }
+  }
+
+  use_explicit_dry_run_spec = true
+}

--- a/inputs/gcp/Access Context Manager (VPC Service Controls)/google_access_context_manager_service_perimeter/spec.ingress_policies.ingress_to.operations.method_selectors.method/compliant.tf
+++ b/inputs/gcp/Access Context Manager (VPC Service Controls)/google_access_context_manager_service_perimeter/spec.ingress_policies.ingress_to.operations.method_selectors.method/compliant.tf
@@ -1,0 +1,23 @@
+resource "google_access_context_manager_service_perimeter" "compliant_example_1" {
+  parent = "accessPolicies/123456789"
+  name   = "compliant_ingress_method"
+  title  = "service_perimeter"
+
+  spec {
+    restricted_services = ["storage.googleapis.com"]
+
+    ingress_policies {
+      ingress_to {
+        operations {
+          service_name = "storage.googleapis.com"
+
+          method_selectors {
+            method = "google.storage.objects.get"
+          }
+        }
+      }
+    }
+  }
+
+  use_explicit_dry_run_spec = true
+}

--- a/inputs/gcp/Access Context Manager (VPC Service Controls)/google_access_context_manager_service_perimeter/spec.ingress_policies.ingress_to.operations.method_selectors.method/config.tf
+++ b/inputs/gcp/Access Context Manager (VPC Service Controls)/google_access_context_manager_service_perimeter/spec.ingress_policies.ingress_to.operations.method_selectors.method/config.tf
@@ -1,0 +1,11 @@
+##### DO NOT EDIT #####
+
+terraform {
+  required_providers {
+    google = {
+      source = "hashicorp/google"
+    }
+  }
+}
+
+provider "google" {}

--- a/inputs/gcp/Access Context Manager (VPC Service Controls)/google_access_context_manager_service_perimeter/spec.ingress_policies.ingress_to.operations.method_selectors.method/nonCompliant.tf
+++ b/inputs/gcp/Access Context Manager (VPC Service Controls)/google_access_context_manager_service_perimeter/spec.ingress_policies.ingress_to.operations.method_selectors.method/nonCompliant.tf
@@ -1,0 +1,23 @@
+resource "google_access_context_manager_service_perimeter" "non_compliant_example_1" {
+  parent = "accessPolicies/123456789"
+  name   = "non_compliant_ingress_method"
+  title  = "service_perimeter"
+
+  spec {
+    restricted_services = ["storage.googleapis.com"]
+
+    ingress_policies {
+      ingress_to {
+        operations {
+          service_name = "storage.googleapis.com"
+
+          method_selectors {
+            method = "*"
+          }
+        }
+      }
+    }
+  }
+
+  use_explicit_dry_run_spec = true
+}

--- a/inputs/gcp/Access Context Manager (VPC Service Controls)/google_access_context_manager_service_perimeter/spec.ingress_policies.ingress_to.operations.method_selectors.permission/compliant.tf
+++ b/inputs/gcp/Access Context Manager (VPC Service Controls)/google_access_context_manager_service_perimeter/spec.ingress_policies.ingress_to.operations.method_selectors.permission/compliant.tf
@@ -1,0 +1,23 @@
+resource "google_access_context_manager_service_perimeter" "compliant_example_1" {
+  parent = "accessPolicies/123456789"
+  name   = "compliant_ingress_permission"
+  title  = "service_perimeter"
+
+  spec {
+    restricted_services = ["storage.googleapis.com"]
+
+    ingress_policies {
+      ingress_to {
+        operations {
+          service_name = "storage.googleapis.com"
+
+          method_selectors {
+            permission = "storage.objects.get"
+          }
+        }
+      }
+    }
+  }
+
+  use_explicit_dry_run_spec = true
+}

--- a/inputs/gcp/Access Context Manager (VPC Service Controls)/google_access_context_manager_service_perimeter/spec.ingress_policies.ingress_to.operations.method_selectors.permission/config.tf
+++ b/inputs/gcp/Access Context Manager (VPC Service Controls)/google_access_context_manager_service_perimeter/spec.ingress_policies.ingress_to.operations.method_selectors.permission/config.tf
@@ -1,0 +1,11 @@
+##### DO NOT EDIT #####
+
+terraform {
+  required_providers {
+    google = {
+      source = "hashicorp/google"
+    }
+  }
+}
+
+provider "google" {}

--- a/inputs/gcp/Access Context Manager (VPC Service Controls)/google_access_context_manager_service_perimeter/spec.ingress_policies.ingress_to.operations.method_selectors.permission/nonCompliant.tf
+++ b/inputs/gcp/Access Context Manager (VPC Service Controls)/google_access_context_manager_service_perimeter/spec.ingress_policies.ingress_to.operations.method_selectors.permission/nonCompliant.tf
@@ -1,0 +1,23 @@
+resource "google_access_context_manager_service_perimeter" "non_compliant_example_1" {
+  parent = "accessPolicies/123456789"
+  name   = "non_compliant_ingress_permission"
+  title  = "service_perimeter"
+
+  spec {
+    restricted_services = ["storage.googleapis.com"]
+
+    ingress_policies {
+      ingress_to {
+        operations {
+          service_name = "storage.googleapis.com"
+
+          method_selectors {
+            permission = "*"
+          }
+        }
+      }
+    }
+  }
+
+  use_explicit_dry_run_spec = true
+}

--- a/inputs/gcp/Access Context Manager (VPC Service Controls)/google_access_context_manager_service_perimeter/spec.ingress_policies.ingress_to.operations.service_name/compliant.tf
+++ b/inputs/gcp/Access Context Manager (VPC Service Controls)/google_access_context_manager_service_perimeter/spec.ingress_policies.ingress_to.operations.service_name/compliant.tf
@@ -1,0 +1,19 @@
+resource "google_access_context_manager_service_perimeter" "compliant_example_1" {
+  parent = "accessPolicies/123456789"
+  name   = "compliant_ingress_service_name"
+  title  = "service_perimeter"
+
+  spec {
+    restricted_services = ["storage.googleapis.com"]
+
+    ingress_policies {
+      ingress_to {
+        operations {
+          service_name = "storage.googleapis.com"
+        }
+      }
+    }
+  }
+
+  use_explicit_dry_run_spec = true
+}

--- a/inputs/gcp/Access Context Manager (VPC Service Controls)/google_access_context_manager_service_perimeter/spec.ingress_policies.ingress_to.operations.service_name/config.tf
+++ b/inputs/gcp/Access Context Manager (VPC Service Controls)/google_access_context_manager_service_perimeter/spec.ingress_policies.ingress_to.operations.service_name/config.tf
@@ -1,0 +1,11 @@
+##### DO NOT EDIT #####
+
+terraform {
+  required_providers {
+    google = {
+      source = "hashicorp/google"
+    }
+  }
+}
+
+provider "google" {}

--- a/inputs/gcp/Access Context Manager (VPC Service Controls)/google_access_context_manager_service_perimeter/spec.ingress_policies.ingress_to.operations.service_name/nonCompliant.tf
+++ b/inputs/gcp/Access Context Manager (VPC Service Controls)/google_access_context_manager_service_perimeter/spec.ingress_policies.ingress_to.operations.service_name/nonCompliant.tf
@@ -1,0 +1,19 @@
+resource "google_access_context_manager_service_perimeter" "non_compliant_example_1" {
+  parent = "accessPolicies/123456789"
+  name   = "non_compliant_ingress_service_name"
+  title  = "service_perimeter"
+
+  spec {
+    restricted_services = ["storage.googleapis.com"]
+
+    ingress_policies {
+      ingress_to {
+        operations {
+          service_name = "*"
+        }
+      }
+    }
+  }
+
+  use_explicit_dry_run_spec = true
+}

--- a/inputs/gcp/Access Context Manager (VPC Service Controls)/google_access_context_manager_service_perimeter/spec.ingress_policies.ingress_to.resources/compliant.tf
+++ b/inputs/gcp/Access Context Manager (VPC Service Controls)/google_access_context_manager_service_perimeter/spec.ingress_policies.ingress_to.resources/compliant.tf
@@ -1,0 +1,17 @@
+resource "google_access_context_manager_service_perimeter" "compliant_example_1" {
+  parent = "accessPolicies/123456789"
+  name   = "compliant_ingress_resources"
+  title  = "service_perimeter"
+
+  spec {
+    restricted_services = ["storage.googleapis.com"]
+
+    ingress_policies {
+      ingress_to {
+        resources = ["projects/123456789"]
+      }
+    }
+  }
+
+  use_explicit_dry_run_spec = true
+}

--- a/inputs/gcp/Access Context Manager (VPC Service Controls)/google_access_context_manager_service_perimeter/spec.ingress_policies.ingress_to.resources/config.tf
+++ b/inputs/gcp/Access Context Manager (VPC Service Controls)/google_access_context_manager_service_perimeter/spec.ingress_policies.ingress_to.resources/config.tf
@@ -1,0 +1,11 @@
+##### DO NOT EDIT #####
+
+terraform {
+  required_providers {
+    google = {
+      source = "hashicorp/google"
+    }
+  }
+}
+
+provider "google" {}

--- a/inputs/gcp/Access Context Manager (VPC Service Controls)/google_access_context_manager_service_perimeter/spec.ingress_policies.ingress_to.resources/nonCompliant.tf
+++ b/inputs/gcp/Access Context Manager (VPC Service Controls)/google_access_context_manager_service_perimeter/spec.ingress_policies.ingress_to.resources/nonCompliant.tf
@@ -1,0 +1,17 @@
+resource "google_access_context_manager_service_perimeter" "non_compliant_example_1" {
+  parent = "accessPolicies/123456789"
+  name   = "non_compliant_ingress_resources"
+  title  = "service_perimeter"
+
+  spec {
+    restricted_services = ["storage.googleapis.com"]
+
+    ingress_policies {
+      ingress_to {
+        resources = ["*"]
+      }
+    }
+  }
+
+  use_explicit_dry_run_spec = true
+}

--- a/inputs/gcp/Access Context Manager (VPC Service Controls)/google_access_context_manager_service_perimeter/spec.vpc_accessible_services.allowed_services/compliant.tf
+++ b/inputs/gcp/Access Context Manager (VPC Service Controls)/google_access_context_manager_service_perimeter/spec.vpc_accessible_services.allowed_services/compliant.tf
@@ -1,0 +1,16 @@
+resource "google_access_context_manager_service_perimeter" "compliant_example_1" {
+  parent = "accessPolicies/123456789"
+  name   = "compliant_allowed_services"
+  title  = "service_perimeter"
+
+  spec {
+    restricted_services = ["storage.googleapis.com"]
+
+    vpc_accessible_services {
+      enable_restriction = true
+      allowed_services   = ["storage.googleapis.com"]
+    }
+  }
+
+  use_explicit_dry_run_spec = true
+}

--- a/inputs/gcp/Access Context Manager (VPC Service Controls)/google_access_context_manager_service_perimeter/spec.vpc_accessible_services.allowed_services/config.tf
+++ b/inputs/gcp/Access Context Manager (VPC Service Controls)/google_access_context_manager_service_perimeter/spec.vpc_accessible_services.allowed_services/config.tf
@@ -1,0 +1,11 @@
+##### DO NOT EDIT #####
+
+terraform {
+  required_providers {
+    google = {
+      source = "hashicorp/google"
+    }
+  }
+}
+
+provider "google" {}

--- a/inputs/gcp/Access Context Manager (VPC Service Controls)/google_access_context_manager_service_perimeter/spec.vpc_accessible_services.allowed_services/nonCompliant.tf
+++ b/inputs/gcp/Access Context Manager (VPC Service Controls)/google_access_context_manager_service_perimeter/spec.vpc_accessible_services.allowed_services/nonCompliant.tf
@@ -1,0 +1,16 @@
+resource "google_access_context_manager_service_perimeter" "non_compliant_example_1" {
+  parent = "accessPolicies/123456789"
+  name   = "non_compliant_allowed_services"
+  title  = "service_perimeter"
+
+  spec {
+    restricted_services = ["storage.googleapis.com"]
+
+    vpc_accessible_services {
+      enable_restriction = true
+      allowed_services   = ["*"]
+    }
+  }
+
+  use_explicit_dry_run_spec = true
+}

--- a/inputs/gcp/Access Context Manager (VPC Service Controls)/google_access_context_manager_service_perimeter/spec.vpc_accessible_services.enable_restriction/compliant.tf
+++ b/inputs/gcp/Access Context Manager (VPC Service Controls)/google_access_context_manager_service_perimeter/spec.vpc_accessible_services.enable_restriction/compliant.tf
@@ -1,0 +1,15 @@
+resource "google_access_context_manager_service_perimeter" "compliant_example_1" {
+  parent = "accessPolicies/123456789"
+  name   = "accessPolicies/123456789/servicePerimeters/compliant_enable_restriction"
+  title  = "service_perimeter"
+
+  spec {
+    restricted_services = ["storage.googleapis.com"]
+
+    vpc_accessible_services {
+      enable_restriction = true
+    }
+  }
+
+  use_explicit_dry_run_spec = true
+}

--- a/inputs/gcp/Access Context Manager (VPC Service Controls)/google_access_context_manager_service_perimeter/spec.vpc_accessible_services.enable_restriction/config.tf
+++ b/inputs/gcp/Access Context Manager (VPC Service Controls)/google_access_context_manager_service_perimeter/spec.vpc_accessible_services.enable_restriction/config.tf
@@ -1,0 +1,11 @@
+##### DO NOT EDIT #####
+
+terraform {
+  required_providers {
+    google = {
+      source = "hashicorp/google"
+    }
+  }
+}
+
+provider "google" {}

--- a/inputs/gcp/Access Context Manager (VPC Service Controls)/google_access_context_manager_service_perimeter/spec.vpc_accessible_services.enable_restriction/nonCompliant.tf
+++ b/inputs/gcp/Access Context Manager (VPC Service Controls)/google_access_context_manager_service_perimeter/spec.vpc_accessible_services.enable_restriction/nonCompliant.tf
@@ -1,0 +1,15 @@
+resource "google_access_context_manager_service_perimeter" "non_compliant_example_1" {
+  parent = "accessPolicies/123456789"
+  name   = "accessPolicies/123456789/servicePerimeters/non_compliant_enable_restriction"
+  title  = "service_perimeter"
+
+  spec {
+    restricted_services = ["storage.googleapis.com"]
+
+    vpc_accessible_services {
+      enable_restriction = false
+    }
+  }
+
+  use_explicit_dry_run_spec = true
+}

--- a/inputs/gcp/Access Context Manager (VPC Service Controls)/google_access_context_manager_service_perimeter/status.access_levels/compliant.tf
+++ b/inputs/gcp/Access Context Manager (VPC Service Controls)/google_access_context_manager_service_perimeter/status.access_levels/compliant.tf
@@ -1,0 +1,11 @@
+resource "google_access_context_manager_service_perimeter" "compliant_example_1" {
+  parent = "accessPolicies/123456789"
+  name   = "accessPolicies/123456789/servicePerimeters/compliant_status_access_levels"
+  title  = "service_perimeter"
+
+  status {
+    access_levels = [
+      "accessPolicies/123456789/accessLevels/trusted_access"
+    ]
+  }
+}

--- a/inputs/gcp/Access Context Manager (VPC Service Controls)/google_access_context_manager_service_perimeter/status.access_levels/config.tf
+++ b/inputs/gcp/Access Context Manager (VPC Service Controls)/google_access_context_manager_service_perimeter/status.access_levels/config.tf
@@ -1,0 +1,11 @@
+##### DO NOT EDIT #####
+
+terraform {
+  required_providers {
+    google = {
+      source = "hashicorp/google"
+    }
+  }
+}
+
+provider "google" {}

--- a/inputs/gcp/Access Context Manager (VPC Service Controls)/google_access_context_manager_service_perimeter/status.access_levels/nonCompliant.tf
+++ b/inputs/gcp/Access Context Manager (VPC Service Controls)/google_access_context_manager_service_perimeter/status.access_levels/nonCompliant.tf
@@ -1,0 +1,9 @@
+resource "google_access_context_manager_service_perimeter" "non_compliant_example_1" {
+  parent = "accessPolicies/123456789"
+  name   = "accessPolicies/123456789/servicePerimeters/non_compliant_status_access_levels"
+  title  = "service_perimeter"
+
+  status {
+    access_levels = []
+  }
+}

--- a/inputs/gcp/Access Context Manager (VPC Service Controls)/google_access_context_manager_service_perimeter/status.egress_policies.egress_from.identities/compliant.tf
+++ b/inputs/gcp/Access Context Manager (VPC Service Controls)/google_access_context_manager_service_perimeter/status.egress_policies.egress_from.identities/compliant.tf
@@ -1,0 +1,27 @@
+resource "google_access_context_manager_service_perimeter" "compliant_example_1" {
+  parent = "accessPolicies/123456789"
+  name   = "accessPolicies/123456789/servicePerimeters/compliant_status_egress_identities"
+  title  = "service_perimeter"
+
+  status {
+    restricted_services = ["storage.googleapis.com"]
+
+    egress_policies {
+      egress_from {
+        identity_type = "ANY_SERVICE_ACCOUNT"
+
+        identities = [
+          "serviceAccount:approved@example-project.iam.gserviceaccount.com"
+        ]
+      }
+
+      egress_to {
+        resources = ["projects/123456789"]
+
+        operations {
+          service_name = "storage.googleapis.com"
+        }
+      }
+    }
+  }
+}

--- a/inputs/gcp/Access Context Manager (VPC Service Controls)/google_access_context_manager_service_perimeter/status.egress_policies.egress_from.identities/config.tf
+++ b/inputs/gcp/Access Context Manager (VPC Service Controls)/google_access_context_manager_service_perimeter/status.egress_policies.egress_from.identities/config.tf
@@ -1,0 +1,11 @@
+##### DO NOT EDIT #####
+
+terraform {
+  required_providers {
+    google = {
+      source = "hashicorp/google"
+    }
+  }
+}
+
+provider "google" {}

--- a/inputs/gcp/Access Context Manager (VPC Service Controls)/google_access_context_manager_service_perimeter/status.egress_policies.egress_from.identities/nonCompliant.tf
+++ b/inputs/gcp/Access Context Manager (VPC Service Controls)/google_access_context_manager_service_perimeter/status.egress_policies.egress_from.identities/nonCompliant.tf
@@ -1,0 +1,24 @@
+resource "google_access_context_manager_service_perimeter" "non_compliant_example_1" {
+  parent = "accessPolicies/123456789"
+  name   = "accessPolicies/123456789/servicePerimeters/non_compliant_status_egress_identities"
+  title  = "service_perimeter"
+
+  status {
+    restricted_services = ["storage.googleapis.com"]
+
+    egress_policies {
+      egress_from {
+        identity_type = "ANY_SERVICE_ACCOUNT"
+        identities    = ["*"]
+      }
+
+      egress_to {
+        resources = ["projects/123456789"]
+
+        operations {
+          service_name = "storage.googleapis.com"
+        }
+      }
+    }
+  }
+}

--- a/inputs/gcp/Access Context Manager (VPC Service Controls)/google_access_context_manager_service_perimeter/status.egress_policies.egress_from.identity_type/compliant.tf
+++ b/inputs/gcp/Access Context Manager (VPC Service Controls)/google_access_context_manager_service_perimeter/status.egress_policies.egress_from.identity_type/compliant.tf
@@ -1,0 +1,15 @@
+resource "google_access_context_manager_service_perimeter" "compliant_example_1" {
+  parent = "accessPolicies/123456789"
+  name   = "accessPolicies/123456789/servicePerimeters/compliant_status_egress_identity_type"
+  title  = "service_perimeter"
+
+  status {
+    restricted_services = ["storage.googleapis.com"]
+
+    egress_policies {
+      egress_from {
+        identity_type = "ANY_SERVICE_ACCOUNT"
+      }
+    }
+  }
+}

--- a/inputs/gcp/Access Context Manager (VPC Service Controls)/google_access_context_manager_service_perimeter/status.egress_policies.egress_from.identity_type/config.tf
+++ b/inputs/gcp/Access Context Manager (VPC Service Controls)/google_access_context_manager_service_perimeter/status.egress_policies.egress_from.identity_type/config.tf
@@ -1,0 +1,11 @@
+##### DO NOT EDIT #####
+
+terraform {
+  required_providers {
+    google = {
+      source = "hashicorp/google"
+    }
+  }
+}
+
+provider "google" {}

--- a/inputs/gcp/Access Context Manager (VPC Service Controls)/google_access_context_manager_service_perimeter/status.egress_policies.egress_from.identity_type/nonCompliant.tf
+++ b/inputs/gcp/Access Context Manager (VPC Service Controls)/google_access_context_manager_service_perimeter/status.egress_policies.egress_from.identity_type/nonCompliant.tf
@@ -1,0 +1,15 @@
+resource "google_access_context_manager_service_perimeter" "non_compliant_example_1" {
+  parent = "accessPolicies/123456789"
+  name   = "accessPolicies/123456789/servicePerimeters/non_compliant_status_egress_identity_type"
+  title  = "service_perimeter"
+
+  status {
+    restricted_services = ["storage.googleapis.com"]
+
+    egress_policies {
+      egress_from {
+        identity_type = "ANY_IDENTITY"
+      }
+    }
+  }
+}

--- a/inputs/gcp/Access Context Manager (VPC Service Controls)/google_access_context_manager_service_perimeter/status.egress_policies.egress_from.source_restriction/compliant.tf
+++ b/inputs/gcp/Access Context Manager (VPC Service Controls)/google_access_context_manager_service_perimeter/status.egress_policies.egress_from.source_restriction/compliant.tf
@@ -1,0 +1,15 @@
+resource "google_access_context_manager_service_perimeter" "compliant_example_1" {
+  parent = "accessPolicies/123456789"
+  name   = "accessPolicies/123456789/servicePerimeters/compliant_status_egress_source_restriction"
+  title  = "service_perimeter"
+
+  status {
+    restricted_services = ["storage.googleapis.com"]
+
+    egress_policies {
+      egress_from {
+        source_restriction = "SOURCE_RESTRICTION_ENABLED"
+      }
+    }
+  }
+}

--- a/inputs/gcp/Access Context Manager (VPC Service Controls)/google_access_context_manager_service_perimeter/status.egress_policies.egress_from.source_restriction/config.tf
+++ b/inputs/gcp/Access Context Manager (VPC Service Controls)/google_access_context_manager_service_perimeter/status.egress_policies.egress_from.source_restriction/config.tf
@@ -1,0 +1,11 @@
+##### DO NOT EDIT #####
+
+terraform {
+  required_providers {
+    google = {
+      source = "hashicorp/google"
+    }
+  }
+}
+
+provider "google" {}

--- a/inputs/gcp/Access Context Manager (VPC Service Controls)/google_access_context_manager_service_perimeter/status.egress_policies.egress_from.source_restriction/nonCompliant.tf
+++ b/inputs/gcp/Access Context Manager (VPC Service Controls)/google_access_context_manager_service_perimeter/status.egress_policies.egress_from.source_restriction/nonCompliant.tf
@@ -1,0 +1,15 @@
+resource "google_access_context_manager_service_perimeter" "non_compliant_example_1" {
+  parent = "accessPolicies/123456789"
+  name   = "accessPolicies/123456789/servicePerimeters/non_compliant_status_egress_source_restriction"
+  title  = "service_perimeter"
+
+  status {
+    restricted_services = ["storage.googleapis.com"]
+
+    egress_policies {
+      egress_from {
+        source_restriction = "SOURCE_RESTRICTION_DISABLED"
+      }
+    }
+  }
+}

--- a/inputs/gcp/Access Context Manager (VPC Service Controls)/google_access_context_manager_service_perimeter/status.ingress_policies.ingress_from.identities/compliant.tf
+++ b/inputs/gcp/Access Context Manager (VPC Service Controls)/google_access_context_manager_service_perimeter/status.ingress_policies.ingress_from.identities/compliant.tf
@@ -1,0 +1,17 @@
+resource "google_access_context_manager_service_perimeter" "compliant_example_1" {
+  parent = "accessPolicies/123456789"
+  name   = "accessPolicies/123456789/servicePerimeters/compliant_status_ingress_identities"
+  title  = "service_perimeter"
+
+  status {
+    restricted_services = ["storage.googleapis.com"]
+
+    ingress_policies {
+      ingress_from {
+        identities = [
+          "serviceAccount:approved@example-project.iam.gserviceaccount.com"
+        ]
+      }
+    }
+  }
+}

--- a/inputs/gcp/Access Context Manager (VPC Service Controls)/google_access_context_manager_service_perimeter/status.ingress_policies.ingress_from.identities/config.tf
+++ b/inputs/gcp/Access Context Manager (VPC Service Controls)/google_access_context_manager_service_perimeter/status.ingress_policies.ingress_from.identities/config.tf
@@ -1,0 +1,11 @@
+##### DO NOT EDIT #####
+
+terraform {
+  required_providers {
+    google = {
+      source = "hashicorp/google"
+    }
+  }
+}
+
+provider "google" {}

--- a/inputs/gcp/Access Context Manager (VPC Service Controls)/google_access_context_manager_service_perimeter/status.ingress_policies.ingress_from.identities/nonCompliant.tf
+++ b/inputs/gcp/Access Context Manager (VPC Service Controls)/google_access_context_manager_service_perimeter/status.ingress_policies.ingress_from.identities/nonCompliant.tf
@@ -1,0 +1,17 @@
+resource "google_access_context_manager_service_perimeter" "non_compliant_example_1" {
+  parent = "accessPolicies/123456789"
+  name   = "accessPolicies/123456789/servicePerimeters/non_compliant_status_ingress_identities"
+  title  = "service_perimeter"
+
+  status {
+    restricted_services = ["storage.googleapis.com"]
+
+    ingress_policies {
+      ingress_from {
+        identities = [
+          "allUsers"
+        ]
+      }
+    }
+  }
+}

--- a/inputs/gcp/Access Context Manager (VPC Service Controls)/google_access_context_manager_service_perimeter/status.ingress_policies.ingress_from.identity_type/compliant.tf
+++ b/inputs/gcp/Access Context Manager (VPC Service Controls)/google_access_context_manager_service_perimeter/status.ingress_policies.ingress_from.identity_type/compliant.tf
@@ -1,0 +1,15 @@
+resource "google_access_context_manager_service_perimeter" "compliant_example_1" {
+  parent = "accessPolicies/123456789"
+  name   = "accessPolicies/123456789/servicePerimeters/compliant_status_ingress_identity_type"
+  title  = "service_perimeter"
+
+  status {
+    restricted_services = ["storage.googleapis.com"]
+
+    ingress_policies {
+      ingress_from {
+        identity_type = "ANY_SERVICE_ACCOUNT"
+      }
+    }
+  }
+}

--- a/inputs/gcp/Access Context Manager (VPC Service Controls)/google_access_context_manager_service_perimeter/status.ingress_policies.ingress_from.identity_type/config.tf
+++ b/inputs/gcp/Access Context Manager (VPC Service Controls)/google_access_context_manager_service_perimeter/status.ingress_policies.ingress_from.identity_type/config.tf
@@ -1,0 +1,11 @@
+##### DO NOT EDIT #####
+
+terraform {
+  required_providers {
+    google = {
+      source = "hashicorp/google"
+    }
+  }
+}
+
+provider "google" {}

--- a/inputs/gcp/Access Context Manager (VPC Service Controls)/google_access_context_manager_service_perimeter/status.ingress_policies.ingress_from.identity_type/nonCompliant.tf
+++ b/inputs/gcp/Access Context Manager (VPC Service Controls)/google_access_context_manager_service_perimeter/status.ingress_policies.ingress_from.identity_type/nonCompliant.tf
@@ -1,0 +1,15 @@
+resource "google_access_context_manager_service_perimeter" "non_compliant_example_1" {
+  parent = "accessPolicies/123456789"
+  name   = "accessPolicies/123456789/servicePerimeters/non_compliant_status_ingress_identity_type"
+  title  = "service_perimeter"
+
+  status {
+    restricted_services = ["storage.googleapis.com"]
+
+    ingress_policies {
+      ingress_from {
+        identity_type = "ANY_IDENTITY"
+      }
+    }
+  }
+}

--- a/inputs/gcp/Access Context Manager (VPC Service Controls)/google_access_context_manager_service_perimeter/status.vpc_accessible_services.enable_restriction/compliant.tf
+++ b/inputs/gcp/Access Context Manager (VPC Service Controls)/google_access_context_manager_service_perimeter/status.vpc_accessible_services.enable_restriction/compliant.tf
@@ -1,0 +1,13 @@
+resource "google_access_context_manager_service_perimeter" "compliant_example_1" {
+  parent = "accessPolicies/123456789"
+  name   = "accessPolicies/123456789/servicePerimeters/compliant_status_vpc_enable_restriction"
+  title  = "service_perimeter"
+
+  status {
+    restricted_services = ["storage.googleapis.com"]
+
+    vpc_accessible_services {
+      enable_restriction = true
+    }
+  }
+}

--- a/inputs/gcp/Access Context Manager (VPC Service Controls)/google_access_context_manager_service_perimeter/status.vpc_accessible_services.enable_restriction/config.tf
+++ b/inputs/gcp/Access Context Manager (VPC Service Controls)/google_access_context_manager_service_perimeter/status.vpc_accessible_services.enable_restriction/config.tf
@@ -1,0 +1,11 @@
+##### DO NOT EDIT #####
+
+terraform {
+  required_providers {
+    google = {
+      source = "hashicorp/google"
+    }
+  }
+}
+
+provider "google" {}

--- a/inputs/gcp/Access Context Manager (VPC Service Controls)/google_access_context_manager_service_perimeter/status.vpc_accessible_services.enable_restriction/nonCompliant.tf
+++ b/inputs/gcp/Access Context Manager (VPC Service Controls)/google_access_context_manager_service_perimeter/status.vpc_accessible_services.enable_restriction/nonCompliant.tf
@@ -1,0 +1,13 @@
+resource "google_access_context_manager_service_perimeter" "non_compliant_example_1" {
+  parent = "accessPolicies/123456789"
+  name   = "accessPolicies/123456789/servicePerimeters/non_compliant_status_vpc_enable_restriction"
+  title  = "service_perimeter"
+
+  status {
+    restricted_services = ["storage.googleapis.com"]
+
+    vpc_accessible_services {
+      enable_restriction = false
+    }
+  }
+}

--- a/policies/gcp/Access Context Manager (VPC Service Controls)/google_access_context_manager_service_perimeter/_vars.rego
+++ b/policies/gcp/Access Context Manager (VPC Service Controls)/google_access_context_manager_service_perimeter/_vars.rego
@@ -1,8 +1,7 @@
 package terraform.gcp.security.access_context_manager_vpc_service_controls.google_access_context_manager_service_perimeter.vars
 
-
 variables := {
-    "friendly_resource_name": "service_perimeter", 
-    "resource_type":  "google_access_context_manager_service_perimeter", 
-    "resource_value_name" : "name" 
+    "friendly_resource_name": "Access Context Manager Service Perimeter",
+    "resource_type": "google_access_context_manager_service_perimeter",
+    "resource_value_name": "name"
 }

--- a/policies/gcp/Access Context Manager (VPC Service Controls)/google_access_context_manager_service_perimeter/deletion_policy.rego
+++ b/policies/gcp/Access Context Manager (VPC Service Controls)/google_access_context_manager_service_perimeter/deletion_policy.rego
@@ -1,0 +1,22 @@
+package terraform.gcp.security.access_context_manager_vpc_service_controls.google_access_context_manager_service_perimeter.deletion_policy
+
+import data.terraform.helpers as helpers
+import data.terraform.gcp.security.access_context_manager_vpc_service_controls.google_access_context_manager_service_perimeter.vars as vars
+
+conditions := [[
+  {
+    "situation_description": "Service Perimeter must be protected from accidental or unauthorized deletion.",
+    "remedies": ["Set deletion_policy = PREVENT."],
+  },
+  {
+    "condition": "deletion_policy must be PREVENT.",
+    "attribute_path": ["deletion_policy"],
+    "values": ["PREVENT"],
+    "policy_type": "whitelist",
+  },
+]]
+
+summary := helpers.get_multi_summary(conditions, vars.variables)
+
+message := summary.message
+details := summary.details

--- a/policies/gcp/Access Context Manager (VPC Service Controls)/google_access_context_manager_service_perimeter/perimeter_type.rego
+++ b/policies/gcp/Access Context Manager (VPC Service Controls)/google_access_context_manager_service_perimeter/perimeter_type.rego
@@ -1,0 +1,22 @@
+package terraform.gcp.security.access_context_manager_vpc_service_controls.google_access_context_manager_service_perimeter.perimeter_type
+
+import data.terraform.helpers as helpers
+import data.terraform.gcp.security.access_context_manager_vpc_service_controls.google_access_context_manager_service_perimeter.vars as vars
+
+conditions := [[
+  {
+    "situation_description": "Service Perimeter should use the regular perimeter type to enforce access restrictions.",
+    "remedies": ["Set perimeter_type = PERIMETER_TYPE_REGULAR."],
+  },
+  {
+    "condition": "perimeter_type must be PERIMETER_TYPE_REGULAR.",
+    "attribute_path": ["perimeter_type"],
+    "values": ["PERIMETER_TYPE_REGULAR"],
+    "policy_type": "whitelist",
+  },
+]]
+
+summary := helpers.get_multi_summary(conditions, vars.variables)
+
+message := summary.message
+details := summary.details

--- a/policies/gcp/Access Context Manager (VPC Service Controls)/google_access_context_manager_service_perimeter/spec.egress_policies.egress_from.identities.rego
+++ b/policies/gcp/Access Context Manager (VPC Service Controls)/google_access_context_manager_service_perimeter/spec.egress_policies.egress_from.identities.rego
@@ -1,0 +1,22 @@
+package terraform.gcp.security.access_context_manager_vpc_service_controls.google_access_context_manager_service_perimeter.spec_egress_policies_egress_from_identities
+
+import data.terraform.helpers as helpers
+import data.terraform.gcp.security.access_context_manager_vpc_service_controls.google_access_context_manager_service_perimeter.vars as vars
+
+conditions := [[
+  {
+    "situation_description": "Egress access should be restricted to explicitly scoped identities.",
+    "remedies": ["Configure spec.egress_policies.egress_from.identities with specific service account identities instead of wildcard or public principals."],
+  },
+  {
+    "condition": "Each egress identity must not be a wildcard or public principal.",
+    "attribute_path": ["spec", 0, "egress_policies", 0, "egress_from", 0, "identities"],
+    "values": ["*", "allUsers", "allAuthenticatedUsers"],
+    "policy_type": "element blacklist",
+  },
+]]
+
+summary := helpers.get_multi_summary(conditions, vars.variables)
+
+message := summary.message
+details := summary.details

--- a/policies/gcp/Access Context Manager (VPC Service Controls)/google_access_context_manager_service_perimeter/spec.egress_policies.egress_from.identity_type.rego
+++ b/policies/gcp/Access Context Manager (VPC Service Controls)/google_access_context_manager_service_perimeter/spec.egress_policies.egress_from.identity_type.rego
@@ -1,0 +1,22 @@
+package terraform.gcp.security.access_context_manager_vpc_service_controls.google_access_context_manager_service_perimeter.spec_egress_policies_egress_from_identity_type
+
+import data.terraform.helpers as helpers
+import data.terraform.gcp.security.access_context_manager_vpc_service_controls.google_access_context_manager_service_perimeter.vars
+
+conditions := [[
+    {
+        "situation_description": "Egress access should prevent overly permissive identity types while allowing valid identity configurations.",
+        "remedies": ["Configure spec.egress_policies.egress_from.identity_type to use an appropriate identity type and avoid ANY_IDENTITY."],
+    },
+    {
+        "condition": "Egress identity type must not allow the overly permissive ANY_IDENTITY value.",
+        "attribute_path": ["spec", 0, "egress_policies", 0, "egress_from", 0, "identity_type"],
+        "values": ["ANY_IDENTITY"],
+        "policy_type": "blacklist",
+    },
+]]
+
+summary := helpers.get_multi_summary(conditions, vars.variables)
+
+message := summary.message
+details := summary.details

--- a/policies/gcp/Access Context Manager (VPC Service Controls)/google_access_context_manager_service_perimeter/spec.egress_policies.egress_from.source_restriction.rego
+++ b/policies/gcp/Access Context Manager (VPC Service Controls)/google_access_context_manager_service_perimeter/spec.egress_policies.egress_from.source_restriction.rego
@@ -1,0 +1,22 @@
+package terraform.gcp.security.access_context_manager_vpc_service_controls.google_access_context_manager_service_perimeter.spec_egress_policies_egress_from_source_restriction
+
+import data.terraform.helpers as helpers
+import data.terraform.gcp.security.access_context_manager_vpc_service_controls.google_access_context_manager_service_perimeter.vars as vars
+
+conditions := [[
+  {
+    "situation_description": "Egress source-based traffic restrictions should be enabled.",
+    "remedies": ["Set spec.egress_policies.egress_from.source_restriction to SOURCE_RESTRICTION_ENABLED."],
+  },
+  {
+    "condition": "Egress source restriction must be enabled.",
+    "attribute_path": ["spec", 0, "egress_policies", 0, "egress_from", 0, "source_restriction"],
+    "values": ["SOURCE_RESTRICTION_ENABLED"],
+    "policy_type": "whitelist",
+  },
+]]
+
+summary := helpers.get_multi_summary(conditions, vars.variables)
+
+message := summary.message
+details := summary.details

--- a/policies/gcp/Access Context Manager (VPC Service Controls)/google_access_context_manager_service_perimeter/spec.egress_policies.egress_to.operations.method_selectors.method.rego
+++ b/policies/gcp/Access Context Manager (VPC Service Controls)/google_access_context_manager_service_perimeter/spec.egress_policies.egress_to.operations.method_selectors.method.rego
@@ -1,0 +1,22 @@
+package terraform.gcp.security.access_context_manager_vpc_service_controls.google_access_context_manager_service_perimeter.spec_egress_policies_egress_to_operations_method_selectors_method
+
+import data.terraform.helpers as helpers
+import data.terraform.gcp.security.access_context_manager_vpc_service_controls.google_access_context_manager_service_perimeter.vars as vars
+
+conditions := [[
+  {
+    "situation_description": "Egress operations should use explicitly selected API methods instead of allowing all methods.",
+    "remedies": ["Configure spec.egress_policies.egress_to.operations.method_selectors.method with an explicit method instead of '*'."],
+  },
+  {
+    "condition": "Egress method selector must not allow all methods.",
+    "attribute_path": ["spec", 0, "egress_policies", 0, "egress_to", 0, "operations", 0, "method_selectors", 0, "method"],
+    "values": ["*"],
+    "policy_type": "blacklist",
+  },
+]]
+
+summary := helpers.get_multi_summary(conditions, vars.variables)
+
+message := summary.message
+details := summary.details

--- a/policies/gcp/Access Context Manager (VPC Service Controls)/google_access_context_manager_service_perimeter/spec.egress_policies.egress_to.operations.method_selectors.permission.rego
+++ b/policies/gcp/Access Context Manager (VPC Service Controls)/google_access_context_manager_service_perimeter/spec.egress_policies.egress_to.operations.method_selectors.permission.rego
@@ -1,0 +1,22 @@
+package terraform.gcp.security.access_context_manager_vpc_service_controls.google_access_context_manager_service_perimeter.spec_egress_policies_egress_to_operations_method_selectors_permission
+
+import data.terraform.helpers as helpers
+import data.terraform.gcp.security.access_context_manager_vpc_service_controls.google_access_context_manager_service_perimeter.vars as vars
+
+conditions := [[
+  {
+    "situation_description": "Egress operations should use explicitly selected IAM permissions instead of overly broad permissions.",
+    "remedies": ["Configure spec.egress_policies.egress_to.operations.method_selectors.permission with an explicit IAM permission instead of '*'."],
+  },
+  {
+    "condition": "Egress permission selector must not allow all permissions.",
+    "attribute_path": ["spec", 0, "egress_policies", 0, "egress_to", 0, "operations", 0, "method_selectors", 0, "permission"],
+    "values": ["*"],
+    "policy_type": "blacklist",
+  },
+]]
+
+summary := helpers.get_multi_summary(conditions, vars.variables)
+
+message := summary.message
+details := summary.details

--- a/policies/gcp/Access Context Manager (VPC Service Controls)/google_access_context_manager_service_perimeter/spec.egress_policies.egress_to.operations.service_name.rego
+++ b/policies/gcp/Access Context Manager (VPC Service Controls)/google_access_context_manager_service_perimeter/spec.egress_policies.egress_to.operations.service_name.rego
@@ -1,0 +1,22 @@
+package terraform.gcp.security.access_context_manager_vpc_service_controls.google_access_context_manager_service_perimeter.spec_egress_policies_egress_to_operations_service_name
+
+import data.terraform.helpers as helpers
+import data.terraform.gcp.security.access_context_manager_vpc_service_controls.google_access_context_manager_service_perimeter.vars as vars
+
+conditions := [[
+  {
+    "situation_description": "Egress operations should use explicitly selected service names instead of allowing all services.",
+    "remedies": ["Configure spec.egress_policies.egress_to.operations.service_name with an explicit service name instead of '*'."],
+  },
+  {
+    "condition": "Egress service name must not allow all services.",
+    "attribute_path": ["spec", 0, "egress_policies", 0, "egress_to", 0, "operations", 0, "service_name"],
+    "values": ["*"],
+    "policy_type": "blacklist",
+  },
+]]
+
+summary := helpers.get_multi_summary(conditions, vars.variables)
+
+message := summary.message
+details := summary.details

--- a/policies/gcp/Access Context Manager (VPC Service Controls)/google_access_context_manager_service_perimeter/spec.ingress_policies.ingress_from.identities.rego
+++ b/policies/gcp/Access Context Manager (VPC Service Controls)/google_access_context_manager_service_perimeter/spec.ingress_policies.ingress_from.identities.rego
@@ -1,0 +1,22 @@
+package terraform.gcp.security.access_context_manager_vpc_service_controls.google_access_context_manager_service_perimeter.spec_ingress_policies_ingress_from_identities
+
+import data.terraform.helpers as helpers
+import data.terraform.gcp.security.access_context_manager_vpc_service_controls.google_access_context_manager_service_perimeter.vars as vars
+
+conditions := [[
+  {
+    "situation_description": "Ingress policies should allow only explicitly specified users or service accounts.",
+    "remedies": ["Configure spec.ingress_policies.ingress_from.identities with specific user or service account identities instead of wildcard or public principals."],
+  },
+  {
+    "condition": "Each ingress identity must not be a wildcard or public principal.",
+    "attribute_path": ["spec", 0, "ingress_policies", 0, "ingress_from", 0, "identities"],
+    "values": ["*", "allUsers", "allAuthenticatedUsers"],
+    "policy_type": "element blacklist",
+  },
+]]
+
+summary := helpers.get_multi_summary(conditions, vars.variables)
+
+message := summary.message
+details := summary.details

--- a/policies/gcp/Access Context Manager (VPC Service Controls)/google_access_context_manager_service_perimeter/spec.ingress_policies.ingress_from.identity_type.rego
+++ b/policies/gcp/Access Context Manager (VPC Service Controls)/google_access_context_manager_service_perimeter/spec.ingress_policies.ingress_from.identity_type.rego
@@ -1,0 +1,22 @@
+package terraform.gcp.security.access_context_manager_vpc_service_controls.google_access_context_manager_service_perimeter.spec_ingress_policies_ingress_from_identity_type
+
+import data.terraform.helpers as helpers
+import data.terraform.gcp.security.access_context_manager_vpc_service_controls.google_access_context_manager_service_perimeter.vars as vars
+
+conditions := [[
+  {
+    "situation_description": "Ingress policies should use appropriately scoped identity types instead of allowing any identity.",
+    "remedies": ["Configure spec.ingress_policies.ingress_from.identity_type with a scoped identity type instead of ANY_IDENTITY."],
+  },
+  {
+    "condition": "Ingress identity type must not allow any identity.",
+    "attribute_path": ["spec", 0, "ingress_policies", 0, "ingress_from", 0, "identity_type"],
+    "values": ["ANY_IDENTITY"],
+    "policy_type": "blacklist",
+  },
+]]
+
+summary := helpers.get_multi_summary(conditions, vars.variables)
+
+message := summary.message
+details := summary.details

--- a/policies/gcp/Access Context Manager (VPC Service Controls)/google_access_context_manager_service_perimeter/spec.ingress_policies.ingress_from.sources.access_level.rego
+++ b/policies/gcp/Access Context Manager (VPC Service Controls)/google_access_context_manager_service_perimeter/spec.ingress_policies.ingress_from.sources.access_level.rego
@@ -1,0 +1,22 @@
+package terraform.gcp.security.access_context_manager_vpc_service_controls.google_access_context_manager_service_perimeter.spec_ingress_policies_ingress_from_sources_access_level
+
+import data.terraform.helpers as helpers
+import data.terraform.gcp.security.access_context_manager_vpc_service_controls.google_access_context_manager_service_perimeter.vars as vars
+
+conditions := [[
+  {
+    "situation_description": "Ingress sources should use explicitly constrained access levels instead of allowing all ingress sources.",
+    "remedies": ["Configure spec.ingress_policies.ingress_from.sources.access_level with a specific AccessLevel instead of '*'."],
+  },
+  {
+    "condition": "Ingress source access level must not allow all ingress sources.",
+    "attribute_path": ["spec", 0, "ingress_policies", 0, "ingress_from", 0, "sources", 0, "access_level"],
+    "values": ["*"],
+    "policy_type": "blacklist",
+  },
+]]
+
+summary := helpers.get_multi_summary(conditions, vars.variables)
+
+message := summary.message
+details := summary.details

--- a/policies/gcp/Access Context Manager (VPC Service Controls)/google_access_context_manager_service_perimeter/spec.ingress_policies.ingress_to.operations.method_selectors.method.rego
+++ b/policies/gcp/Access Context Manager (VPC Service Controls)/google_access_context_manager_service_perimeter/spec.ingress_policies.ingress_to.operations.method_selectors.method.rego
@@ -1,0 +1,22 @@
+package terraform.gcp.security.access_context_manager_vpc_service_controls.google_access_context_manager_service_perimeter.spec_ingress_policies_ingress_to_operations_method_selectors_method
+
+import data.terraform.helpers as helpers
+import data.terraform.gcp.security.access_context_manager_vpc_service_controls.google_access_context_manager_service_perimeter.vars as vars
+
+conditions := [[
+  {
+    "situation_description": "Ingress policies should explicitly select required API methods instead of allowing all methods and permissions.",
+    "remedies": ["Configure spec.ingress_policies.ingress_to.operations.method_selectors.method with a specific method instead of '*'."],
+  },
+  {
+    "condition": "Ingress method selector must not allow all methods.",
+    "attribute_path": ["spec", 0, "ingress_policies", 0, "ingress_to", 0, "operations", 0, "method_selectors", 0, "method"],
+    "values": ["*"],
+    "policy_type": "blacklist",
+  },
+]]
+
+summary := helpers.get_multi_summary(conditions, vars.variables)
+
+message := summary.message
+details := summary.details

--- a/policies/gcp/Access Context Manager (VPC Service Controls)/google_access_context_manager_service_perimeter/spec.ingress_policies.ingress_to.operations.method_selectors.permission.rego
+++ b/policies/gcp/Access Context Manager (VPC Service Controls)/google_access_context_manager_service_perimeter/spec.ingress_policies.ingress_to.operations.method_selectors.permission.rego
@@ -1,0 +1,22 @@
+package terraform.gcp.security.access_context_manager_vpc_service_controls.google_access_context_manager_service_perimeter.spec_ingress_policies_ingress_to_operations_method_selectors_permission
+
+import data.terraform.helpers as helpers
+import data.terraform.gcp.security.access_context_manager_vpc_service_controls.google_access_context_manager_service_perimeter.vars as vars
+
+conditions := [[
+  {
+    "situation_description": "Ingress policies should explicitly select required IAM permissions instead of allowing overly broad permissions.",
+    "remedies": ["Configure spec.ingress_policies.ingress_to.operations.method_selectors.permission with a specific IAM permission instead of '*'."],
+  },
+  {
+    "condition": "Ingress permission selector must not allow unrestricted permissions.",
+    "attribute_path": ["spec", 0, "ingress_policies", 0, "ingress_to", 0, "operations", 0, "method_selectors", 0, "permission"],
+    "values": ["*"],
+    "policy_type": "blacklist",
+  },
+]]
+
+summary := helpers.get_multi_summary(conditions, vars.variables)
+
+message := summary.message
+details := summary.details

--- a/policies/gcp/Access Context Manager (VPC Service Controls)/google_access_context_manager_service_perimeter/spec.ingress_policies.ingress_to.operations.service_name.rego
+++ b/policies/gcp/Access Context Manager (VPC Service Controls)/google_access_context_manager_service_perimeter/spec.ingress_policies.ingress_to.operations.service_name.rego
@@ -1,0 +1,22 @@
+package terraform.gcp.security.access_context_manager_vpc_service_controls.google_access_context_manager_service_perimeter.spec_ingress_policies_ingress_to_operations_service_name
+
+import data.terraform.helpers as helpers
+import data.terraform.gcp.security.access_context_manager_vpc_service_controls.google_access_context_manager_service_perimeter.vars as vars
+
+conditions := [[
+  {
+    "situation_description": "Ingress policies should explicitly select required services instead of allowing all services.",
+    "remedies": ["Configure spec.ingress_policies.ingress_to.operations.service_name with a specific service name instead of '*'."],
+  },
+  {
+    "condition": "Ingress service name must not allow all services.",
+    "attribute_path": ["spec", 0, "ingress_policies", 0, "ingress_to", 0, "operations", 0, "service_name"],
+    "values": ["*"],
+    "policy_type": "blacklist",
+  },
+]]
+
+summary := helpers.get_multi_summary(conditions, vars.variables)
+
+message := summary.message
+details := summary.details

--- a/policies/gcp/Access Context Manager (VPC Service Controls)/google_access_context_manager_service_perimeter/spec.ingress_policies.ingress_to.resources.rego
+++ b/policies/gcp/Access Context Manager (VPC Service Controls)/google_access_context_manager_service_perimeter/spec.ingress_policies.ingress_to.resources.rego
@@ -1,0 +1,22 @@
+package terraform.gcp.security.access_context_manager_vpc_service_controls.google_access_context_manager_service_perimeter.spec_ingress_policies_ingress_to_resources
+
+import data.terraform.helpers as helpers
+import data.terraform.gcp.security.access_context_manager_vpc_service_controls.google_access_context_manager_service_perimeter.vars as vars
+
+conditions := [[
+  {
+    "situation_description": "Ingress policies should target explicitly selected resources instead of allowing access to all resources within the Service Perimeter.",
+    "remedies": ["Configure spec.ingress_policies.ingress_to.resources with specific project resources instead of '*'."],
+  },
+  {
+    "condition": "Ingress resource targets must not allow all resources.",
+    "attribute_path": ["spec", 0, "ingress_policies", 0, "ingress_to", 0, "resources"],
+    "values": ["*"],
+    "policy_type": "blacklist",
+  },
+]]
+
+summary := helpers.get_multi_summary(conditions, vars.variables)
+
+message := summary.message
+details := summary.details

--- a/policies/gcp/Access Context Manager (VPC Service Controls)/google_access_context_manager_service_perimeter/spec.vpc_accessible_services.allowed_services.rego
+++ b/policies/gcp/Access Context Manager (VPC Service Controls)/google_access_context_manager_service_perimeter/spec.vpc_accessible_services.allowed_services.rego
@@ -1,0 +1,22 @@
+package terraform.gcp.security.access_context_manager_vpc_service_controls.google_access_context_manager_service_perimeter.spec_vpc_accessible_services_allowed_services
+
+import data.terraform.helpers as helpers
+import data.terraform.gcp.security.access_context_manager_vpc_service_controls.google_access_context_manager_service_perimeter.vars as vars
+
+conditions := [[
+  {
+    "situation_description": "VPC accessible services should explicitly select required APIs instead of allowing unrestricted API access.",
+    "remedies": ["Configure spec.vpc_accessible_services.allowed_services with explicitly required services instead of '*'."],
+  },
+  {
+    "condition": "VPC accessible services must not allow unrestricted API access.",
+    "attribute_path": ["spec", 0, "vpc_accessible_services", 0, "allowed_services"],
+    "values": ["*"],
+    "policy_type": "blacklist",
+  },
+]]
+
+summary := helpers.get_multi_summary(conditions, vars.variables)
+
+message := summary.message
+details := summary.details

--- a/policies/gcp/Access Context Manager (VPC Service Controls)/google_access_context_manager_service_perimeter/spec.vpc_accessible_services.enable_restriction.rego
+++ b/policies/gcp/Access Context Manager (VPC Service Controls)/google_access_context_manager_service_perimeter/spec.vpc_accessible_services.enable_restriction.rego
@@ -1,0 +1,22 @@
+package terraform.gcp.security.access_context_manager_vpc_service_controls.google_access_context_manager_service_perimeter.spec_vpc_accessible_services_enable_restriction
+
+import data.terraform.helpers as helpers
+import data.terraform.gcp.security.access_context_manager_vpc_service_controls.google_access_context_manager_service_perimeter.vars as vars
+
+conditions := [[
+  {
+    "situation_description": "VPC accessible services should restrict access to explicitly allowed services.",
+    "remedies": ["Set spec.vpc_accessible_services.enable_restriction to true."],
+  },
+  {
+    "condition": "VPC accessible services restriction must be enabled.",
+    "attribute_path": ["spec", 0, "vpc_accessible_services", 0, "enable_restriction"],
+    "values": [true],
+    "policy_type": "whitelist",
+  },
+]]
+
+summary := helpers.get_multi_summary(conditions, vars.variables)
+
+message := summary.message
+details := summary.details

--- a/policies/gcp/Access Context Manager (VPC Service Controls)/google_access_context_manager_service_perimeter/status.access_levels.rego
+++ b/policies/gcp/Access Context Manager (VPC Service Controls)/google_access_context_manager_service_perimeter/status.access_levels.rego
@@ -1,0 +1,22 @@
+package terraform.gcp.security.access_context_manager_vpc_service_controls.google_access_context_manager_service_perimeter.status_access_levels
+
+import data.terraform.helpers as helpers
+import data.terraform.gcp.security.access_context_manager_vpc_service_controls.google_access_context_manager_service_perimeter.vars as vars
+
+conditions := [[
+  {
+    "situation_description": "Service Perimeter status should contain configured access levels.",
+    "remedies": ["Configure status.access_levels with at least one valid AccessLevel."],
+  },
+  {
+    "condition": "Status access levels must not be empty.",
+    "attribute_path": ["status", 0, "access_levels"],
+    "values": null,
+    "policy_type": "blacklist",
+  },
+]]
+
+summary := helpers.get_multi_summary(conditions, vars.variables)
+
+message := summary.message
+details := summary.details

--- a/policies/gcp/Access Context Manager (VPC Service Controls)/google_access_context_manager_service_perimeter/status.egress_policies.egress_from.identities.rego
+++ b/policies/gcp/Access Context Manager (VPC Service Controls)/google_access_context_manager_service_perimeter/status.egress_policies.egress_from.identities.rego
@@ -1,0 +1,22 @@
+package terraform.gcp.security.access_context_manager_vpc_service_controls.google_access_context_manager_service_perimeter.status_egress_policies_egress_from_identities
+
+import data.terraform.helpers as helpers
+import data.terraform.gcp.security.access_context_manager_vpc_service_controls.google_access_context_manager_service_perimeter.vars as vars
+
+conditions := [[
+  {
+    "situation_description": "Egress access should be restricted to explicitly scoped identities.",
+    "remedies": ["Configure status.egress_policies.egress_from.identities with specific service account identities instead of wildcard or public principals."],
+  },
+  {
+    "condition": "Egress identities must not contain wildcard or public principals.",
+    "attribute_path": ["status", 0, "egress_policies", 0, "egress_from", 0, "identities"],
+    "values": ["*", "allUsers", "allAuthenticatedUsers"],
+    "policy_type": "blacklist",
+  },
+]]
+
+summary := helpers.get_multi_summary(conditions, vars.variables)
+
+message := summary.message
+details := summary.details

--- a/policies/gcp/Access Context Manager (VPC Service Controls)/google_access_context_manager_service_perimeter/status.egress_policies.egress_from.identity_type.rego
+++ b/policies/gcp/Access Context Manager (VPC Service Controls)/google_access_context_manager_service_perimeter/status.egress_policies.egress_from.identity_type.rego
@@ -1,0 +1,22 @@
+package terraform.gcp.security.access_context_manager_vpc_service_controls.google_access_context_manager_service_perimeter.status_egress_policies_egress_from_identity_type
+
+import data.terraform.helpers as helpers
+import data.terraform.gcp.security.access_context_manager_vpc_service_controls.google_access_context_manager_service_perimeter.vars
+
+conditions := [[
+    {
+        "situation_description": "Egress access should prevent overly permissive identity types while allowing valid identity configurations.",
+        "remedies": ["Configure status.egress_policies.egress_from.identity_type to use an appropriate identity type and avoid ANY_IDENTITY."],
+    },
+    {
+        "condition": "Egress identity type must not allow the overly permissive ANY_IDENTITY value.",
+        "attribute_path": ["status", 0, "egress_policies", 0, "egress_from", 0, "identity_type"],
+        "values": ["ANY_IDENTITY"],
+        "policy_type": "blacklist",
+    },
+]]
+
+summary := helpers.get_multi_summary(conditions, vars.variables)
+
+message := summary.message
+details := summary.details

--- a/policies/gcp/Access Context Manager (VPC Service Controls)/google_access_context_manager_service_perimeter/status.egress_policies.egress_from.source_restriction.rego
+++ b/policies/gcp/Access Context Manager (VPC Service Controls)/google_access_context_manager_service_perimeter/status.egress_policies.egress_from.source_restriction.rego
@@ -1,0 +1,22 @@
+package terraform.gcp.security.access_context_manager_vpc_service_controls.google_access_context_manager_service_perimeter.status_egress_policies_egress_from_source_restriction
+
+import data.terraform.helpers as helpers
+import data.terraform.gcp.security.access_context_manager_vpc_service_controls.google_access_context_manager_service_perimeter.vars as vars
+
+conditions := [[
+  {
+    "situation_description": "Source restrictions should be enabled for egress traffic.",
+    "remedies": ["Configure status.egress_policies.egress_from.source_restriction as SOURCE_RESTRICTION_ENABLED."],
+  },
+  {
+    "condition": "Egress source restriction must be enabled.",
+    "attribute_path": ["status", 0, "egress_policies", 0, "egress_from", 0, "source_restriction"],
+    "values": ["SOURCE_RESTRICTION_ENABLED"],
+    "policy_type": "whitelist",
+  },
+]]
+
+summary := helpers.get_multi_summary(conditions, vars.variables)
+
+message := summary.message
+details := summary.details

--- a/policies/gcp/Access Context Manager (VPC Service Controls)/google_access_context_manager_service_perimeter/status.ingress_policies.ingress_from.identities.rego
+++ b/policies/gcp/Access Context Manager (VPC Service Controls)/google_access_context_manager_service_perimeter/status.ingress_policies.ingress_from.identities.rego
@@ -1,0 +1,22 @@
+package terraform.gcp.security.access_context_manager_vpc_service_controls.google_access_context_manager_service_perimeter.status_ingress_policies_ingress_from_identities
+
+import data.terraform.helpers as helpers
+import data.terraform.gcp.security.access_context_manager_vpc_service_controls.google_access_context_manager_service_perimeter.vars as vars
+
+conditions := [[
+  {
+    "situation_description": "Ingress access should be restricted to explicitly scoped identities.",
+    "remedies": ["Configure status.ingress_policies.ingress_from.identities with specific users, groups, or service accounts instead of wildcard or public principals."],
+  },
+  {
+    "condition": "Each ingress identity must not be a wildcard or public principal.",
+    "attribute_path": ["status", 0, "ingress_policies", 0, "ingress_from", 0, "identities"],
+    "values": ["*", "allUsers", "allAuthenticatedUsers"],
+    "policy_type": "element blacklist",
+  },
+]]
+
+summary := helpers.get_multi_summary(conditions, vars.variables)
+
+message := summary.message
+details := summary.details

--- a/policies/gcp/Access Context Manager (VPC Service Controls)/google_access_context_manager_service_perimeter/status.ingress_policies.ingress_from.identity_type.rego
+++ b/policies/gcp/Access Context Manager (VPC Service Controls)/google_access_context_manager_service_perimeter/status.ingress_policies.ingress_from.identity_type.rego
@@ -1,0 +1,22 @@
+package terraform.gcp.security.access_context_manager_vpc_service_controls.google_access_context_manager_service_perimeter.status_ingress_policies_ingress_from_identity_type
+
+import data.terraform.helpers as helpers
+import data.terraform.gcp.security.access_context_manager_vpc_service_controls.google_access_context_manager_service_perimeter.vars as vars
+
+conditions := [[
+  {
+    "situation_description": "Ingress policies should use appropriately scoped identity types instead of allowing any identity.",
+    "remedies": ["Configure status.ingress_policies.ingress_from.identity_type with a scoped identity type instead of ANY_IDENTITY."],
+  },
+  {
+    "condition": "Ingress identity type must not allow any identity.",
+    "attribute_path": ["status", 0, "ingress_policies", 0, "ingress_from", 0, "identity_type"],
+    "values": ["ANY_IDENTITY"],
+    "policy_type": "blacklist",
+  },
+]]
+
+summary := helpers.get_multi_summary(conditions, vars.variables)
+
+message := summary.message
+details := summary.details

--- a/policies/gcp/Access Context Manager (VPC Service Controls)/google_access_context_manager_service_perimeter/status.restricted_services.rego
+++ b/policies/gcp/Access Context Manager (VPC Service Controls)/google_access_context_manager_service_perimeter/status.restricted_services.rego
@@ -4,27 +4,27 @@ import data.terraform.helpers
 import data.terraform.gcp.security.access_context_manager_vpc_service_controls.google_access_context_manager_service_perimeter.vars
 
 conditions := [
-    [
+  [
     {
-      "situation_description": "Ensure restricted services is not empty (no protection) or to general.",
-      "remedies": ["Update status/restricted_services to explicitly include only required service calls."]
+      "situation_description": "Restricted services should explicitly identify protected Google Cloud services and must not use overly broad wildcard service entries.",
+      "remedies": ["Configure status.restricted_services with explicit required Google Cloud service names instead of wildcard service entries."]
     },
     {
-      "condition": "restricted_services is not an empty list",
+      "condition": "restricted_services must not be an empty list",
       "attribute_path": ["status", 0, "restricted_services"],
       "values": null,
       "policy_type": "blacklist"
     },
     {
-      "condition": "restricted_services is too permissive",
+      "condition": "restricted_services must not contain overly broad wildcard service entries",
       "attribute_path": ["status", 0, "restricted_services"],
-      "values": ["*"],
+      "values": ["*", "*.googleapis.com"],
       "policy_type": "element blacklist"
     }
   ]
 ]
 
 result := helpers.get_multi_summary(conditions, vars.variables)
-  
+
 message := result.message
 details := result.details

--- a/policies/gcp/Access Context Manager (VPC Service Controls)/google_access_context_manager_service_perimeter/status.vpc_accessible_services.enable_restriction.rego
+++ b/policies/gcp/Access Context Manager (VPC Service Controls)/google_access_context_manager_service_perimeter/status.vpc_accessible_services.enable_restriction.rego
@@ -1,0 +1,22 @@
+package terraform.gcp.security.access_context_manager_vpc_service_controls.google_access_context_manager_service_perimeter.status_vpc_accessible_services_enable_restriction
+
+import data.terraform.helpers as helpers
+import data.terraform.gcp.security.access_context_manager_vpc_service_controls.google_access_context_manager_service_perimeter.vars as vars
+
+conditions := [[
+  {
+    "situation_description": "VPC accessible services restriction should be enabled.",
+    "remedies": ["Configure status.vpc_accessible_services.enable_restriction to true."],
+  },
+  {
+    "condition": "VPC accessible services restriction must be enabled.",
+    "attribute_path": ["status", 0, "vpc_accessible_services", 0, "enable_restriction"],
+    "values": [true],
+    "policy_type": "whitelist",
+  },
+]]
+
+summary := helpers.get_multi_summary(conditions, vars.variables)
+
+message := summary.message
+details := summary.details


### PR DESCRIPTION
## Summary

Completed the GCP Access Context Manager (VPC Service Controls) `google_access_context_manager_service_perimeter` resource.

This PR includes the required security impact documentation, Rego policies, and Terraform test files for the security-related arguments.

I also tested the resource using the automated resource check and it is passing successfully.

## Validation

`[OK] google_access_context_manager_service_perimeter: doc complete, every true arg covered, OPA passed.`