### PR TITLE
Add Dataproc session template policies

### DIFF
--- a/docs/gcp/Dataproc/google_dataproc_session_template.json
+++ b/docs/gcp/Dataproc/google_dataproc_session_template.json
@@ -6,15 +6,15 @@
       "description": "Whether Terraform will be prevented from destroying the instance. Defaults to \"DELETE\".\nWhen a 'terraform destroy' or 'terraform apply' would delete the instance,\nthe command will fail if this field is set to \"PREVENT\" in Terraform state.\nWhen set to \"ABANDON\", the command will remove the resource from Terraform\nmanagement without updating or deleting the resource in the API.\nWhen set to \"DELETE\", deleting the resource is allowed.\n",
       "required": false,
       "type": "string",
-      "security_impact": "true/false",
-      "rationale": ""
+      "security_impact": false,
+      "rationale": "Controls how Terraform handles resource deletion, but does not directly control access, identity, encryption, networking, or data protection. "
     },
     "labels": {
       "description": "The labels to associate with this session template.\n\n\n**Note**: This field is non-authoritative, and will only manage the labels present in your configuration.\nPlease refer to the field 'effective_labels' for all of the labels present on the resource.",
       "required": false,
       "type": "map(string)",
-      "security_impact": "true/false",
-      "rationale": ""
+      "security_impact": false,
+      "rationale": "Labels are used to organise and identify the resource and do not directly control its security. "
     },
     "location": {
       "description": "The location in which the session template will be created in.",
@@ -27,15 +27,15 @@
       "description": "The resource name of the session template in the following format:\nprojects/{project}/locations/{location}/sessionTemplates/{template_id}",
       "required": true,
       "type": "string",
-      "security_impact": "true/false",
-      "rationale": ""
+      "security_impact": false,
+      "rationale": "The resource name identifies the session template but does not control its security settings. "
     },
     "project": {
       "description": "The ID of the project in which the resource belongs. If it is not provided, the provider project is used.",
       "required": false,
       "type": "string",
-      "security_impact": "true/false",
-      "rationale": ""
+      "security_impact": false,
+      "rationale": "Identifies the Google Cloud Project that owns the resource but does not directly configure its security."
     },
     "environment_config": {
       "type": "block",
@@ -46,55 +46,56 @@
       "type": "block",
       "description": "Execution configuration for a workload.",
       "required": false
+
     },
     "environment_config.execution_config.idle_ttl": {
       "description": "The duration to keep the session alive while it's idling.\nExceeding this threshold causes the session to terminate. Minimum value is 10 minutes; maximum value is 14 day.\nDefaults to 1 hour if not set. If both ttl and idleTtl are specified for an interactive session, the conditions\nare treated as OR conditions: the workload will be terminated when it has been idle for idleTtl or when ttl has\nbeen exceeded, whichever occurs first.",
       "required": false,
       "type": "string",
-      "security_impact": "true/false",
-      "rationale": ""
+      "security_impact": false,
+      "rationale": "Controls how long an idle session can remain active and does not directly control access, identity, encryption, or networking. "
     },
     "environment_config.execution_config.kms_key": {
       "description": "The Cloud KMS key to use for encryption.",
       "required": false,
       "type": "string",
-      "security_impact": "true/false",
-      "rationale": ""
+      "security_impact": true,
+      "rationale": "Specifies the cloud kms key used to encrypt the workload. "
     },
     "environment_config.execution_config.network_tags": {
       "description": "Tags used for network traffic control.",
       "required": false,
       "type": "list(string)",
-      "security_impact": "true/false",
-      "rationale": ""
+      "security_impact": true,
+      "rationale": "Network tags can affect the firewall rules and network controls applied to the workload. "
     },
     "environment_config.execution_config.service_account": {
       "description": "Service account that used to execute workload.",
       "required": false,
       "type": "string",
-      "security_impact": "true/false",
-      "rationale": ""
+      "security_impact": true,
+      "rationale": "The service account determines the identity used by the workload and therefore the permissions available to it."
     },
     "environment_config.execution_config.staging_bucket": {
       "description": "A Cloud Storage bucket used to stage workload dependencies, config files, and store\nworkload output and other ephemeral data, such as Spark history files. If you do not specify a staging bucket,\nCloud Dataproc will determine a Cloud Storage location according to the region where your workload is running,\nand then create and manage project-level, per-location staging and temporary buckets.\nThis field requires a Cloud Storage bucket name, not a gs://... URI to a Cloud Storage bucket.",
       "required": false,
       "type": "string",
-      "security_impact": "true/false",
-      "rationale": ""
+      "security_impact": true,
+      "rationale": "The staging bucket can hold workload dependencies, configuration, and output data, so the bucked used by the workload can affect data protection. "
     },
     "environment_config.execution_config.subnetwork_uri": {
       "description": "Subnetwork configuration for workload execution.",
       "required": false,
       "type": "string",
-      "security_impact": "true/false",
-      "rationale": ""
+      "security_impact": true,
+      "rationale": "Determines the subnetwork used by the workload and can affect which network resources and controls it can reach. "
     },
     "environment_config.execution_config.ttl": {
       "description": "The duration after which the workload will be terminated.\nWhen the workload exceeds this duration, it will be unconditionally terminated without waiting for ongoing\nwork to finish. If ttl is not specified for a session workload, the workload will be allowed to run until it\nexits naturally (or run forever without exiting). If ttl is not specified for an interactive session,\nit defaults to 24 hours. If ttl is not specified for a batch that uses 2.1+ runtime version, it defaults to 4 hours.\nMinimum value is 10 minutes; maximum value is 14 days. If both ttl and idleTtl are specified (for an interactive session),\nthe conditions are treated as OR conditions: the workload will be terminated when it has been idle for idleTtl or\nwhen ttl has been exceeded, whichever occurs first.",
       "required": false,
       "type": "string",
-      "security_impact": "true/false",
-      "rationale": ""
+      "security_impact": false,
+      "rationale": "Controls how long the workload can run and does not directly configure accesss, identity, encryption, or network security. "
     },
     "environment_config.execution_config.authentication_config": {
       "type": "block",
@@ -105,8 +106,8 @@
       "description": "Authentication type for the user workload running in containers. Possible values: [\"SERVICE_ACCOUNT\", \"END_USER_CREDENTIALS\"]",
       "required": false,
       "type": "string",
-      "security_impact": "true/false",
-      "rationale": ""
+      "security_impact": true,
+      "rationale": "Controls whether the workload uses a service account or end user credentials for authentication. "
     },
     "environment_config.peripherals_config": {
       "type": "block",
@@ -117,8 +118,8 @@
       "description": "Resource name of an existing Dataproc Metastore service.",
       "required": false,
       "type": "string",
-      "security_impact": "true/false",
-      "rationale": ""
+      "security_impact": false,
+      "rationale": "Identifies the Dataproc Metastore service available to the workload but does not directly configure its access or security controls. "
     },
     "environment_config.peripherals_config.spark_history_server_config": {
       "type": "block",
@@ -129,8 +130,8 @@
       "description": "Resource name of an existing Dataproc Cluster to act as a Spark History Server for the workload.",
       "required": false,
       "type": "string",
-      "security_impact": "true/false",
-      "rationale": ""
+      "security_impact": false,
+      "rationale": "Identifies the Dataproc cluster used for spark history but does not directly configure security controls for the workload. "
     },
     "jupyter_session": {
       "type": "block",
@@ -141,15 +142,15 @@
       "description": "Display name, shown in the Jupyter kernelspec card.",
       "required": false,
       "type": "string",
-      "security_impact": "true/false",
-      "rationale": ""
+      "security_impact": false,
+      "rationale": "Only controls the name displayed for the Jupyter session and has no direct effect on security. "
     },
     "jupyter_session.kernel": {
       "description": "Kernel to be used with Jupyter interactive session. Possible values: [\"PYTHON\", \"SCALA\"]",
       "required": false,
       "type": "string",
-      "security_impact": "true/false",
-      "rationale": ""
+      "security_impact": false,
+      "rationale": "Selects the Jupyter kernel used by the session and does not directly control access, identity, encryption, or networking. "
     },
     "runtime_config": {
       "type": "block",
@@ -160,22 +161,22 @@
       "description": "Optional custom container image for the job runtime environment. If not specified, a default container image will be used.",
       "required": false,
       "type": "string",
-      "security_impact": "true/false",
-      "rationale": ""
+      "security_impact": true,
+      "rationale": "Controls the container image used for workload runtime, which determines the software and dependencies running in the workload. "
     },
     "runtime_config.properties": {
       "description": "A mapping of property names to values, which are used to configure workload execution.",
       "required": false,
       "type": "map(string)",
-      "security_impact": "true/false",
-      "rationale": ""
+      "security_impact": true,
+      "rationale": "Runtime properties can change how the workload runs, including settings that effect security and data handling. "
     },
     "runtime_config.version": {
       "description": "Version of the session runtime.",
       "required": false,
       "type": "string",
-      "security_impact": "true/false",
-      "rationale": ""
+      "security_impact": true,
+      "rationale": "The runtime version determines the software environment used by the workload, so restricting versions helps avoid unsupported or vulnerable runtimes. "
     },
     "spark_connect_session": {
       "type": "block",

--- a/inputs/gcp/Dataproc/google_dataproc_session_template/environment_config.execution_config.authentication_config.user_workload_authentication_type/compliant.tf
+++ b/inputs/gcp/Dataproc/google_dataproc_session_template/environment_config.execution_config.authentication_config.user_workload_authentication_type/compliant.tf
@@ -1,0 +1,13 @@
+resource "google_dataproc_session_template" "compliant_example_1" {
+  project  = "test-project"
+  name     = "compliant_example_1"
+  location = "australia-southeast1"
+
+  environment_config {
+    execution_config {
+      authentication_config {
+        user_workload_authentication_type = "SERVICE_ACCOUNT"
+      }
+    }
+  }
+}

--- a/inputs/gcp/Dataproc/google_dataproc_session_template/environment_config.execution_config.authentication_config.user_workload_authentication_type/config.tf
+++ b/inputs/gcp/Dataproc/google_dataproc_session_template/environment_config.execution_config.authentication_config.user_workload_authentication_type/config.tf
@@ -1,5 +1,3 @@
-##### DO NOT EDIT ######
-
 terraform {
   required_providers {
     google = {
@@ -8,4 +6,5 @@ terraform {
   }
 }
 
-provider "google" {}
+provider "google" {
+}

--- a/inputs/gcp/Dataproc/google_dataproc_session_template/environment_config.execution_config.authentication_config.user_workload_authentication_type/nonCompliant.tf
+++ b/inputs/gcp/Dataproc/google_dataproc_session_template/environment_config.execution_config.authentication_config.user_workload_authentication_type/nonCompliant.tf
@@ -1,0 +1,7 @@
+resource "google_dataproc_session_template" "non_compliant_example_1" {
+  project  = "test-project"
+  name     = "non_compliant_example_1"
+  location = "australia-southeast1"
+
+
+}

--- a/inputs/gcp/Dataproc/google_dataproc_session_template/environment_config.execution_config.kms_key/compliant.tf
+++ b/inputs/gcp/Dataproc/google_dataproc_session_template/environment_config.execution_config.kms_key/compliant.tf
@@ -1,0 +1,11 @@
+resource "google_dataproc_session_template" "compliant_example_1" {
+  project  = "test-project"
+  name     = "compliant_example_1"
+  location = "australia-southeast1"
+
+  environment_config {
+    execution_config {
+      kms_key = "projects/my-project/locations/australia-southeast1/keyRings/my-keyring/cryptoKeys/my-key"
+    }
+  }
+}

--- a/inputs/gcp/Dataproc/google_dataproc_session_template/environment_config.execution_config.kms_key/config.tf
+++ b/inputs/gcp/Dataproc/google_dataproc_session_template/environment_config.execution_config.kms_key/config.tf
@@ -1,5 +1,3 @@
-##### DO NOT EDIT ######
-
 terraform {
   required_providers {
     google = {
@@ -8,4 +6,5 @@ terraform {
   }
 }
 
-provider "google" {}
+provider "google" {
+}

--- a/inputs/gcp/Dataproc/google_dataproc_session_template/environment_config.execution_config.kms_key/nonCompliant.tf
+++ b/inputs/gcp/Dataproc/google_dataproc_session_template/environment_config.execution_config.kms_key/nonCompliant.tf
@@ -1,0 +1,7 @@
+resource "google_dataproc_session_template" "non_compliant_example_1" {
+  project  = "test-project"
+  name     = "non_compliant_example_1"
+  location = "australia-southeast1"
+
+
+}

--- a/inputs/gcp/Dataproc/google_dataproc_session_template/environment_config.execution_config.network_tags/compliant.tf
+++ b/inputs/gcp/Dataproc/google_dataproc_session_template/environment_config.execution_config.network_tags/compliant.tf
@@ -1,0 +1,11 @@
+resource "google_dataproc_session_template" "compliant_example_1" {
+  project  = "test-project"
+  name     = "compliant_example_1"
+  location = "australia-southeast1"
+
+  environment_config {
+    execution_config {
+      network_tags = ["dataproc-workload"]
+    }
+  }
+}

--- a/inputs/gcp/Dataproc/google_dataproc_session_template/environment_config.execution_config.network_tags/config.tf
+++ b/inputs/gcp/Dataproc/google_dataproc_session_template/environment_config.execution_config.network_tags/config.tf
@@ -1,5 +1,3 @@
-##### DO NOT EDIT ######
-
 terraform {
   required_providers {
     google = {
@@ -8,4 +6,5 @@ terraform {
   }
 }
 
-provider "google" {}
+provider "google" {
+}

--- a/inputs/gcp/Dataproc/google_dataproc_session_template/environment_config.execution_config.network_tags/nonCompliant.tf
+++ b/inputs/gcp/Dataproc/google_dataproc_session_template/environment_config.execution_config.network_tags/nonCompliant.tf
@@ -1,0 +1,7 @@
+resource "google_dataproc_session_template" "non_compliant_example_1" {
+  project  = "test-project"
+  name     = "non_compliant_example_1"
+  location = "australia-southeast1"
+
+
+}

--- a/inputs/gcp/Dataproc/google_dataproc_session_template/environment_config.execution_config.service_account/compliant.tf
+++ b/inputs/gcp/Dataproc/google_dataproc_session_template/environment_config.execution_config.service_account/compliant.tf
@@ -1,0 +1,11 @@
+resource "google_dataproc_session_template" "compliant_example_1" {
+  project  = "test-project"
+  name     = "compliant-session-template"
+  location = "australia-southeast1"
+
+  environment_config {
+    execution_config {
+      service_account = "dataproc-sa@my-project.iam.gserviceaccount.com"
+    }
+  }
+}

--- a/inputs/gcp/Dataproc/google_dataproc_session_template/environment_config.execution_config.service_account/config.tf
+++ b/inputs/gcp/Dataproc/google_dataproc_session_template/environment_config.execution_config.service_account/config.tf
@@ -1,0 +1,11 @@
+##### DO NOT EDIT ######
+
+terraform {
+  required_providers {
+    google = {
+      source  = "hashicorp/google"
+    }
+  }
+}
+
+provider "google" {}

--- a/inputs/gcp/Dataproc/google_dataproc_session_template/environment_config.execution_config.service_account/nonCompliant.tf
+++ b/inputs/gcp/Dataproc/google_dataproc_session_template/environment_config.execution_config.service_account/nonCompliant.tf
@@ -1,0 +1,10 @@
+resource "google_dataproc_session_template" "non_compliant_example_1" {
+  project  = "test-project"
+  name     = "non-compliant-session-template"
+  location = "australia-southeast1"
+
+  environment_config {
+    execution_config {
+    }
+  }
+}

--- a/inputs/gcp/Dataproc/google_dataproc_session_template/environment_config.execution_config.staging_bucket/compliant.tf
+++ b/inputs/gcp/Dataproc/google_dataproc_session_template/environment_config.execution_config.staging_bucket/compliant.tf
@@ -1,0 +1,11 @@
+resource "google_dataproc_session_template" "compliant_example_1" {
+  project  = "test-project"
+  name     = "compliant_example_1"
+  location = "australia-southeast1"
+
+  environment_config {
+    execution_config {
+      staging_bucket = "dataproc-secure-staging-bucket"
+    }
+  }
+}

--- a/inputs/gcp/Dataproc/google_dataproc_session_template/environment_config.execution_config.staging_bucket/config.tf
+++ b/inputs/gcp/Dataproc/google_dataproc_session_template/environment_config.execution_config.staging_bucket/config.tf
@@ -1,5 +1,3 @@
-##### DO NOT EDIT ######
-
 terraform {
   required_providers {
     google = {
@@ -8,4 +6,5 @@ terraform {
   }
 }
 
-provider "google" {}
+provider "google" {
+}

--- a/inputs/gcp/Dataproc/google_dataproc_session_template/environment_config.execution_config.staging_bucket/nonCompliant.tf
+++ b/inputs/gcp/Dataproc/google_dataproc_session_template/environment_config.execution_config.staging_bucket/nonCompliant.tf
@@ -1,0 +1,7 @@
+resource "google_dataproc_session_template" "non_compliant_example_1" {
+  project  = "test-project"
+  name     = "non_compliant_example_1"
+  location = "australia-southeast1"
+
+
+}

--- a/inputs/gcp/Dataproc/google_dataproc_session_template/environment_config.execution_config.subnetwork_uri/compliant.tf
+++ b/inputs/gcp/Dataproc/google_dataproc_session_template/environment_config.execution_config.subnetwork_uri/compliant.tf
@@ -1,0 +1,11 @@
+resource "google_dataproc_session_template" "compliant_example_1" {
+  project  = "test-project"
+  name     = "compliant_example_1"
+  location = "australia-southeast1"
+
+  environment_config {
+    execution_config {
+      subnetwork_uri = "projects/my-project/regions/australia-southeast1/subnetworks/dataproc-secure"
+    }
+  }
+}

--- a/inputs/gcp/Dataproc/google_dataproc_session_template/environment_config.execution_config.subnetwork_uri/config.tf
+++ b/inputs/gcp/Dataproc/google_dataproc_session_template/environment_config.execution_config.subnetwork_uri/config.tf
@@ -1,5 +1,3 @@
-##### DO NOT EDIT ######
-
 terraform {
   required_providers {
     google = {
@@ -8,4 +6,5 @@ terraform {
   }
 }
 
-provider "google" {}
+provider "google" {
+}

--- a/inputs/gcp/Dataproc/google_dataproc_session_template/environment_config.execution_config.subnetwork_uri/nonCompliant.tf
+++ b/inputs/gcp/Dataproc/google_dataproc_session_template/environment_config.execution_config.subnetwork_uri/nonCompliant.tf
@@ -1,0 +1,7 @@
+resource "google_dataproc_session_template" "non_compliant_example_1" {
+  project  = "test-project"
+  name     = "non_compliant_example_1"
+  location = "australia-southeast1"
+
+
+}

--- a/inputs/gcp/Dataproc/google_dataproc_session_template/location/compliant.tf
+++ b/inputs/gcp/Dataproc/google_dataproc_session_template/location/compliant.tf
@@ -1,0 +1,11 @@
+resource "google_dataproc_session_template" "compliant_example_1" {
+  project  = "test-project"
+  name     = "compliant-session-template"
+  location = "australia-southeast1"
+
+  environment_config {
+    execution_config {
+      service_account = "dataproc-sa@my-project.iam.gserviceaccount.com"
+    }
+  }
+}

--- a/inputs/gcp/Dataproc/google_dataproc_session_template/location/config.tf
+++ b/inputs/gcp/Dataproc/google_dataproc_session_template/location/config.tf
@@ -1,0 +1,11 @@
+##### DO NOT EDIT ######
+
+terraform {
+  required_providers {
+    google = {
+      source  = "hashicorp/google"
+    }
+  }
+}
+
+provider "google" {}

--- a/inputs/gcp/Dataproc/google_dataproc_session_template/location/config.tf
+++ b/inputs/gcp/Dataproc/google_dataproc_session_template/location/config.tf
@@ -3,7 +3,7 @@
 terraform {
   required_providers {
     google = {
-      source  = "hashicorp/google"
+      source = "hashicorp/google"
     }
   }
 }

--- a/inputs/gcp/Dataproc/google_dataproc_session_template/location/nonCompliant.tf
+++ b/inputs/gcp/Dataproc/google_dataproc_session_template/location/nonCompliant.tf
@@ -1,0 +1,11 @@
+resource "google_dataproc_session_template" "non_compliant_example_1" {
+  project  = "test-project"
+  name     = "non-compliant-session-template"
+  location = "europe-west1"
+
+  environment_config {
+    execution_config {
+      service_account = "dataproc-sa@my-project.iam.gserviceaccount.com"
+    }
+  }
+}

--- a/inputs/gcp/Dataproc/google_dataproc_session_template/runtime_config.container_image/compliant.tf
+++ b/inputs/gcp/Dataproc/google_dataproc_session_template/runtime_config.container_image/compliant.tf
@@ -1,0 +1,9 @@
+resource "google_dataproc_session_template" "compliant_example_1" {
+  project  = "test-project"
+  name     = "compliant_example_1"
+  location = "australia-southeast1"
+
+  runtime_config {
+    container_image = "us-docker.pkg.dev/my-project/dataproc/custom-runtime:1.0"
+  }
+}

--- a/inputs/gcp/Dataproc/google_dataproc_session_template/runtime_config.container_image/config.tf
+++ b/inputs/gcp/Dataproc/google_dataproc_session_template/runtime_config.container_image/config.tf
@@ -1,5 +1,3 @@
-##### DO NOT EDIT ######
-
 terraform {
   required_providers {
     google = {
@@ -8,4 +6,5 @@ terraform {
   }
 }
 
-provider "google" {}
+provider "google" {
+}

--- a/inputs/gcp/Dataproc/google_dataproc_session_template/runtime_config.container_image/nonCompliant.tf
+++ b/inputs/gcp/Dataproc/google_dataproc_session_template/runtime_config.container_image/nonCompliant.tf
@@ -1,0 +1,7 @@
+resource "google_dataproc_session_template" "non_compliant_example_1" {
+  project  = "test-project"
+  name     = "non_compliant_example_1"
+  location = "australia-southeast1"
+
+
+}

--- a/inputs/gcp/Dataproc/google_dataproc_session_template/runtime_config.properties/compliant.tf
+++ b/inputs/gcp/Dataproc/google_dataproc_session_template/runtime_config.properties/compliant.tf
@@ -1,0 +1,11 @@
+resource "google_dataproc_session_template" "compliant_example_1" {
+  project  = "test-project"
+  name     = "compliant_example_1"
+  location = "australia-southeast1"
+
+  runtime_config {
+    properties = {
+      "spark.sql.adaptive.enabled" = "true"
+    }
+  }
+}

--- a/inputs/gcp/Dataproc/google_dataproc_session_template/runtime_config.properties/config.tf
+++ b/inputs/gcp/Dataproc/google_dataproc_session_template/runtime_config.properties/config.tf
@@ -1,5 +1,3 @@
-##### DO NOT EDIT ######
-
 terraform {
   required_providers {
     google = {
@@ -8,4 +6,5 @@ terraform {
   }
 }
 
-provider "google" {}
+provider "google" {
+}

--- a/inputs/gcp/Dataproc/google_dataproc_session_template/runtime_config.properties/nonCompliant.tf
+++ b/inputs/gcp/Dataproc/google_dataproc_session_template/runtime_config.properties/nonCompliant.tf
@@ -1,0 +1,7 @@
+resource "google_dataproc_session_template" "non_compliant_example_1" {
+  project  = "test-project"
+  name     = "non_compliant_example_1"
+  location = "australia-southeast1"
+
+
+}

--- a/inputs/gcp/Dataproc/google_dataproc_session_template/runtime_config.version/compliant.tf
+++ b/inputs/gcp/Dataproc/google_dataproc_session_template/runtime_config.version/compliant.tf
@@ -1,0 +1,9 @@
+resource "google_dataproc_session_template" "compliant_example_1" {
+  project  = "test-project"
+  name     = "compliant_example_1"
+  location = "australia-southeast1"
+
+  runtime_config {
+    version = "2.2"
+  }
+}

--- a/inputs/gcp/Dataproc/google_dataproc_session_template/runtime_config.version/config.tf
+++ b/inputs/gcp/Dataproc/google_dataproc_session_template/runtime_config.version/config.tf
@@ -1,5 +1,3 @@
-##### DO NOT EDIT ######
-
 terraform {
   required_providers {
     google = {
@@ -8,4 +6,5 @@ terraform {
   }
 }
 
-provider "google" {}
+provider "google" {
+}

--- a/inputs/gcp/Dataproc/google_dataproc_session_template/runtime_config.version/nonCompliant.tf
+++ b/inputs/gcp/Dataproc/google_dataproc_session_template/runtime_config.version/nonCompliant.tf
@@ -1,0 +1,7 @@
+resource "google_dataproc_session_template" "non_compliant_example_1" {
+  project  = "test-project"
+  name     = "non_compliant_example_1"
+  location = "australia-southeast1"
+
+
+}

--- a/policies/gcp/Dataproc/google_dataproc_session_template/_vars.rego
+++ b/policies/gcp/Dataproc/google_dataproc_session_template/_vars.rego
@@ -1,0 +1,7 @@
+package terraform.gcp.security.dataproc.google_dataproc_session_template.vars
+
+variables := {
+    "friendly_resource_name": "Dataproc Session Template",
+    "resource_type": "google_dataproc_session_template",
+    "resource_value_name": "name",
+}

--- a/policies/gcp/Dataproc/google_dataproc_session_template/environment_config.execution_config.authentication_config.user_workload_authentication_type.rego
+++ b/policies/gcp/Dataproc/google_dataproc_session_template/environment_config.execution_config.authentication_config.user_workload_authentication_type.rego
@@ -1,0 +1,25 @@
+package terraform.gcp.security.dataproc.google_dataproc_session_template.environment_config_execution_config_authentication_config_user_workload_authentication_type
+
+import data.terraform.helpers
+import data.terraform.gcp.security.dataproc.google_dataproc_session_template.vars
+
+conditions := [
+    [
+        {
+            "situation_description": "Dataproc Session Template does not explicitly require service account authentication for user workloads.",
+            "remedies": [
+                "Configure user workload authentication to use SERVICE_ACCOUNT."
+            ]
+        },
+        {
+            "condition": "User workload authentication must use a service account.",
+            "attribute_path": ["environment_config", 0, "execution_config", 0, "authentication_config", 0, "user_workload_authentication_type"],
+            "values": ["SERVICE_ACCOUNT"],
+            "policy_type": "whitelist"
+        }
+    ]
+]
+
+result := helpers.get_multi_summary(conditions, vars.variables)
+message := result.message
+details := result.details

--- a/policies/gcp/Dataproc/google_dataproc_session_template/environment_config.execution_config.kms_key.rego
+++ b/policies/gcp/Dataproc/google_dataproc_session_template/environment_config.execution_config.kms_key.rego
@@ -1,0 +1,25 @@
+package terraform.gcp.security.dataproc.google_dataproc_session_template.environment_config_execution_config_kms_key
+
+import data.terraform.helpers
+import data.terraform.gcp.security.dataproc.google_dataproc_session_template.vars
+
+conditions := [
+    [
+        {
+            "situation_description": "Dataproc Session Template does not specify a Cloud KMS key for workload encryption.",
+            "remedies": [
+                "Configure a valid Cloud KMS key for workload encryption."
+            ]
+        },
+        {
+            "condition": "A Cloud KMS key must be configured.",
+            "attribute_path": ["environment_config", 0, "execution_config", 0, "kms_key"],
+            "values": ["", null],
+            "policy_type": "blacklist"
+        }
+    ]
+]
+
+result := helpers.get_multi_summary(conditions, vars.variables)
+message := result.message
+details := result.details

--- a/policies/gcp/Dataproc/google_dataproc_session_template/environment_config.execution_config.network_tags.rego
+++ b/policies/gcp/Dataproc/google_dataproc_session_template/environment_config.execution_config.network_tags.rego
@@ -1,0 +1,25 @@
+package terraform.gcp.security.dataproc.google_dataproc_session_template.environment_config_execution_config_network_tags
+
+import data.terraform.helpers
+import data.terraform.gcp.security.dataproc.google_dataproc_session_template.vars
+
+conditions := [
+    [
+        {
+            "situation_description": "Dataproc Session Template does not specify network tags for network traffic control.",
+            "remedies": [
+                "Configure appropriate network tags for the workload."
+            ]
+        },
+        {
+            "condition": "Network tags must be configured.",
+            "attribute_path": ["environment_config", 0, "execution_config", 0, "network_tags"],
+            "values": [null, []],
+            "policy_type": "blacklist"
+        }
+    ]
+]
+
+result := helpers.get_multi_summary(conditions, vars.variables)
+message := result.message
+details := result.details

--- a/policies/gcp/Dataproc/google_dataproc_session_template/environment_config.execution_config.service_account.rego
+++ b/policies/gcp/Dataproc/google_dataproc_session_template/environment_config.execution_config.service_account.rego
@@ -1,0 +1,25 @@
+package terraform.gcp.security.dataproc.google_dataproc_session_template.environment_config_execution_config_service_account
+
+import data.terraform.helpers
+import data.terraform.gcp.security.dataproc.google_dataproc_session_template.vars
+
+conditions := [
+    [
+        {
+            "situation_description": "Dataproc Session Template does not specify a dedicated service account, which may result in use of a default identity with overly broad permissions.",
+            "remedies": [
+                "Configure a dedicated service account with least-privilege permissions."
+            ]
+        },
+        {
+            "condition": "A dedicated service account must be configured.",
+            "attribute_path": ["environment_config", 0, "execution_config", 0, "service_account"],
+            "values": [null, ""],
+            "policy_type": "blacklist"
+        }
+    ]
+]
+
+result := helpers.get_multi_summary(conditions, vars.variables)
+message := result.message
+details := result.details

--- a/policies/gcp/Dataproc/google_dataproc_session_template/environment_config.execution_config.staging_bucket.rego
+++ b/policies/gcp/Dataproc/google_dataproc_session_template/environment_config.execution_config.staging_bucket.rego
@@ -1,0 +1,25 @@
+package terraform.gcp.security.dataproc.google_dataproc_session_template.environment_config_execution_config_staging_bucket
+
+import data.terraform.helpers
+import data.terraform.gcp.security.dataproc.google_dataproc_session_template.vars
+
+conditions := [
+    [
+        {
+            "situation_description": "Dataproc Session Template does not specify a staging bucket for workload data and dependencies.",
+            "remedies": [
+                "Configure a dedicated Cloud Storage staging bucket."
+            ]
+        },
+        {
+            "condition": "A staging bucket must be configured.",
+            "attribute_path": ["environment_config", 0, "execution_config", 0, "staging_bucket"],
+            "values": ["", null],
+            "policy_type": "blacklist"
+        }
+    ]
+]
+
+result := helpers.get_multi_summary(conditions, vars.variables)
+message := result.message
+details := result.details

--- a/policies/gcp/Dataproc/google_dataproc_session_template/environment_config.execution_config.subnetwork_uri.rego
+++ b/policies/gcp/Dataproc/google_dataproc_session_template/environment_config.execution_config.subnetwork_uri.rego
@@ -1,0 +1,25 @@
+package terraform.gcp.security.dataproc.google_dataproc_session_template.environment_config_execution_config_subnetwork_uri
+
+import data.terraform.helpers
+import data.terraform.gcp.security.dataproc.google_dataproc_session_template.vars
+
+conditions := [
+    [
+        {
+            "situation_description": "Dataproc Session Template does not specify a controlled subnetwork for workload execution.",
+            "remedies": [
+                "Configure an approved subnetwork for workload execution."
+            ]
+        },
+        {
+            "condition": "A subnetwork must be configured.",
+            "attribute_path": ["environment_config", 0, "execution_config", 0, "subnetwork_uri"],
+            "values": ["", null],
+            "policy_type": "blacklist"
+        }
+    ]
+]
+
+result := helpers.get_multi_summary(conditions, vars.variables)
+message := result.message
+details := result.details

--- a/policies/gcp/Dataproc/google_dataproc_session_template/location.rego
+++ b/policies/gcp/Dataproc/google_dataproc_session_template/location.rego
@@ -1,0 +1,31 @@
+package terraform.gcp.security.dataproc.google_dataproc_session_template.location
+
+import data.terraform.gcp.security.dataproc.google_dataproc_session_template.vars
+import data.terraform.helpers
+
+conditions := [
+    [
+        {
+            "situation_description": "Dataproc Session Template is deployed outside an approved region.",
+            "remedies": [
+                "Deploy the Dataproc Session Template in an approved region.",
+            ],
+        },
+        {
+            "condition": "Location must be one of the approved regions.",
+            "attribute_path": ["location"],
+            "values": [
+                "australia-southeast1",
+                "us-central1",
+                "us-east1",
+            ],
+            "policy_type": "whitelist",
+        },
+    ],
+]
+
+summary := helpers.get_multi_summary(conditions, vars.variables)
+
+message := summary.message
+
+details := summary.details

--- a/policies/gcp/Dataproc/google_dataproc_session_template/runtime_config.container_image.rego
+++ b/policies/gcp/Dataproc/google_dataproc_session_template/runtime_config.container_image.rego
@@ -1,0 +1,25 @@
+package terraform.gcp.security.dataproc.google_dataproc_session_template.runtime_config_container_image
+
+import data.terraform.helpers
+import data.terraform.gcp.security.dataproc.google_dataproc_session_template.vars
+
+conditions := [
+    [
+        {
+            "situation_description": "Dataproc Session Template does not specify a controlled container image for the workload runtime.",
+            "remedies": [
+                "Configure an approved container image for the workload runtime."
+            ]
+        },
+        {
+            "condition": "A container image must be configured.",
+            "attribute_path": ["runtime_config", 0, "container_image"],
+            "values": ["", null],
+            "policy_type": "blacklist"
+        }
+    ]
+]
+
+result := helpers.get_multi_summary(conditions, vars.variables)
+message := result.message
+details := result.details

--- a/policies/gcp/Dataproc/google_dataproc_session_template/runtime_config.properties.rego
+++ b/policies/gcp/Dataproc/google_dataproc_session_template/runtime_config.properties.rego
@@ -1,0 +1,25 @@
+package terraform.gcp.security.dataproc.google_dataproc_session_template.runtime_config_properties
+
+import data.terraform.helpers
+import data.terraform.gcp.security.dataproc.google_dataproc_session_template.vars
+
+conditions := [
+    [
+        {
+            "situation_description": "Dataproc Session Template does not specify controlled runtime properties.",
+            "remedies": [
+                "Configure appropriate runtime properties."
+            ]
+        },
+        {
+            "condition": "Runtime properties must be configured.",
+            "attribute_path": ["runtime_config", 0, "properties"],
+            "values": [null, {}],
+            "policy_type": "blacklist"
+        }
+    ]
+]
+
+result := helpers.get_multi_summary(conditions, vars.variables)
+message := result.message
+details := result.details

--- a/policies/gcp/Dataproc/google_dataproc_session_template/runtime_config.version.rego
+++ b/policies/gcp/Dataproc/google_dataproc_session_template/runtime_config.version.rego
@@ -1,0 +1,25 @@
+package terraform.gcp.security.dataproc.google_dataproc_session_template.runtime_config_version
+
+import data.terraform.helpers
+import data.terraform.gcp.security.dataproc.google_dataproc_session_template.vars
+
+conditions := [
+    [
+        {
+            "situation_description": "Dataproc Session Template does not specify an approved runtime version.",
+            "remedies": [
+                "Configure an approved Dataproc runtime version."
+            ]
+        },
+        {
+            "condition": "Runtime version must be an approved version.",
+            "attribute_path": ["runtime_config", 0, "version"],
+            "values": ["2.2"],
+            "policy_type": "whitelist"
+        }
+    ]
+]
+
+result := helpers.get_multi_summary(conditions, vars.variables)
+message := result.message
+details := result.details


### PR DESCRIPTION
Adds security policies for the Google Dataproc Session Template resource.

Changes include:
- Added security impact metadata and rationales
- Added service account policy
- Added location policy
- Added compliant and non-compliant Terraform examples
- Added Dataproc Session Template policy variables