### PR TITLE
Add security assessment and policy for google_apigee_security_feedback

### DIFF
--- a/docs/gcp/Apigee/google_apigee_security_feedback.json
+++ b/docs/gcp/Apigee/google_apigee_security_feedback.json
@@ -6,50 +6,50 @@
       "description": "Optional text the user can provide for additional, unstructured context.",
       "required": false,
       "type": "string",
-      "security_impact": "true/false",
-      "rationale": ""
+      "security_impact": false,
+      "rationale": "This is free-text informational metadata providing additional context for the exclusion. It has no effect on what traffic is excluded or how the exclusion behaves. Constraining it would not improve security posture."
     },
     "deletion_policy": {
       "description": "Whether Terraform will be prevented from destroying the instance. Defaults to \"DELETE\".\nWhen a 'terraform destroy' or 'terraform apply' would delete the instance,\nthe command will fail if this field is set to \"PREVENT\" in Terraform state.\nWhen set to \"ABANDON\", the command will remove the resource from Terraform\nmanagement without updating or deleting the resource in the API.\nWhen set to \"DELETE\", deleting the resource is allowed.\n",
       "required": false,
       "type": "string",
-      "security_impact": "true/false",
-      "rationale": ""
+      "security_impact": true,
+      "rationale": "This argument controls whether Terraform can destroy the security feedback exclusion list. The default value of DELETE allows unrestricted destructive operations. Deleting a security feedback resource removes the exclusion list, which could cause previously excluded legitimate traffic (such as penetration tests or internal systems) to suddenly trigger false-positive security alerts and potentially be blocked by security actions. A generic platform policy can require this to be set to PREVENT, blocking accidental or unauthorized deletion at the platform level without requiring team-specific values."
     },
     "display_name": {
       "description": "The display name of the feedback.",
       "required": false,
       "type": "string",
-      "security_impact": "true/false",
-      "rationale": ""
+      "security_impact": false,
+      "rationale": "This is a display name for the exclusion list. It is purely informational metadata with no effect on what traffic is excluded or how the exclusion behaves. Constraining it would not improve security posture."
     },
     "feedback_id": {
       "description": "Resource ID of the security feedback.",
       "required": true,
       "type": "string",
-      "security_impact": "true/false",
-      "rationale": ""
+      "security_impact": false,
+      "rationale": "This is the resource identifier for the security feedback. It is a naming identifier with no effect on security posture. A generic policy cannot constrain it without hardcoding team-specific naming schemes."
     },
     "feedback_type": {
       "description": "The type of feedback being submitted. Possible values: [\"EXCLUDED_DETECTION\"]",
       "required": true,
       "type": "string",
-      "security_impact": "true/false",
-      "rationale": ""
+      "security_impact": false,
+      "rationale": "This specifies the type of feedback. Currently the only possible value is EXCLUDED_DETECTION. Since there is only one accepted value, a policy cannot meaningfully constrain this — every instance of this resource will use the same value. No security distinction exists between options."
     },
     "org_id": {
       "description": "The Apigee Organization associated with the Apigee Security Feedback,\nin the format 'organizations/{{org_name}}'.",
       "required": true,
       "type": "string",
-      "security_impact": "true/false",
-      "rationale": ""
+      "security_impact": false,
+      "rationale": "This is a reference to the parent Apigee Organization. The value is inherently team- or project-specific. A generic platform policy cannot constrain it without hardcoding specific organization identifiers. The security of the organization itself is governed by the google_apigee_organization resource."
     },
     "reason": {
       "description": "The reason for the feedback. Possible values: [\"INTERNAL_SYSTEM\", \"NON_RISK_CLIENT\", \"NAT\", \"PENETRATION_TEST\", \"OTHER\"]",
       "required": false,
       "type": "string",
-      "security_impact": "true/false",
-      "rationale": ""
+      "security_impact": false,
+      "rationale": "This classifies why the exclusion is being made (internal system, non-risk client, NAT, penetration test, or other). All values are legitimate reasons for creating an exclusion. The reason is informational metadata that categorises the exclusion but does not change its behaviour. Constraining it would not improve security posture."
     },
     "feedback_contexts": {
       "type": "block",
@@ -60,15 +60,15 @@
       "description": "The attribute the user is providing feedback about. Possible values: [\"ATTRIBUTE_ENVIRONMENTS\", \"ATTRIBUTE_IP_ADDRESS_RANGES\"]",
       "required": true,
       "type": "string",
-      "security_impact": "true/false",
-      "rationale": ""
+      "security_impact": false,
+      "rationale": "This specifies whether the exclusion targets environments or IP address ranges. Both are legitimate exclusion scopes depending on the team's use case. A generic policy cannot determine which scope is appropriate without team-specific knowledge of their exclusion requirements."
     },
     "feedback_contexts.values": {
       "description": "The values of the attribute the user is providing feedback about, separated by commas.",
       "required": true,
       "type": "list(string)",
-      "security_impact": "true/false",
-      "rationale": ""
+      "security_impact": false,
+      "rationale": "This specifies the actual environment names or IP/CIDR ranges being excluded from abuse detection. The values are inherently team-specific — they depend on which environments or IP ranges the team needs to exclude (e.g. pen testing IPs, internal system ranges). A generic policy cannot constrain these without hardcoding team-specific values."
     }
   }
 }

