### PR TITLE
Split policy_check_ALL so a lint failure cannot stop the artifact

### DIFF
--- a/.github/workflows/policy_check_ALL.yaml
+++ b/.github/workflows/policy_check_ALL.yaml
@@ -19,8 +19,30 @@ env:
   TERRAFORM_VERSION: "1.15.7"
   OPA_VERSION: "v1.17.1"
 
+# Two independent jobs, deliberately.
+#
+# They used to be one, with the whole-tree lint first. When that lint failed, the
+# Terraform+OPA step never ran, policy_results.json was never written, and the
+# policy-results upload — `if: always()` — had nothing to upload. dev was in
+# exactly that state for the whole #720 -> #750 window, and the PDE Portal's
+# dev-branch rollup consumes that artifact newest-wins without comparing it to the
+# commit being scanned, so for two days it paired a fresh head sha with the last
+# pre-#720 verdicts and said nothing.
+#
+# Splitting is better than `continue-on-error` on the lint step: the run still goes
+# red honestly when the lint is red, rather than a step marked "soft" hiding it and
+# a later step re-raising it. The two jobs share nothing, so neither can stop the
+# other reporting.
+#
+# NOT applied to policy_check_PR. Its structural lint stays a hard gate: the portal
+# bot polls `PR checks` and refuses to merge a raised pull request while it is red,
+# so softening it there would reopen the hole that let nine red pull requests reach
+# dev. See scripts/_tests/test_workflow_contracts.py, which asserts both halves.
 jobs:
-  policy_check:
+  # Whole-tree lint. Fails red when the tree is broken — this is the alarm that
+  # surfaced #720 -> #750 — and blocks nothing else, because nothing else is in
+  # this job. Python only: no terraform, no OPA, no provider mirror.
+  lint:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7
@@ -49,6 +71,21 @@ jobs:
       - name: Lint (whole tree, structural + content)
         run: python3 scripts/linters/linter.py --tree all --platform gcp
 
+  # The verdicts the portal reads. Runs whatever the lint job does, and always
+  # uploads, so a repo-wide lint regression can never again cost the repo its
+  # policy results. The contract the portal matches on is the artifact name
+  # `policy-results`, its member `policy_results.json`, and that it comes from a
+  # run on dev — none of which may change without telling them.
+  policy_results:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+
+      - name: Setup Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: '3.x'
+
       - name: Setup Terraform
         uses: hashicorp/setup-terraform@v4
         with:
@@ -67,7 +104,8 @@ jobs:
       # gcp resource — a repo-wide companion to the structural lint above, not a gate:
       # continue-on-error so a repo-wide content regression never reddens this job.
       # `--json gcp` is the whole-platform sweep (~11s; needs only OPA, no terraform
-      # plan), so it must run after "Install OPA" above and needs nothing else set up.
+      # plan), so it lives in this job — the one that installs OPA — rather than
+      # beside the structural lint it reads as a companion to.
       - name: Policy lint (whole tree, report only)
         continue-on-error: true
         run: |

