### PR TITLE
Report CRLF blobs on dev, without letting them block anyone

### DIFF
--- a/.github/workflows/policy_check_ALL.yaml
+++ b/.github/workflows/policy_check_ALL.yaml
@@ -30,6 +30,22 @@ jobs:
         with:
           python-version: '3.x'
 
+      # Report-only, and deliberately BEFORE the lint gate so it is still reported
+      # on a run the lint then fails. `.gitattributes` normalises new content at
+      # check-in, but it does not retro-fix blobs already committed on a branch cut
+      # before it landed, and git does not renormalise on merge — so such a branch
+      # can still carry CRLF onto dev. Nothing breaks when it does (fixture_sha
+      # canonicalises before hashing), but the files then read as modified in every
+      # clean checkout, which is how #750's two errors ended up attributed to
+      # whoever happened to be committing.
+      #
+      # continue-on-error on purpose: a hard whole-tree gate on this would be the
+      # very failure it exists to catch — one CRLF file anywhere on dev would turn
+      # every contributor's pull request red at once. dev-only, advisory, visible.
+      - name: Line endings (report only)
+        continue-on-error: true
+        run: python3 scripts/linters/check_line_endings.py
+
       - name: Lint (whole tree, structural + content)
         run: python3 scripts/linters/linter.py --tree all --platform gcp
 