--- a/inputs/gcp/Apigee/google_apigee_security_feedback/deletion_policy/compliant.tf
+++ b/inputs/gcp/Apigee/google_apigee_security_feedback/deletion_policy/compliant.tf
@@ -1,0 +1,14 @@
+resource "google_apigee_security_feedback" "compliant_example_1" {
+  org_id          = "organizations/PDE-Apigee-Project"
+  feedback_id     = "example-feedback"
+  feedback_type   = "EXCLUDED_DETECTION"
+  display_name    = "Example exclusion list"
+  reason          = "PENETRATION_TEST"
+  comment         = "Example exclusion"
+  deletion_policy = "PREVENT"
+
+  feedback_contexts {
+    attribute = "ATTRIBUTE_IP_ADDRESS_RANGES"
+    values    = ["192.168.1.0/24"]
+  }
+}

--- a/inputs/gcp/Apigee/google_apigee_security_feedback/deletion_policy/config.tf
+++ b/inputs/gcp/Apigee/google_apigee_security_feedback/deletion_policy/config.tf
@@ -1,0 +1,11 @@
+##### DO NOT EDIT ######
+
+terraform {
+  required_providers {
+    google = {
+      source  = "hashicorp/google"
+    }
+  }
+}
+
+provider "google" {}

--- a/inputs/gcp/Apigee/google_apigee_security_feedback/deletion_policy/nonCompliant.tf
+++ b/inputs/gcp/Apigee/google_apigee_security_feedback/deletion_policy/nonCompliant.tf
@@ -1,0 +1,14 @@
+resource "google_apigee_security_feedback" "non_compliant_example_1" {
+  org_id          = "organizations/PDE-Apigee-Project"
+  feedback_id     = "example-feedback"
+  feedback_type   = "EXCLUDED_DETECTION"
+  display_name    = "Example exclusion list"
+  reason          = "PENETRATION_TEST"
+  comment         = "Example exclusion"
+  deletion_policy = "DELETE"
+
+  feedback_contexts {
+    attribute = "ATTRIBUTE_IP_ADDRESS_RANGES"
+    values    = ["192.168.1.0/24"]
+  }
+}

--- a/policies/gcp/Apigee/google_apigee_security_feedback/_vars.rego
+++ b/policies/gcp/Apigee/google_apigee_security_feedback/_vars.rego
@@ -1,0 +1,6 @@
+package terraform.gcp.security.apigee.google_apigee_security_feedback.vars
+variables := {
+    "friendly_resource_name": "Apigee Security Feedback", 
+    "resource_type":  "google_apigee_security_feedback",
+    "resource_value_name" : "name" 
+}

--- a/policies/gcp/Apigee/google_apigee_security_feedback/deletion_policy.rego
+++ b/policies/gcp/Apigee/google_apigee_security_feedback/deletion_policy.rego
@@ -1,0 +1,22 @@
+package terraform.gcp.security.apigee.google_apigee_security_feedback.deletion_policy
+import data.terraform.helpers
+import data.terraform.gcp.security.apigee.google_apigee_security_feedback.vars
+conditions := [
+    [
+        {
+            "situation_description": "deletion_policy must be set to PREVENT to block destructive operations",
+            "remedies": [
+                "Set deletion_policy to PREVENT to block accidental or unauthorized deletion of the security feedback exclusion list via terraform destroy"
+            ]
+        },
+        {
+            "condition": "check deletion_policy is set to PREVENT",
+            "attribute_path": ["deletion_policy"],
+            "values": ["PREVENT"],
+            "policy_type": "whitelist"
+        }
+    ]
+]
+result := helpers.get_multi_summary(conditions, vars.variables)
+message := result.message
+details := result.details


### PR DESCRIPTION
### Summary

Completed the security assessment for `google_apigee_security_feedback` under the Apigee service, including a Rego policy and Terraform fixtures for the one true argument.

### What was done

- Assessed all 9 leaf arguments (`comment`, `deletion_policy`, `display_name`, `feedback_id`, `feedback_type`, `org_id`, `reason`, `feedback_contexts.attribute`, `feedback_contexts.values`) for `security_impact` using the five-question framework
- Researched each argument against Terraform provider docs and GCP's
Security Feedback API and Abuse Detection exclusion list documentation
- Wrote defensible rationales for each argument
- Created Rego policy and Terraform fixtures for the `deletion_policy` argument

### Assessment outcome

1 argument assessed as `security_impact: true`, 8 assessed as `false`.

- **deletion_policy** — true: Deletion-blocking flag
prevents destructive loss; removing an exclusion list could cause
legitimate traffic to trigger false-positive security alerts
- **comment** — false: Free-text informational metadata; no effect on exclusion behaviour
- **display_name** — false: Naming metadata; no security effect
- **feedback_id** — false: Resource identifier; team-specific naming
- **feedback_type** — false: Only one possible value (EXCLUDED_DETECTION); nothing to constrain
- **org_id** — false: Parent resource reference; team-specific, not policy-targetable
- **reason** — false: Informational classification; all values equally legitimate
- **feedback_contexts.attribute** — false: Exclusion scope (environments or IP ranges); team-specific choice
- **feedback_contexts.values** — false: Actual environment names or IP ranges; inherently team-specific

### Files changed

- `docs/gcp/Apigee/google_apigee_security_feedback.json` — completed `security_impact` and `rationale` for all arguments
- `policies/gcp/Apigee/google_apigee_security_feedback/_vars.rego` — resource-level variables
- `policies/gcp/Apigee/google_apigee_security_feedback/deletion_policy.rego` — policy whitelisting PREVENT
- `inputs/gcp/Apigee/google_apigee_security_feedback/deletion_policy/` — compliant (PREVENT) and non-compliant (DELETE) fixtures