--- a/scripts/_tests/test_workflow_contracts.py
+++ b/scripts/_tests/test_workflow_contracts.py
@@ -1,0 +1,183 @@
+"""Contracts the two policy-check workflows must keep.
+
+Not YAML style checks. Each one encodes a decision that was expensive to learn and
+is invisible in the file itself:
+
+* `policy_check_ALL` must always produce the `policy-results` artifact. The PDE
+  Portal's dev-branch rollup consumes it newest-wins with no comparison to the
+  commit being scanned, so when the whole-tree lint used to fail the job outright —
+  taking the Terraform+OPA step and the upload down with it — the portal silently
+  paired a fresh head sha with the last good verdicts for the two days of the
+  #720 -> #750 window. The fix is two independent jobs, so neither can stop the
+  other reporting.
+
+* `policy_check_PR`'s structural lint must stay a hard gate. The portal bot polls
+  `PR checks` and refuses to merge a raised pull request while it is red, so
+  softening it there would quietly reopen the hole that let nine red pull requests
+  reach dev.
+
+The two lints look alike and are one `continue-on-error:` apart, which is exactly
+why this is asserted rather than remembered.
+
+Parsed by hand rather than with PyYAML: the repo declares no runtime dependencies
+and CI installs only pytest, so a yaml import here would simply not run where it
+matters most.
+"""
+
+import re
+from pathlib import Path
+
+import pytest
+
+WORKFLOWS = Path(__file__).parent.parent.parent / ".github" / "workflows"
+ALL_WORKFLOW = WORKFLOWS / "policy_check_ALL.yaml"
+PR_WORKFLOW = WORKFLOWS / "policy_check_PR.yaml"
+
+JOB_RE = re.compile(r"^  ([A-Za-z_][A-Za-z0-9_-]*):\s*$")
+STEP_RE = re.compile(r"^      - (?:name: (.+?)|uses: (.+?))\s*$")
+
+
+def jobs(path):
+    """``{job name: {"body": text, "steps": {step name: text}}}``.
+
+    Job keys are the 2-space-indented mappings under a top-level ``jobs:``; steps
+    are ``- name:``/``- uses:`` at 6 spaces. Enough structure for the assertions
+    here, and no dependency.
+    """
+    out, job, step = {}, None, None
+    in_jobs = False
+    for line in path.read_text(encoding="utf-8").splitlines():
+        if line.startswith("jobs:"):
+            in_jobs = True
+            continue
+        if not in_jobs:
+            continue
+        if line and not line.startswith(" ") and not line.startswith("#"):
+            in_jobs = False           # a new top-level key ends the jobs block
+            continue
+        job_match = JOB_RE.match(line)
+        if job_match:
+            job, step = job_match.group(1), None
+            out[job] = {"body": [], "steps": {}}
+            continue
+        if job is None:
+            continue
+        out[job]["body"].append(line)
+        step_match = STEP_RE.match(line)
+        if step_match:
+            step = step_match.group(1) or step_match.group(2)
+            out[job]["steps"][step] = []
+            continue
+        if step is not None:
+            out[job]["steps"][step].append(line)
+    return {
+        name: {"body": "\n".join(data["body"]),
+               "steps": {s: "\n".join(b) for s, b in data["steps"].items()}}
+        for name, data in out.items()
+    }
+
+
+def has_line(body, text):
+    """True when some line of ``body`` is exactly ``text`` (after stripping).
+
+    Substring matching is not good enough for the artifact contract: `name:
+    policy-results` is a prefix of `name: policy-results-v2`, so a rename would
+    sail past an `in` check — which is precisely the change these assertions exist
+    to catch.
+    """
+    return any(line.strip() == text for line in body.splitlines())
+
+
+def step_of(path, job, name):
+    parsed = jobs(path)
+    assert job in parsed, f"{path.name} has no job {job!r} (renamed?): {list(parsed)}"
+    found = parsed[job]["steps"]
+    assert name in found, f"{path.name}:{job} has no step {name!r}: {list(found)}"
+    return found[name]
+
+
+# --------------------------------------------------------------------------- #
+# policy_check_ALL: the artifact must survive a lint failure.
+# --------------------------------------------------------------------------- #
+def test_lint_and_policy_results_are_separate_jobs():
+    parsed = jobs(ALL_WORKFLOW)
+    assert "lint" in parsed and "policy_results" in parsed, (
+        "the whole-tree lint and the Terraform+OPA run must be separate jobs, so a "
+        "lint failure cannot stop the policy-results artifact being produced")
+
+
+def test_policy_results_does_not_wait_on_the_lint():
+    # A `needs: lint` would restore the exact coupling this split removes: the
+    # artifact would stop being produced the moment the tree failed to lint.
+    body = jobs(ALL_WORKFLOW)["policy_results"]["body"]
+    assert "needs:" not in body, (
+        "policy_results must not depend on the lint job — that dependency is the "
+        "#720 -> #750 failure mode with extra steps")
+
+
+def test_the_whole_tree_lint_still_fails_red():
+    # Splitting must not turn into hiding: a broken tree still reddens the run.
+    body = step_of(ALL_WORKFLOW, "lint", "Lint (whole tree, structural + content)")
+    assert "continue-on-error" not in body, (
+        "the lint job exists to go red honestly; it no longer needs softening "
+        "because it no longer blocks anything")
+
+
+def test_the_policy_run_and_its_upload_live_together():
+    steps = jobs(ALL_WORKFLOW)["policy_results"]["steps"]
+    assert "Run policy checks (Terraform + OPA)" in steps
+    assert "Upload policy results artifact" in steps
+
+
+def test_the_artifact_contract_the_portal_depends_on():
+    # Names the portal matches on. Changing any of them silently breaks its dev
+    # rollup, so they are spelled out here as much as documentation as assertion.
+    body = step_of(ALL_WORKFLOW, "policy_results", "Upload policy results artifact")
+    assert has_line(body, "name: policy-results"), \
+        "the artifact name is what the portal fetches by; it may not be renamed"
+    assert has_line(body, "path: policy_results.json"), \
+        "the member filename is what the portal reads inside the artifact"
+    assert has_line(body, "if: always()"), \
+        "the upload must survive a failing policy run — the report is written first"
+
+
+def test_the_policy_run_writes_the_report_the_upload_expects():
+    assert "--report policy_results.json" in step_of(
+        ALL_WORKFLOW, "policy_results", "Run policy checks (Terraform + OPA)")
+
+
+def test_the_all_workflow_still_runs_on_dev_pushes():
+    # The portal fetches from runs on dev; a trigger change would starve it.
+    head = ALL_WORKFLOW.read_text(encoding="utf-8").split("jobs:")[0]
+    assert "push:" in head and "- dev" in head
+
+
+# --------------------------------------------------------------------------- #
+# policy_check_PR: the gate must stay hard.
+# --------------------------------------------------------------------------- #
+@pytest.mark.parametrize("name", [
+    "Structural lint (whole tree)",
+    "Lint changed files (structural + content)",
+    "Run the test suite",
+])
+def test_the_pr_gates_stay_hard(name):
+    assert "continue-on-error" not in step_of(PR_WORKFLOW, "lint", name), (
+        f"{name!r} must fail the job. The portal bot polls `PR checks` and refuses "
+        "to merge while it is red; softening it reopens the hole that let nine red "
+        "pull requests reach dev")
+
+
+# --------------------------------------------------------------------------- #
+# The line-endings detector is advisory, and dev-only.
+# --------------------------------------------------------------------------- #
+def test_the_line_ending_check_is_report_only():
+    body = step_of(ALL_WORKFLOW, "lint", "Line endings (report only)")
+    assert "continue-on-error: true" in body, (
+        "a hard gate on line endings would be the exact failure it exists to catch "
+        "— one CRLF file on dev would redden every pull request")
+
+
+def test_the_line_ending_check_is_not_on_the_pr_workflow():
+    for job in jobs(PR_WORKFLOW).values():
+        assert not [s for s in job["steps"] if "Line endings" in s], \
+            "the detector is dev-only by design"


