### PR TITLE
Run the PR checks on every pull request

### DIFF
--- a/.github/workflows/policy_check_PR.yaml
+++ b/.github/workflows/policy_check_PR.yaml
@@ -2,22 +2,25 @@ name: Terraform OPA Policy Check PR
 
 on:
   workflow_dispatch:
+  # NO paths filter, deliberately. Two reasons, and the second is the one that
+  # bites:
+  #
+  #   * A change to scripts/ is the change most able to break every contributor at
+  #     once — it is the harness they are all checked by — so it must not be the
+  #     one change that runs no checks. Same for templates/, tests/ and the
+  #     workflows themselves.
+  #   * `lint` is a REQUIRED status check. GitHub does not treat a workflow that
+  #     never ran as satisfied: it waits for a report that will never come, and the
+  #     pull request cannot be merged at all. A paths filter here would therefore
+  #     wedge every docs-only pull request — a Guide/ edit, a README fix — with a
+  #     check that is not pending, not failing, just absent. A job skipped by its
+  #     own `if:` (policy_check, below) reports "skipped" and does satisfy the
+  #     requirement; a workflow filtered out by `paths:` reports nothing.
+  #
+  # The lint job is ~25s, so running it on every pull request is the cheaper half
+  # of that trade by a wide margin.
   pull_request:
     types: [opened, synchronize, reopened]
-    # The three content trees, AND everything that decides whether they are valid.
-    # A change to scripts/ is the change most able to break every contributor at
-    # once — it is the harness they are all checked by — so it must not be the one
-    # change that runs no checks. templates/ and tests/ are shared source for the
-    # same reason; .github/workflows/ so a workflow edit is checked by the
-    # workflow it edits.
-    paths:
-      - 'inputs/**'
-      - 'policies/**'
-      - 'docs/**'
-      - 'scripts/**'
-      - 'templates/**'
-      - 'tests/**'
-      - '.github/workflows/**'
 
 # Least privilege by default; the policy_check job widens to pull-requests:write
 # for labelling. The lint job needs only read.

--- a/README.md
+++ b/README.md
@@ -209,8 +209,8 @@ rather than re-deriving a path or a hash — which is why a provider bump, or th
 
 Two GitHub Actions workflows in `.github/workflows/`:
 
-- **`policy_check_PR`** — runs on every PR that touches `docs/`, `inputs/`, `policies/`, or the
-  tooling that validates them (`scripts/`, `templates/`, `tests/`, `.github/workflows/`):
+- **`policy_check_PR`** — runs on **every** pull request (no `paths:` filter: `lint` is a required
+  check, and GitHub never treats a workflow that did not run as satisfied):
   - *lint* job (all PRs): branch-name convention → whole-tree **structural** lint → the tools'
     own **test suite** → a **content** lint scoped to the files this PR changed (the repo-wide
     backlog never blocks you).


### PR DESCRIPTION
**Prerequisite for making `lint` a required status check.**

GitHub does not treat a workflow that never ran as satisfied — it waits for a report that will never arrive. So with a `paths:` filter in place, a required `lint` would leave every pull request outside those paths permanently unmergeable: the check is not pending, not failing, just **absent**.

#702 was exactly that shape — it touched only `Guide/`. A README fix would be too.

The filter is removed, so `policy_check_PR` now runs on every pull request.

One distinction worth knowing, because it is what makes this safe: a job skipped by its own `if:` — `policy_check`, gated on `Service/` branches — reports a `skipped` conclusion, and that **does** satisfy a required check. Only a workflow filtered out before it starts reports nothing at all. So `policy_check` can stay conditional; the workflow itself cannot.

The `lint` job is ~25s, so running it everywhere is much the cheaper half of the trade. It also finishes what #703 started — the checks now watch everything, instead of everything someone remembered to list.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Jw92EhGxpjjsgoNYkqPgMm