### PR TITLE
Fix Dataproc batch id rationale

### DIFF
--- a/docs/gcp/Dataproc/google_dataproc_batch.json
+++ b/docs/gcp/Dataproc/google_dataproc_batch.json
@@ -7,7 +7,7 @@
       "required": false,
       "type": "string",
       "security_impact": false,
-      "rationale": "Identifies the Dataproc Batch resource. Because the resource identifier determines which workload resource is targeted and can affect resource identity and lifecycle operations, it has a security impact."
+      "rationale": "Identifies the Dataproc Batch resource. Resource identifiers and names are not useful platform security policy targets."
     },
     "deletion_policy": {
       "description": "Whether Terraform will be prevented from destroying the instance. Defaults to \"DELETE\".\nWhen a 'terraform destroy' or 'terraform apply' would delete the instance,\nthe command will fail if this field is set to \"PREVENT\" in Terraform state.\nWhen set to \"ABANDON\", the command will remove the resource from Terraform\nmanagement without updating or deleting the resource in the API.\nWhen set to \"DELETE\", deleting the resource is allowed.\n",


### PR DESCRIPTION
## Summary

Fix the remaining Dataproc Batch reviewer feedback for batch_id.

## Change

Updated the batch_id rationale to clarify that resource identifiers and names are not useful platform security policy targets.

## Validation

Policy, docs, and inputs linter passed.
JSON validation passed.
Git diff check passed.