--- a/scripts/linters/_tests/test_line_endings.py
+++ b/scripts/linters/_tests/test_line_endings.py
@@ -1,0 +1,140 @@
+"""Unit tests for scripts/linters/check_line_endings.py.
+
+The detector reads the *index*, not the working tree, so every case here builds a
+real throwaway repo and commits into it. That distinction is the whole point: a
+CRLF working tree is normal and harmless on Windows; a CRLF *blob* is the thing
+that shows as modified in every clean checkout forever.
+"""
+
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+project_root = Path(__file__).parent.parent.parent.parent
+sys.path.insert(0, str(project_root))
+
+from scripts.linters import check_line_endings as cle
+
+
+def _git(*args, cwd):
+    proc = subprocess.run(["git", *args], cwd=cwd, capture_output=True, text=True)
+    assert proc.returncode == 0, f"git {' '.join(args)}: {proc.stderr}"
+    return proc.stdout
+
+
+@pytest.fixture
+def repo(tmp_path):
+    """A repo with an inputs/ tree and no .gitattributes (so blobs go in verbatim)."""
+    _git("init", "--quiet", cwd=tmp_path)
+    _git("config", "user.email", "t@example.com", cwd=tmp_path)
+    _git("config", "user.name", "t", cwd=tmp_path)
+    _git("config", "core.autocrlf", "false", cwd=tmp_path)
+    (tmp_path / "inputs").mkdir()
+    return tmp_path
+
+
+def _commit(repo, name, data: bytes):
+    path = repo / "inputs" / name
+    path.write_bytes(data)
+    _git("add", "--", f"inputs/{name}", cwd=repo)
+    _git("commit", "--quiet", "-m", name, cwd=repo)
+    return path
+
+
+def test_an_lf_blob_is_clean(repo):
+    _commit(repo, "a.tf", b'resource "x" "y" {}\n')
+    assert cle.crlf_files(("inputs",), cwd=repo) == []
+
+
+def test_a_crlf_blob_is_reported(repo):
+    _commit(repo, "a.tf", b'resource "x" "y" {}\r\n')
+    assert cle.crlf_files(("inputs",), cwd=repo) == ["inputs/a.tf"]
+
+
+def test_a_mixed_blob_is_reported(repo):
+    # Half CRLF, half LF — git calls this `i/mixed`, and it is just as sticky.
+    _commit(repo, "a.tf", b'a = 1\r\nb = 2\n')
+    assert cle.crlf_files(("inputs",), cwd=repo) == ["inputs/a.tf"]
+
+
+def test_a_file_with_no_line_endings_is_clean(repo):
+    # `i/none` — a single line with no terminator. Nothing to normalise.
+    _commit(repo, "a.tf", b"a = 1")
+    assert cle.crlf_files(("inputs",), cwd=repo) == []
+
+
+def test_a_binary_file_is_never_reported(repo):
+    # `i/-text`. A .png full of \r\n bytes is not a line-ending problem.
+    _commit(repo, "a.png", b"\x89PNG\r\n\x1a\n\x00\x01\x02\r\n")
+    assert cle.crlf_files(("inputs",), cwd=repo) == []
+
+
+def test_only_the_index_counts_not_the_working_tree(repo):
+    # The distinction the whole check rests on: a contributor may hold CRLF in
+    # their working tree (Windows default) with an LF blob committed, and that is
+    # the *correct* state — it must not be reported.
+    path = _commit(repo, "a.tf", b"a = 1\n")
+    path.write_bytes(b"a = 1\r\n")
+    assert cle.crlf_files(("inputs",), cwd=repo) == []
+
+
+def test_results_are_sorted(repo):
+    for name in ("c.tf", "a.tf", "b.tf"):
+        _commit(repo, name, b"x = 1\r\n")
+    assert cle.crlf_files(("inputs",), cwd=repo) == [
+        "inputs/a.tf", "inputs/b.tf", "inputs/c.tf"]
+
+
+def test_untracked_files_are_invisible(repo):
+    _commit(repo, "a.tf", b"a = 1\n")
+    (repo / "inputs" / "scratch.tf").write_bytes(b"junk\r\n")
+    assert cle.crlf_files(("inputs",), cwd=repo) == []
+
+
+# --------------------------------------------------------------------------- #
+# Line parsing — the `git ls-files --eol` format is space-padded, not tabbed,
+# for its first three fields, which is easy to get wrong.
+# --------------------------------------------------------------------------- #
+@pytest.mark.parametrize("line,expected", [
+    ("i/lf    w/lf    attr/text eol=lf      \tinputs/a.tf", ("lf", "inputs/a.tf")),
+    ("i/crlf  w/crlf  attr/text eol=lf      \tinputs/a.tf", ("crlf", "inputs/a.tf")),
+    ("i/-text w/-text attr/                 \tinputs/a.png", ("-text", "inputs/a.png")),
+    # A path containing a space must survive: the path is everything after the
+    # last tab, and this repo is full of them ("Compute Engine").
+    ("i/crlf  w/crlf  attr/                 \tinputs/gcp/Compute Engine/a.tf",
+     ("crlf", "inputs/gcp/Compute Engine/a.tf")),
+])
+def test_eol_lines_parse(line, expected):
+    assert cle.parse_eol_line(line) == expected
+
+
+@pytest.mark.parametrize("line", ["", "not a git line", "i/lf w/lf attr/ no-tab-here"])
+def test_unparseable_lines_are_skipped(line):
+    assert cle.parse_eol_line(line) is None
+
+
+# --------------------------------------------------------------------------- #
+# Exit codes — it is wired report-only in CI, but must still work as a check.
+# --------------------------------------------------------------------------- #
+def test_main_exits_zero_on_the_real_repo(capsys):
+    # dev is LF-clean and must stay that way; this is the regression guard.
+    assert cle.main([]) == 0
+    assert "[OK]" in capsys.readouterr().out
+
+
+def test_main_exits_one_when_something_is_found(repo, monkeypatch, capsys):
+    monkeypatch.setattr(cle, "crlf_files", lambda *a, **k: ["inputs/a.tf"])
+    assert cle.main([]) == 1
+    out = capsys.readouterr().out
+    assert "inputs/a.tf" in out
+    assert "git add --renormalize" in out, "the remedy is the point of the output"
+
+
+def test_quiet_drops_the_remedy(repo, monkeypatch, capsys):
+    monkeypatch.setattr(cle, "crlf_files", lambda *a, **k: ["inputs/a.tf"])
+    assert cle.main(["--quiet"]) == 1
+    out = capsys.readouterr().out
+    assert "inputs/a.tf" in out
+    assert "git add --renormalize" not in out

