### PR TITLE
Require a maintainer's approval, not anyone's

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,19 @@
+# Who has to approve a pull request into dev.
+#
+# Paired with `require_code_owner_review` on the protect-dev-reviews ruleset, this
+# is what makes "1 approving review" mean a maintainer rather than anyone with
+# write access. Without it, the repo's 55 write-access collaborators — which
+# includes contributors — can approve each other.
+#
+# The list is a TEAM, not people, so adding or removing a reviewer is a change to
+# @Hardhat-Enterprises/pde-admin and never a change to this file or the ruleset.
+#
+# The team needs write access to the repository or its reviews do not count
+# towards the requirement. pde-admin has admin, so it does.
+#
+# Note the PDE Portal app is deliberately absent: CODEOWNERS accepts users and
+# teams only, never a GitHub App. It does not need to be here — it already holds a
+# `pull_request` bypass on the ruleset, so the pull requests it raises are not held
+# up by this file.
+
+*   @Hardhat-Enterprises/pde-admin


### PR DESCRIPTION
The `dev` ruleset asks for **1 approving review** — but with no CODEOWNERS file and no named reviewers, that means *any* collaborator with write access. There are **55** of them, and contributors are in that list. Two contributors can approve each other today.

Adds `* @Hardhat-Enterprises/pde-admin`.

## The team already exists, with the membership you wanted

`@Hardhat-Enterprises/pde-admin` — currently one member, `JBarazani`, with admin. Adding reviewers later is a change to the **team**, never to this file or the ruleset.

It needs write access or its reviews wouldn't count toward the requirement. It has admin, so it does.

## One correction: the portal app can't be a code owner

CODEOWNERS accepts **users and teams only** — never a GitHub App. But it doesn't need to be there: the app already holds a `pull_request` bypass on `protect-dev-reviews`, so the pull requests it raises aren't held up by this.

## This file does nothing until you flip the switch

It has no effect until `require_code_owner_review` is set to `true` on `protect-dev-reviews`. Landing the file first means that toggle can be turned on — and off — without a commit either way.

## Before you flip it, one decision

`*` means **every** pull request needs `pde-admin` approval, including every contributor resource PR. With one person on the team that's a queue on you.

The alternative is to scope it to what actually needs a maintainer's eye and leave resource PRs to peer review:

```
/scripts/              @Hardhat-Enterprises/pde-admin
/policies/_helpers/    @Hardhat-Enterprises/pde-admin
/templates/            @Hardhat-Enterprises/pde-admin
/.github/              @Hardhat-Enterprises/pde-admin
```

That covers the shared harness — the code every contributor is checked by, which is where an unreviewed change does the most damage — and leaves the ~400 resource kits to the existing gates. Say which you want and I'll adjust before this merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Jw92EhGxpjjsgoNYkqPgMm