### PR DESCRIPTION
Item 3 from the portal owners' answer, rebuilt to their **preferred shape** (two jobs, not `continue-on-error`) after their follow-up. Rebased onto dev now that #763 is merged — conflicts gone, single commit.

## The bug

`policy_check_ALL`'s lint step failed the job outright, so `Run policy checks (Terraform + OPA)` never ran, `policy_results.json` was never written, and the `policy-results` upload — `if: always()` — had nothing to upload. `dev` sat in exactly that state for the whole #720 → #750 window.

The portal consumes that artifact newest-wins for its dev rollup with **no comparison against the commit being scanned**, so for two days every dev scan paired a fresh head sha with the last pre-#720 verdicts, silently.

Scoping, confirmed by the portal owners against their own code: student contribution, stage and gating never touch this artifact — those run on their in-repo scanner with no Actions involved — so **no student was mis-scored**. The damage was the instructor-facing dev rollup, plus a completion-reconcile backstop whose primary path (the PR-merge webhook) was unaffected.

## The change

Two independent jobs:

| Job | Does | Fails red? |
|---|---|---|
| `lint` | whole-tree lint + the report-only line-endings check | **yes** — this is the alarm that surfaced the incident |
| `policy_results` | terraform + OPA, and the upload | independently; runs whatever `lint` does |

I originally implemented this as `continue-on-error` on the lint step with the verdict re-raised at the end. **Your split is better and I've switched to it** — the run goes red honestly, rather than a step marked soft hiding it and a later step un-hiding it. The jobs share nothing, so neither can stop the other reporting.

One judgement call worth flagging: the `Policy lint (whole tree, report only)` sweep moved into `policy_results`, because it needs OPA and only that job installs it. That keeps `lint` a ~20s Python-only job instead of making it download OPA to run a report. Its `policy-lint-report` artifact is unchanged.

## Your constraints, checked

1. **Nothing under `scripts/linters/` is touched.** Confirmed — the diff is the workflow plus one new test file under `scripts/_tests/`. (Flagging separately: #750/#751/#763 did edit `scripts/linters/`, so that wave has already gone out. Since every affected branch needs to merge dev anyway for the plan renames, it's aligned rather than additional — but you should know it happened.)
2. **Scope limited to `policy_check_ALL`.** `policy_check_PR` is byte-identical to dev — verified with `diff`.
3. **Two independent jobs**, as preferred.
4. **Contract preserved**: `name: policy-results`, `path: policy_results.json`, from runs on dev, `if: always()`.

## The contract is asserted, not remembered

The boundary — soft in ALL, hard in PR — is one `continue-on-error:` across two near-identical files. `scripts/_tests/test_workflow_contracts.py` (12 tests) pins: the job split; the absence of a `needs:` that would restore the coupling; that ALL's lint still fails red; that PR's three gates stay hard; the artifact name/member/`if: always()`; that ALL still triggers on dev pushes; and that the line-endings check stays report-only and off the PR workflow.

**Every assertion was mutation-tested**, not trusted. Adding `needs: lint`, softening either lint, and renaming the artifact each fail the right test.

That last one initially **did not** — `name: policy-results` is a prefix of `name: policy-results-v2`, so the substring check sailed past a rename of the exact thing you asked me to protect. Hence `has_line()`, which matches whole lines. Worth saying plainly: without the mutation pass that hole would have shipped inside the test meant to prevent it.

Parsed without PyYAML deliberately — the repo declares no runtime dependencies and CI installs only pytest, so a `yaml` import would skip exactly where it matters most.

## Gates

`pytest` 378 passed · whole-tree lint `[OK] No errors found` · `check_resource.py` every check passed · YAML parses, jobs `['lint', 'policy_results']`.

## Your follow-up

The `workflow_run.head_sha` comparison you're adding is the right belt to this braces: this makes the artifact fresh, yours makes staleness *visible* if it goes stale again for a different reason. Nothing here blocks it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UBbGxYwxacJMHq9NH2wG2B