--- a/scripts/linters/check_line_endings.py
+++ b/scripts/linters/check_line_endings.py
@@ -1,0 +1,119 @@
+#!/usr/bin/env python3
+"""
+Report tracked text files whose committed blob holds CRLF line endings.
+
+Nothing in the harness depends on line endings any more — ``.gitattributes``
+normalises on check-in, and ``auto_test.fixture_sha`` canonicalises before
+hashing, so a CRLF file no longer changes a fixture's plan name. This is not a
+correctness gate; it is a smoke alarm for one specific thing that can still
+happen and is invisible until it hurts:
+
+    `.gitattributes` normalises new *content* at check-in. It does not
+    retro-fix blobs already committed on a branch cut before it landed, and git
+    does not renormalise on merge. So such a branch can still carry CRLF blobs
+    onto dev — which is exactly how google_compute_network_endpoints arrived
+    after the fix that was supposed to prevent it.
+
+The symptom is nasty out of proportion to the cause: the blob is CRLF while the
+attribute says LF, so git reports the file as *modified in every clean
+checkout*, forever, for everyone. During the September 2026 incident that made
+run_precommit_linter attribute two unrelated errors to whoever happened to be
+committing, on whatever branch.
+
+Run it against a checkout (it reads the index, so it describes the commit you
+have checked out, not your working tree edits):
+
+    python3 scripts/linters/check_line_endings.py
+
+Exits 1 when anything is found, so it works as a check. In CI it is deliberately
+wired report-only (`continue-on-error`) on the dev-only whole-tree workflow: a
+CRLF blob is worth knowing about the day it lands, and is never worth blocking
+every contributor over. That distinction is the whole point — a hard whole-tree
+gate on this would reproduce the incident it exists to catch.
+"""
+import argparse
+import subprocess
+import sys
+
+# Trees worth watching. scripts/ and Guide/ are included because the same merge
+# that carries a fixture can carry a helper or a doc.
+DEFAULT_PATHS = ("docs", "inputs", "policies", "scripts", "templates", "tests", "Guide")
+
+# `git ls-files --eol` index states that mean "this blob is not LF-clean".
+# `i/none` (no line endings at all) and `i/-text` (binary) are both fine.
+BAD_INDEX_EOL = ("crlf", "mixed")
+
+REMEDY = """
+Fix on the branch that introduced them:
+
+    git config core.autocrlf input      # Windows only; stops it recurring
+    git add --renormalize .
+    git commit -m "Normalise line endings"
+
+If a fixture's committed plan then reports as missing, run
+`python3 scripts/auto_test/auto_test.py` and commit the renames it makes — the
+plan contents are already correct, so no terraform is needed.
+""".strip()
+
+
+def parse_eol_line(line):
+    """``('crlf', 'path')`` from one `git ls-files --eol` line, or None.
+
+    The format is ``i/<eol>\tw/<eol>\tattr/<attrs>\t<path>``, except the first
+    three fields are space-padded rather than tab-separated in practice, so the
+    path is taken from the last tab and the states from the leading tokens.
+    """
+    if "\t" not in line:
+        return None
+    head, path = line.split("\t")[0], line.split("\t")[-1]
+    fields = head.split()
+    if not fields or not fields[0].startswith("i/"):
+        return None
+    return fields[0][len("i/"):], path
+
+
+def crlf_files(paths=DEFAULT_PATHS, cwd=None):
+    """Tracked files under ``paths`` whose index blob is CRLF or mixed."""
+    proc = subprocess.run(["git", "ls-files", "--eol", "--", *paths],
+                          capture_output=True, text=True, cwd=cwd)
+    if proc.returncode != 0:
+        raise RuntimeError(proc.stderr.strip() or "git ls-files --eol failed")
+    found = []
+    for line in proc.stdout.splitlines():
+        parsed = parse_eol_line(line)
+        if parsed and parsed[0] in BAD_INDEX_EOL:
+            found.append(parsed[1])
+    return sorted(found)
+
+
+def main(argv=None):
+    parser = argparse.ArgumentParser(
+        description="Report tracked files committed with CRLF line endings.")
+    parser.add_argument("paths", nargs="*", default=list(DEFAULT_PATHS),
+                        help=f"paths to scan (default: {' '.join(DEFAULT_PATHS)})")
+    parser.add_argument("--quiet", action="store_true",
+                        help="print only the count and the paths, no remedy text")
+    args = parser.parse_args(argv)
+
+    try:
+        found = crlf_files(args.paths or DEFAULT_PATHS)
+    except RuntimeError as exc:
+        print(f"[ERROR] {exc}", file=sys.stderr)
+        return 2
+
+    if not found:
+        print("[OK] no tracked files carry CRLF line endings.")
+        return 0
+
+    print(f"[WARN] {len(found)} tracked file(s) committed with CRLF line endings.")
+    print("       They will show as modified in every clean checkout until "
+          "renormalised.\n")
+    for path in found:
+        print(f"  {path}")
+    if not args.quiet:
+        print(f"\n{REMEDY}")
+    return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/linters/readme-linters.md
+++ b/scripts/linters/readme-linters.md
@@ -24,6 +24,15 @@ There are four supporting scripts:
   and sweeping up another resource's files — neither of which fails any test on
   the branch that caused it. Rules are documented in
   `Guide/Policy_writing_tutorial/branch-scope.md`.
