### PR TITLE
Close pull requests that do not target dev or main

### DIFF
--- a/.github/workflows/pr-target.yml
+++ b/.github/workflows/pr-target.yml
@@ -1,0 +1,89 @@
+name: PR Target
+
+# Only `dev` and `main` are merge targets in this repo.
+#
+# There are no long-lived feature branches here. A
+# Service/<platform>/<service_slug>/<resource_type> branch belongs to ONE resource type and is
+# merged into dev exactly once, by the pull request the portal raises for it. Contributors were
+# doing two other things instead, and both leave a permanent trail of merges in the history that
+# says nothing about what actually reached dev — which is the only question the history is read
+# for:
+#
+#   * opening a sub-feature branch (feature/foo -> Service/.../bar) and merging it into their own
+#     service branch, several times per resource type;
+#   * opening a dev -> Service/... pull request to catch a branch up.
+#
+# Neither needs a pull request at all. Work goes straight onto the Service branch; catching up is
+# `git merge origin/dev` locally. So anything not targeting dev or main is closed here, with the
+# alternative spelled out on the pull request itself.
+#
+# `pull_request_target`, NOT `pull_request`: this needs `pull-requests: write` to comment and
+# close, and a `pull_request` run originating from a fork is handed a read-only token. The usual
+# hazard of pull_request_target does not apply — nothing from the contributor's branch is checked
+# out, built or executed here. The job reads the event payload and calls the API, so the elevated
+# token never meets contributor-controlled code.
+on:
+  pull_request_target:
+    types: [opened, reopened, edited]
+
+permissions:
+  contents: read
+
+concurrency:
+  group: pr-target-${{ github.event.pull_request.number }}
+  # NOT cancel-in-progress: a superseded run here is one that was about to close a pull request.
+  cancel-in-progress: false
+
+jobs:
+  check_base:
+    name: PR target
+    runs-on: ubuntu-latest
+    # `edited` also fires for title and body edits; only a change of base is interesting here.
+    # Anything else would re-close a pull request every time someone fixed a typo.
+    if: github.event.action != 'edited' || github.event.changes.base != null
+    permissions:
+      pull-requests: write
+    steps:
+      # A pull request targeting dev or main skips this step, so the check still reports green on
+      # every legitimate pull request rather than being silently absent from the list.
+      - name: Close pull requests that do not target dev or main
+        if: ${{ !contains(fromJSON('["dev", "main"]'), github.event.pull_request.base.ref) }}
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR: ${{ github.event.pull_request.number }}
+          REPO: ${{ github.repository }}
+          # The message lives in a YAML block scalar, NOT a shell heredoc: a heredoc inside
+          # `run: |` carries this file's indentation into its output, and four leading spaces turn
+          # every line of Markdown into a code block. YAML strips block-scalar indentation, so what
+          # lands here starts at column zero.
+          #
+          # The branch names are interpolated HERE, into an env value, and never inside `run:`.
+          # That is the documented-safe place for it: Actions substitutes the expression into the
+          # variable's VALUE, so a contributor-controlled branch name never reaches a shell command
+          # line as syntax. Substituting them in bash instead would be worse than it looks — a
+          # pattern-substitution replacement treats `&` as "the text that matched" (bash 5.2+), so
+          # a branch containing `&` would quietly corrupt this message.
+          BODY: |
+            Closing this automatically — pull requests in this repository may only target `dev` or `main`, and this one targets `${{ github.event.pull_request.base.ref }}`.
+
+            **Nothing has been deleted.** Your commits are still on `${{ github.event.pull_request.head.ref }}`.
+
+            There are no long-lived feature branches in this repository. Your `Service/<platform>/<service>/<resource_type>` branch is where your work lives, and it is merged into `dev` once, by the pull request raised for you from the portal.
+
+            **If you were adding more work to your resource type**, commit straight to your `Service/...` branch. You do not need a second branch, and you do not need a pull request to get your own work onto your own branch.
+
+            **If you were catching your branch up with `dev`**, do that locally — no pull request needed:
+
+            ```
+            git checkout ${{ github.event.pull_request.head.ref }}
+            git fetch origin
+            git merge origin/dev
+            git push
+            ```
+
+            If this work really is ready for `dev`, change this pull request's target to `dev` and reopen it. Reopening it against `${{ github.event.pull_request.base.ref }}` will just close it again.
+        run: |
+          set -euo pipefail
+          printf '%s' "$BODY" > comment.md
+          gh pr comment "$PR" --repo "$REPO" --body-file comment.md
+          gh pr close "$PR" --repo "$REPO"


### PR DESCRIPTION
Adds `.github/workflows/pr-target.yml`: any pull request whose base is not `dev` or `main` gets a comment explaining the alternative, and is closed.

## Why

Only `dev` and `main` are merge targets here, but across the repo's history **282 pull requests target `dev`, 1 targets `main`, and 14 target a `Service/*` branch**. All 14 are one of two shapes:

- a sub-feature branch merged into its own service branch — `feature/dataproc-batch-{service-fix,review-fixes,final-fix,sync}` into `Service/gcp/dataproc/google_dataproc_batch` (#656, #657, #659, #660), same again for `google_dataproc_session_template` (#664, #670, #671, #672) and `google_dataproc_autoscaling_policy` (#676);
- a `dev -> Service/...` pull request to catch a branch up (#678).

Neither needs a pull request at all. Work goes straight onto the Service branch; catching up is `git merge origin/dev` locally. Both leave permanent merges in a history whose only real question is what reached `dev`.

## Why a workflow and not a ruleset

No GitHub ruleset can express "you may not open a pull request targeting this branch". Rulesets act on the target ref, and the only rules that would bite — restrict updates, restrict creations, require a pull request — would also block contributors pushing their own commits to their own `Service/...` branch, which is the intended workflow. A failing required status check would not help either: nothing protects `Service/*` branches, so contributors merge those pull requests themselves regardless of a red check. Closing is the only thing that actually blocks it.

## Shape of the workflow

- **`pull_request_target`, not `pull_request`** — commenting and closing needs `pull-requests: write`, and a fork-originated `pull_request` run is handed a read-only token. The usual hazard does not apply: nothing from the contributor's branch is checked out, built or executed, so the elevated token never meets contributor-controlled code.
- **The comment body is a YAML block scalar, not a shell heredoc** — a heredoc inside `run: |` carries the file's indentation into its output, and four leading spaces would render the whole message as one grey code block.
- **Branch names interpolate into an `env:` value, never inside `run:`** — Actions substitutes into the variable's value, so a contributor-controlled branch name never reaches a shell command line as syntax. (Doing it in bash instead is subtly wrong: since bash 5.2, `${var//pat/repl}` treats `&` in the replacement as the matched text, so a branch name containing `&` would silently corrupt the message.)
- **`edited` acts only when `changes.base` is set**, so fixing a typo in a title does not re-close a pull request.
- The job runs on every pull request and skips only the close step, so the **"PR target"** check reports green on legitimate ones rather than being silently absent from the list.

Note that `pull_request_target` reads the workflow from the base branch, so this does not police itself — it takes effect for pull requests opened after it lands on `dev`.

## Also done

The workflow only fires on `opened`/`reopened`/`edited`, so three existing wrong-base pull requests were closed by hand, each with a comment pointing at the same guidance: #660, #588, #478. Verified before closing that none holds work that has not reached `dev` another way — #660's head differs from its base only by a merge of `dev`, #588 is `dev -> Service/...`, and #478's branch is fully contained in `dev` (its head and base are the same branch).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Jw92EhGxpjjsgoNYkqPgMm