### PR TITLE
Add security assessment for google_apigee_keystores_aliases_key_cert_file

### DIFF
--- a/docs/gcp/Apigee/google_apigee_keystores_aliases_key_cert_file.json
+++ b/docs/gcp/Apigee/google_apigee_keystores_aliases_key_cert_file.json
@@ -6,50 +6,50 @@
       "description": "Alias Name.",
       "required": true,
       "type": "string",
-      "security_impact": "true/false",
-      "rationale": ""
+      "security_impact": false,
+      "rationale": "This is a naming identifier for the cert/key pair within the keystore. The alias name is a team-specific label with no effect on security posture. A generic platform policy cannot constrain alias names without hardcoding team-specific naming schemes."
     },
     "cert": {
       "description": "Cert content.",
       "required": true,
       "type": "string",
-      "security_impact": "true/false",
-      "rationale": ""
+      "security_impact": false,
+      "rationale": "This is the actual TLS certificate content in PEM format. The certificate is team-specific cryptographic material issued by each team's CA or self-signed. A Rego policy evaluating terraform plan JSON sees only a raw string and cannot parse X.509 attributes such as key size, expiry, or issuer. No meaningful generic platform policy can be written against the raw cert content."
     },
     "environment": {
       "description": "Environment associated with the alias.",
       "required": true,
       "type": "string",
-      "security_impact": "true/false",
-      "rationale": ""
+      "security_impact": false,
+      "rationale": "This specifies which Apigee environment the keystore alias belongs to. Environment names are arbitrary, team-specific strings with no platform-enforced security distinction. The security configuration of the environment itself is governed by the google_apigee_environment resource."
     },
     "key": {
       "description": "Private Key content, omit if uploading to truststore.",
       "required": false,
       "type": "string",
-      "security_impact": "true/false",
-      "rationale": ""
+      "security_impact": false,
+      "rationale": "This is the private key content in PEM format. It is optional and must be omitted when uploading to a truststore, which only requires certificates. The key content is team-specific cryptographic material. A generic policy cannot meaningfully constrain it: requiring it to be present would break truststore use cases, and the raw PEM string in the terraform plan JSON cannot be parsed for key strength or algorithm."
     },
     "keystore": {
       "description": "Keystore Name.",
       "required": true,
       "type": "string",
-      "security_impact": "true/false",
-      "rationale": ""
+      "security_impact": false,
+      "rationale": "This is a reference to the keystore by name. The value is team-specific. The keystore's own creation and configuration are managed on the google_apigee_env_keystore resource, not by resources that reference it."
     },
     "org_id": {
       "description": "Organization ID associated with the alias.",
       "required": true,
       "type": "string",
-      "security_impact": "true/false",
-      "rationale": ""
+      "security_impact": false,
+      "rationale": "This is a reference to the parent Apigee Organization. The value is inherently team- or project-specific. A generic platform policy cannot constrain it without hardcoding specific organization identifiers. The security of the organization itself is governed by the google_apigee_organization resource."
     },
     "password": {
       "description": "Password for the Private Key if it's encrypted.",
       "required": false,
       "type": "string",
-      "security_impact": "true/false",
-      "rationale": ""
+      "security_impact": false,
+      "rationale": "This is the password used to decrypt the private key if it is encrypted. Whether a password is needed depends on whether the team used an encrypted key, which is a team-specific operational decision. A generic policy cannot enforce password strength from a raw string in the terraform plan, and requiring a password to always be set would break use cases with unencrypted keys or truststore-only uploads where no key is present."
     }
   }
 }

--- a/policies/gcp/Apigee/google_apigee_keystores_aliases_key_cert_file/_vars.rego
+++ b/policies/gcp/Apigee/google_apigee_keystores_aliases_key_cert_file/_vars.rego
@@ -1,0 +1,6 @@
+package terraform.gcp.security.apigee.google_apigee_keystores_aliases_key_cert_file.vars
+variables := {
+    "friendly_resource_name": "Apigee Keystores Aliases Key Cert File", 
+    "resource_type":  "google_apigee_keystores_aliases_key_cert_file",
+    "resource_value_name" : "name" 
+}


### PR DESCRIPTION
### Summary
Completed the security assessment for `google_apigee_keystores_aliases_key_cert_file `under the Apigee service.

### What was done

- Assessed all 7 arguments (`alias, cert, environment, key, keystore, org_id, password`) for `security_impact `using the five-question framework.

- Researched each argument against Terraform provider docs and GCP's Apigee Keystores and Truststores documentation

### Assessment outcome
All 7 arguments assessed as `security_impact: false`. No policies or input fixtures are required. This resource does not have a `deletion_policy `argument.

- **alias = false:** Naming identifier; team-specific, no security effect
- **cert = false:** Team-specific certificate PEM content; raw string cannot be parsed for X.509 attributes in a Rego policy
- **environment = false:** Team-specific environment name; security managed on google_apigee_environment
- **key = false:** Team-specific private key content; optional for truststores, raw PEM cannot be validated
- **keystore = false:** Reference to another resource; keystore managed on google_apigee_env_keystore
- **org_id = false:** Parent resource reference; team-specific, not policy-targetable
- **password = false:** Team-specific key decryption password; requiring it would break unencrypted key and truststore use cases

### Files changed
`docs/gcp/Apigee/google_apigee_keystores_aliases_key_cert_file.json` - completed security_impact and rationale for all arguments