### PR TITLE
Guide: what to do when the portal says your branch is behind the harness

### DIFF
--- a/Guide/Policy_writing_tutorial/common-errors.md
+++ b/Guide/Policy_writing_tutorial/common-errors.md
@@ -1,6 +1,50 @@
 <a id="top"></a>
 <h1 align="center">Common Errors</h1>
 
+## Your branch is behind the shared harness
+
+The portal will not scan your branch while its copy of `scripts/` differs from the one on `dev`.
+It cannot judge your policies against a test harness that is not the harness CI uses, so instead
+of scanning it shows a blocker on your stage bar and runs nothing. **Your existing results are
+kept** — nothing you have already done is lost.
+
+This is normal whenever the shared tooling changes, and it is not something wrong with your
+resource. The fix is one merge.
+
+### Fix
+
+Bring your branch up to date, then run the test harness once:
+
+```bash
+git checkout Service/<platform>/<service_slug>/<resource_type>
+git fetch origin
+git merge origin/dev
+python3 scripts/auto_test/auto_test.py "gcp/<Service>/<resource type>"
+```
+
+The run may print something like `adopted 1 plan(s) from the pre-move inputs/plan_cache/ layout`.
+That is it moving your committed Terraform plan into your own fixture folder, which is where plans
+live now — one `<sha>.json` beside the `compliant.tf` / `nonCompliant.tf` it was planned from.
+Nothing is re-planned and nothing is lost; the file is only being put where it now belongs.
+
+Commit what the run moved, then push:
+
+```bash
+git add inputs
+git commit -m "Merge dev and move committed plan into the fixture folder"
+git push
+```
+
+If the harness printed nothing about adopting a plan, there may be nothing to add — push the merge
+on its own and you are done. The portal scans your branch again on the next push.
+
+> If `inputs/plan_cache/` still contains files after all that, they belong to other people's
+> fixtures and were picked up by a stray `git add .` at some point. Remove them with
+> `git rm -r inputs/plan_cache` and commit that too — see
+> [Branch scope](branch-scope.md#legacy-plan-cache).
+
+---
+
 ## Missing required Terraform attributes
 
 ![Failed-terraform-plan](images/failed-terraform-plan.PNG)

--- a/Guide/Policy_writing_tutorial/common-errors.md
+++ b/Guide/Policy_writing_tutorial/common-errors.md
@@ -1,6 +1,8 @@
 <a id="top"></a>
 <h1 align="center">Common Errors</h1>
 
+<a id="harness-out-of-date"></a>
+
 ## "Merge dev into your branch to catch up — nothing is scanned until then"
 
 Once your documentation has been reviewed, this notice replaces everything else on your portal

--- a/Guide/Policy_writing_tutorial/common-errors.md
+++ b/Guide/Policy_writing_tutorial/common-errors.md
@@ -1,19 +1,30 @@
 <a id="top"></a>
 <h1 align="center">Common Errors</h1>
 
-## Your branch is behind the shared harness
+## "Merge dev into your branch to catch up — nothing is scanned until then"
 
-The portal will not scan your branch while its copy of `scripts/` differs from the one on `dev`.
-It cannot judge your policies against a test harness that is not the harness CI uses, so instead
-of scanning it shows a blocker on your stage bar and runs nothing. **Your existing results are
-kept** — nothing you have already done is lost.
+Once your documentation has been reviewed, this notice replaces everything else on your portal
+card:
 
-This is normal whenever the shared tooling changes, and it is not something wrong with your
-resource. The fix is one merge.
+> Your branch's copy of the shared test harness or linter (scripts/, policies/_helpers/) doesn't
+> match dev's. Merge dev into your branch to catch up — nothing is scanned until then.
+
+A shorter version names only the linter (`scripts/linters/`). Older tabs may still show a version
+that says you *changed* those files — ignore that wording; you almost certainly did not. It means
+your branch was cut before the shared tooling was last updated, which happens to everyone
+periodically and is not a problem with your resource.
+
+While the notice is up, the portal scans nothing and shows no other feedback — no per-argument
+rows, no linter advice. **Your existing results are kept.** You get them back on your next push
+after the steps below.
+
+> If your documentation has not been reviewed yet you will not see this notice at all, because
+> the documentation blockers come first — but your branch still needs the same catch-up before
+> anything will scan.
 
 ### Fix
 
-Bring your branch up to date, then run the test harness once:
+One merge, one harness run, one commit.
 
 ```bash
 git checkout Service/<platform>/<service_slug>/<resource_type>
@@ -22,24 +33,31 @@ git merge origin/dev
 python3 scripts/auto_test/auto_test.py "gcp/<Service>/<resource type>"
 ```
 
-The run may print something like `adopted 1 plan(s) from the pre-move inputs/plan_cache/ layout`.
-That is it moving your committed Terraform plan into your own fixture folder, which is where plans
-live now — one `<sha>.json` beside the `compliant.tf` / `nonCompliant.tf` it was planned from.
-Nothing is re-planned and nothing is lost; the file is only being put where it now belongs.
+Running the harness is not optional here — it is the step that finishes the job. Committed
+Terraform plans now live inside the fixture folder they belong to, as one `<sha>.json` beside the
+`compliant.tf` / `nonCompliant.tf` it was planned from, and the run moves yours there. It prints
+something like:
 
-Commit what the run moved, then push:
+    [*] adopted 1 plan(s) from the pre-move inputs/plan_cache/ layout — commit the moved files
+
+**`git status` will then show deletions and additions, not edits.** That is what a moved file looks
+like and it is exactly right — do not `git checkout` it away. Commit it and push:
 
 ```bash
 git add inputs
-git commit -m "Merge dev and move committed plan into the fixture folder"
+git commit -m "Merge dev and move committed plans into the fixture folders"
 git push
 ```
 
-If the harness printed nothing about adopting a plan, there may be nothing to add — push the merge
-on its own and you are done. The portal scans your branch again on the next push.
+If you skip the harness run, the linters will report `fixture-missing-plan` for your arguments and
+`legacy-plan-cache` for the files left behind. Those are not three separate problems — the single
+run above clears both.
 
-> If `inputs/plan_cache/` still contains files after all that, they belong to other people's
-> fixtures and were picked up by a stray `git add .` at some point. Remove them with
+If the harness printed nothing about adopting a plan, there was nothing to move: push the merge on
+its own and you are done.
+
+> If `inputs/plan_cache/` still contains files afterwards, they belong to other people's fixtures
+> and were picked up by a stray `git add .` at some point. Remove them with
 > `git rm -r inputs/plan_cache` and commit that too — see
 > [Branch scope](branch-scope.md#legacy-plan-cache).
 

--- a/Guide/Policy_writing_tutorial/general-workflow.md
+++ b/Guide/Policy_writing_tutorial/general-workflow.md
@@ -70,9 +70,9 @@
 - Attribute paths must match the structure of `plan.json`  
 - Always test before pushing  
 - Documentation must be completed before raising a PR  
-- If the portal stops scanning your branch and shows a blocker about the harness being out of
-  date, merge `dev` and re-run the test harness — see
-  [Your branch is behind the shared harness](common-errors.md#your-branch-is-behind-the-shared-harness)  
+- If the portal stops scanning your branch and asks you to merge `dev` to catch up, do that **and**
+  re-run the test harness — see
+  [Merge dev into your branch to catch up](common-errors.md#merge-dev-into-your-branch-to-catch-up--nothing-is-scanned-until-then)  
 
 
 <div align="center">

--- a/Guide/Policy_writing_tutorial/general-workflow.md
+++ b/Guide/Policy_writing_tutorial/general-workflow.md
@@ -70,6 +70,9 @@
 - Attribute paths must match the structure of `plan.json`  
 - Always test before pushing  
 - Documentation must be completed before raising a PR  
+- If the portal stops scanning your branch and shows a blocker about the harness being out of
+  date, merge `dev` and re-run the test harness — see
+  [Your branch is behind the shared harness](common-errors.md#your-branch-is-behind-the-shared-harness)  
 
 
 <div align="center">

--- a/Guide/Policy_writing_tutorial/general-workflow.md
+++ b/Guide/Policy_writing_tutorial/general-workflow.md
@@ -72,7 +72,7 @@
 - Documentation must be completed before raising a PR  
 - If the portal stops scanning your branch and asks you to merge `dev` to catch up, do that **and**
   re-run the test harness — see
-  [Merge dev into your branch to catch up](common-errors.md#merge-dev-into-your-branch-to-catch-up--nothing-is-scanned-until-then)  
+  [Merge dev into your branch to catch up](common-errors.md#harness-out-of-date)  
 
 
 <div align="center">


### PR DESCRIPTION
The portal will not scan a branch whose copy of `scripts/` or `policies/_helpers/` differs from `dev`'s — it cannot judge policies against a harness that is not the one CI runs. So any change to the shared tooling blocks every unmerged work branch until its owner merges `dev`, and #701 did that to roughly 220 branches at once. Stored results are preserved.

The recovery was already documented, but only under the `legacy-plan-cache` heading in `branch-scope.md` — a page nobody has a reason to open from a portal card.

`common-errors.md` now leads with it, written against the exact copy the portal renders (confirmed with the team that owns it):

- **Titled off the sentence students can actually see**, since the notice has no heading of its own to search for.
- **Quotes both variants verbatim**, and warns about the older wording still sitting in stale tabs — it said the branch had *changed* the shared files, which is wrong for every branch #701 drifted and reads as an accusation.
- **Corrects who sees it.** The notice only appears once documentation has been reviewed, because the documentation blockers are returned first — so "you will see this blocker" would have been wrong for everyone still in the doc stages, whose branch is equally drifted and equally unscanned.
- **Carries the whole sequence**, because the card shows nothing else while the blocker is up: no per-argument rows, no linter advice. It gives them the merge and no step after it.
- **Adds the two things a student hits blind after the merge**: `git status` shows deletions and additions rather than edits, because the plans are *moved* — not something to `git checkout` away — and `fixture-missing-plan` plus `legacy-plan-cache` are one problem cleared by one run, not three.

`general-workflow.md`'s best-practices list links to it. The leftover-`inputs/plan_cache/` case still points at `branch-scope.md#legacy-plan-cache` rather than repeating it.

Docs only — no code, no fixtures. Linter clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Jw92EhGxpjjsgoNYkqPgMm
