### PR TITLE
Add Dataproc session template policies

### DIFF
--- a/docs/gcp/Dataproc/google_dataproc_session_template.json
+++ b/docs/gcp/Dataproc/google_dataproc_session_template.json
@@ -59,7 +59,7 @@
       "required": false,
       "type": "string",
       "security_impact": true,
-      "rationale": "Controls the Cloud KMS key used to encrypt the workload. The selected encryption key is security-relevant because it determines the encryption protection applied to workload data."
+      "rationale": "Encryption keys require a policy to ensure they are set and customer-managed. The policy should require the key to be non-empty without pinning a specific key."
     },
     "environment_config.execution_config.network_tags": {
       "description": "Tags used for network traffic control.",
@@ -167,8 +167,8 @@
       "description": "A mapping of property names to values, which are used to configure workload execution.",
       "required": false,
       "type": "map(string)",
-      "security_impact": true,
-      "rationale": "Controls runtime properties that can change workload execution behavior. Some properties can affect security-sensitive runtime configuration, so this argument can be a valid platform security policy target."
+      "security_impact": false,
+      "rationale": "Runtime properties are free-form configuration values used to customize workload execution. A generic platform policy cannot meaningfully constrain arbitrary property names and values without being overly broad, so this argument is not a useful platform policy target."
     },
     "runtime_config.version": {
       "description": "Version of the session runtime.",

--- a/policies/gcp/Dataproc/google_dataproc_session_template/_vars.rego
+++ b/policies/gcp/Dataproc/google_dataproc_session_template/_vars.rego
@@ -1,0 +1,7 @@
+package terraform.gcp.security.dataproc.google_dataproc_session_template.vars
+
+variables := {
+    "friendly_resource_name": "Dataproc Session Template",
+    "resource_type": "google_dataproc_session_template",
+    "resource_value_name": "name",
+}

--- a/policies/gcp/Dataproc/google_dataproc_session_template/environment_config.execution_config.authentication_config.user_workload_authentication_type.rego
+++ b/policies/gcp/Dataproc/google_dataproc_session_template/environment_config.execution_config.authentication_config.user_workload_authentication_type.rego
@@ -1,0 +1,25 @@
+package terraform.gcp.security.dataproc.google_dataproc_session_template.environment_config_execution_config_authentication_config_user_workload_authentication_type
+
+import data.terraform.helpers
+import data.terraform.gcp.security.dataproc.google_dataproc_session_template.vars
+
+conditions := [
+    [
+        {
+            "situation_description": "Dataproc Session Template does not explicitly require service account authentication for user workloads.",
+            "remedies": [
+                "Configure user workload authentication to use SERVICE_ACCOUNT.",
+            ]
+        },
+        {
+            "condition": "User workload authentication must use a service account.",
+            "attribute_path": ["environment_config", 0, "execution_config", 0, "authentication_config", 0, "user_workload_authentication_type"],
+            "values": ["SERVICE_ACCOUNT"],
+            "policy_type": "whitelist"
+        }
+    ]
+]
+
+result := helpers.get_multi_summary(conditions, vars.variables)
+message := result.message
+details := result.details

--- a/policies/gcp/Dataproc/google_dataproc_session_template/environment_config.execution_config.kms_key.rego
+++ b/policies/gcp/Dataproc/google_dataproc_session_template/environment_config.execution_config.kms_key.rego
@@ -1,0 +1,25 @@
+package terraform.gcp.security.dataproc.google_dataproc_session_template.environment_config_execution_config_kms_key
+
+import data.terraform.helpers
+import data.terraform.gcp.security.dataproc.google_dataproc_session_template.vars
+
+conditions := [
+    [
+        {
+            "situation_description": "Dataproc Session Template does not specify a Cloud KMS key for workload encryption.",
+            "remedies": [
+                "Configure a valid Cloud KMS key for workload encryption.",
+            ]
+        },
+        {
+            "condition": "A Cloud KMS key must be configured.",
+            "attribute_path": ["environment_config", 0, "execution_config", 0, "kms_key"],
+            "values": [null, ""],
+            "policy_type": "blacklist"
+        }
+    ]
+]
+
+result := helpers.get_multi_summary(conditions, vars.variables)
+message := result.message
+details := result.details

--- a/policies/gcp/Dataproc/google_dataproc_session_template/environment_config.execution_config.service_account.rego
+++ b/policies/gcp/Dataproc/google_dataproc_session_template/environment_config.execution_config.service_account.rego
@@ -1,0 +1,25 @@
+package terraform.gcp.security.dataproc.google_dataproc_session_template.environment_config_execution_config_service_account
+
+import data.terraform.helpers
+import data.terraform.gcp.security.dataproc.google_dataproc_session_template.vars
+
+conditions := [
+    [
+        {
+            "situation_description": "Dataproc Session Template does not specify a dedicated service account, which may result in use of a default identity with overly broad permissions.",
+            "remedies": [
+                "Configure a dedicated service account with least-privilege permissions.",
+            ]
+        },
+        {
+            "condition": "A dedicated service account must be configured.",
+            "attribute_path": ["environment_config", 0, "execution_config", 0, "service_account"],
+            "values": [null, ""],
+            "policy_type": "blacklist"
+        }
+    ]
+]
+
+result := helpers.get_multi_summary(conditions, vars.variables)
+message := result.message
+details := result.details

--- a/policies/gcp/Dataproc/google_dataproc_session_template/location.rego
+++ b/policies/gcp/Dataproc/google_dataproc_session_template/location.rego
@@ -1,0 +1,29 @@
+package terraform.gcp.security.dataproc.google_dataproc_session_template.location
+
+import data.terraform.gcp.security.dataproc.google_dataproc_session_template.vars
+import data.terraform.helpers
+
+conditions := [
+    [
+        {
+            "situation_description": "Dataproc Session Template is deployed outside an approved region.",
+            "remedies": [
+                "Deploy the Dataproc Session Template in an approved region.",
+            ]
+        },
+        {
+            "condition": "Location must be one of the approved regions.",
+            "attribute_path": ["location"],
+            "values": [
+                "australia-southeast1",
+                "us-central1",
+                "us-east1",
+            ],
+            "policy_type": "whitelist",
+        }
+    ]
+]
+
+summary := helpers.get_multi_summary(conditions, vars.variables)
+message := summary.message
+details := summary.details


### PR DESCRIPTION
## Summary

Added security policies for the Dataproc Session Template resource.

## Policies added

- Location whitelist
- Cloud KMS key requirement
- Dedicated service account requirement
- Service account authentication requirement

## Validation

- Policy, docs, and inputs lint passed
- JSON validation passed
- Git diff check passed