+- `check_line_endings.py` — reports tracked files whose **committed blob** holds
+  CRLF. Advisory, not a gate: nothing in the harness depends on line endings any
+  more (`.gitattributes` normalises at check-in and `auto_test.fixture_sha`
+  canonicalises before hashing), but `.gitattributes` cannot retro-fix blobs on a
+  branch cut before it landed, and git does not renormalise on merge — so such a
+  branch can still carry CRLF onto `dev`. Those files then read as modified in
+  every clean checkout, for everyone, until renormalised. Runs report-only on the
+  dev-only `policy_check_ALL` workflow and never on a pull request: a hard
+  whole-tree gate on this would be the exact failure it exists to catch.
 - `policy_lint.py` — deterministic *content*-quality rules over a policy kit's
   declared `conditions`/`variables` (hard-coded literals, trivial messages,
   fixture drift, ...). It answers whether the policy is any good, not just


### PR DESCRIPTION
A smoke alarm for the one line-ending failure that can still happen. Advisory only — it cannot fail any pull request.

## What can still happen

`.gitattributes` normalises new content at check-in, and `auto_test.fixture_sha` canonicalises before hashing, so a CRLF file can no longer change a fixture's plan name. Neither retro-fixes a blob **already committed** on a branch cut before they landed, and **git does not renormalise on merge**.

That is how `google_compute_network_endpoints` carried five CRLF files onto `dev` *after* the fix meant to prevent exactly that (#750). 225 of 244 `Service/` branches still hold CRLF blobs, so it can happen again.

Nothing breaks when it does — which is the problem. The blob is CRLF while the attribute says LF, so git reports those files as **modified in every clean checkout, for everyone, forever**. That is what had `run_precommit_linter` attributing two unrelated errors to whoever happened to be committing, on whatever branch, for two days before anyone worked out why.

## Why it is advisory and dev-only

A hard whole-tree gate on this would be the exact failure it exists to catch: one CRLF file anywhere on `dev` would turn every contributor's PR red at once — which is what #720→#750 actually was.

So: `policy_check_ALL` only (dev pushes), `continue-on-error: true`, and placed **before** the lint gate so it still reports on a run the lint then fails. Visible the day it lands, never blocking.

## The detector

`scripts/linters/check_line_endings.py` reads the **index**, not the working tree, and lists any blob git calls `crlf` or `mixed`, with the renormalise remedy. Exit 1 when it finds something, so it is usable as a check by hand.

The index/worktree distinction is the whole design: a CRLF *working tree* on Windows is correct and must never be reported; a CRLF *blob* is the sticky one. There is a test for exactly that.

Verified against `562e07cf` (last commit before #750) — names exactly the five files:

```
[WARN] 5 tracked file(s) committed with CRLF line endings.
       They will show as modified in every clean checkout until renormalised.

  inputs/gcp/Compute Engine/google_compute_network_endpoints/deletion_policy/compliant.tf
  inputs/gcp/Compute Engine/google_compute_network_endpoints/deletion_policy/nonCompliant.tf
  inputs/gcp/Compute Engine/google_compute_network_endpoints/zone/compliant.tf
  inputs/gcp/Compute Engine/google_compute_network_endpoints/zone/nonCompliant.tf
  policies/gcp/Compute Engine/google_compute_network_endpoints/zone.rego
```

…and silent on `dev` today.

## Tests

18, covering: LF clean; CRLF reported; mixed reported; no-line-endings clean; binary never reported; **a CRLF working tree over an LF blob is clean**; untracked invisible; sorted output; the space-padded `git ls-files --eol` parse including paths with spaces (`Compute Engine`); and both exit codes.

## Gates

`pytest` 366 passed · whole-tree lint `[OK] No errors found` · `check_resource.py` every check passed · workflow YAML parses with the step in position 3, `continue-on-error: true`.

## Note for the bot owners

This does not touch `PR checks` and does not rename any check context — the portal bot's new polling gate is unaffected.

Separately, I have asked them about something adjacent I noticed while mapping this workflow: the `Lint (whole tree…)` step has no `continue-on-error` and `Run policy checks` comes after it, so when the lint fails, `policy_results.json` is never regenerated and the `policy-results` artifact upload (`if: always()`) has nothing to upload. That was `dev`'s state for the whole #720→#750 window. Not changed here — the portal is the consumer and should say what it wants.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UBbGxYwxacJMHq9NH2wG2B