### PR TITLE
Print one recovery recipe from branch_scope, not one command per rule

### DIFF
--- a/scripts/linters/_tests/test_branch_scope.py
+++ b/scripts/linters/_tests/test_branch_scope.py
@@ -6,8 +6,11 @@ a tiny docs tree built in ``tmp_path``, and the one test that covers the git
 output parser feeds it a recorded ``git diff -z --name-status`` byte string).
 """
 
+import shlex
 import sys
 from pathlib import Path
+
+import pytest
 
 project_root = Path(__file__).parent.parent.parent.parent
 sys.path.insert(0, str(project_root))
@@ -291,3 +294,118 @@ def test_changed_entries_parses_statuses_spaces_and_renames(monkeypatch):
         ("D", "inputs/gcp/Cloud Storage/google_storage_bucket/location/aaa.json"),
         ("A", "inputs/gcp/Cloud Storage/google_storage_bucket/location/bbb.json"),
     ]
+
+
+# --------------------------------------------------------------------------- #
+# The recovery recipe
+# --------------------------------------------------------------------------- #
+# A per-rule remedy names one file because a rule is about one file. On the branch
+# this was written for (2026-09-08, an old snapshot of the whole tree re-committed
+# on top of a recent dev) that produced 2,737 findings and three example commands,
+# and it read as "run this 2,737 times": the contributor ran the three, saw nothing
+# change, and gave up. What is asserted here is not the wording but the two
+# properties that made the report unusable — the recipe is built from the *whole*
+# finding list rather than the truncated display list, and it never names the
+# contributor's own resource kit, which `git checkout origin/dev -- .` would
+# overwrite whenever that resource already has a version on dev.
+
+SIBLING = "inputs/gcp/Cloud Storage/google_storage_hmac_key"
+OWN = "inputs/gcp/Cloud Storage/google_storage_bucket"
+
+# Three rule kinds spread over the shared trees, a sibling resource type and a
+# resurrected plan cache — plus the contributor's own files, which are legitimate.
+MIXED = [
+    ("D", ".github/workflows/branch-scope.yml"),             # deleted-file
+    ("M", "Guide/Policy_writing_tutorial/branch-scope.md"),  # out-of-scope-file
+    ("M", "scripts/_tests/test_check_resource.py"),          # shared-harness-edit
+    ("M", f"{SIBLING}/main.tf"),                             # out-of-scope-file
+    ("D", f"{SIBLING}/variables.tf"),                        # deleted-file
+    ("A", "inputs/plan_cache/gcp/old.json"),                 # legacy-plan-cache
+    ("M", f"{OWN}/location/compliant.tf"),                   # in scope
+    ("M", "docs/gcp/Cloud Storage/google_storage_bucket.json"),  # in scope
+]
+
+
+def _pathspec(line):
+    """The paths a recipe command names, unquoted the way a shell would."""
+    return shlex.split(line.split(" -- ", 1)[1])
+
+
+def _commands(lines, name):
+    return [line for line in lines if name in line]
+
+
+def test_the_whole_mess_becomes_one_checkout_and_one_removal():
+    findings = bs.check(MIXED, PLATFORM, FOLDER, RTYPE)
+    recipe = bs.recovery_lines(findings, "origin/dev")
+
+    checkouts = _commands(recipe, "git checkout")
+    removals = _commands(recipe, "git rm")
+    assert len(checkouts) == 1
+    assert len(removals) == 1
+    assert _pathspec(checkouts[0]) == [".github", "Guide", "scripts", SIBLING]
+    assert _pathspec(removals[0]) == ["inputs/plan_cache"]
+
+
+def test_the_recipe_never_names_the_branchs_own_resource():
+    recipe = bs.recovery_lines(bs.check(MIXED, PLATFORM, FOLDER, RTYPE), "origin/dev")
+    named = [p for line in recipe if " -- " in line for p in _pathspec(line)]
+
+    assert not any(p == OWN or p.startswith(OWN + "/") for p in named)
+    assert f"{RTYPE}.json" not in named
+    # nor anything wide enough to swallow the branch's own kit on the way past
+    assert not any(p in (".", "inputs", "docs", "policies") for p in named)
+
+
+def test_the_recipe_ends_with_commit_and_push():
+    recipe = bs.recovery_lines(bs.check(MIXED, PLATFORM, FOLDER, RTYPE), "origin/dev")
+    assert _commands(recipe, "git status")
+    assert _commands(recipe, 'git commit -m "Restore shared files from dev"')
+    assert _commands(recipe, "git push")
+
+
+def test_a_clean_branch_gets_no_recipe():
+    assert bs.recovery_lines([], "origin/dev") == []
+
+
+def test_the_recipe_covers_findings_the_listing_truncated_away(capsys):
+    entries = MIXED + [("M", f"Guide/extra_{i}.md") for i in range(30)]
+    bs._report(bs.check(entries, PLATFORM, FOLDER, RTYPE), max_per_rule=2,
+               base="origin/dev")
+    printed = capsys.readouterr().out
+
+    assert "more file(s) with the same problem" in printed   # the listing truncated
+    block = printed.split("How to fix all of the above", 1)[1]
+    checkouts = _commands(block.splitlines(), "git checkout")
+    assert len(checkouts) == 1
+    assert "Guide" in _pathspec(checkouts[0])
+
+
+@pytest.mark.parametrize("path,group", [
+    (".github/workflows/branch-scope.yml", ".github"),
+    (".gitattributes", ".gitattributes"),
+    ("scripts/linters/branch_scope.py", "scripts"),
+    (f"{SIBLING}/location/{SHA}.json", SIBLING),
+    ("policies/gcp/Cloud Storage/google_storage_hmac_key/location.rego",
+     "policies/gcp/Cloud Storage/google_storage_hmac_key"),
+    ("docs/gcp/Compute Engine/google_compute_image.json",
+     "docs/gcp/Compute Engine/google_compute_image.json"),
+    ("inputs/plan_cache/gcp/Cloud Storage/old.json", "inputs/plan_cache"),
+])
+def test_a_path_is_named_at_the_width_that_is_safe(path, group):
+    assert bs.recovery_group(path) == group
+
+
+def test_a_directory_that_must_be_restored_is_not_also_removed_wholesale():
+    # A sibling resource with a modified file and an added one: restoring the
+    # directory and then `git rm -r` on it would delete what was just restored,
+    # so the addition is named file by file instead.
+    findings = bs.check([("M", f"{SIBLING}/main.tf"), ("A", f"{SIBLING}/new.tf")],
+                        PLATFORM, FOLDER, RTYPE)
+    assert bs.recovery_plan(findings) == ([SIBLING], [f"{SIBLING}/new.tf"])
+
+
+def test_a_path_with_spaces_is_quoted_and_a_plain_one_is_not():
+    assert bs._quote("scripts") == "scripts"
+    assert bs._quote("inputs/gcp/Cloud Run (v2 API)/x") == (
+        '"inputs/gcp/Cloud Run (v2 API)/x"')

--- a/scripts/linters/branch_scope.py
+++ b/scripts/linters/branch_scope.py
@@ -59,6 +59,7 @@ import argparse
 import json
 import os
 import re
+import shlex
 import subprocess
 import sys
 from dataclasses import dataclass, asdict
@@ -101,6 +102,19 @@ LEGACY_PLAN_CACHE_PREFIX = "inputs/plan_cache/"
 
 # A committed plan is named for the sha of the *.tf beside it (auto_test.fixture_sha).
 PLAN_FILE_RE = re.compile(r"^[0-9a-f]{64}\.json$")
+
+# How wide a directory the recovery recipe is allowed to name.
+#
+# `git checkout origin/dev -- .` would also overwrite a resource type the
+# contributor legitimately edited, if that type already exists on `dev` (a merged
+# extra, a resubmission). Under the three content roots the recipe therefore
+# names the resource type itself — `inputs/gcp/Cloud Storage/google_storage_bucket`
+# — so a sibling resource is restored precisely and the contributor's own kit is
+# never inside the command. Everywhere else the top-level directory is safe:
+# nothing under `.github/`, `Guide/`, `scripts/` or `tests/` is ever one
+# contributor's work.
+CONTENT_ROOTS = ("docs/", "inputs/", "policies/")
+RESOURCE_DEPTH = 4
 
 SERVICE_PREFIX = "Service/"
 
@@ -232,6 +246,55 @@ def changed_entries(base, head="HEAD"):
     return _parse_name_status(_git("diff", "-z", "--name-status", ref, head))
 
 
+def _git_text(*args):
+    """stdout of a git command as text, or None if it failed.
+
+    Used for the advisory context lines only: a missing upstream or a base ref
+    that cannot be described must never turn a scope report into an error.
+    """
+    proc = subprocess.run(["git", *args], capture_output=True, text=True)
+    if proc.returncode != 0:
+        return None
+    out = proc.stdout.strip()
+    return out or None
+
+
+def base_description(base):
+    """``(sha7, committer date)`` for ``base``, or None if it cannot be read.
+
+    Printed so a contributor can tell *which* `dev` they were compared against.
+    A branch that merged `dev` a month ago and never merged again is measured
+    against that month-old merge-base, and nothing else on screen says so.
+    """
+    described = _git_text("log", "-1", "--abbrev=7",
+                          "--format=%h\t%cd", "--date=format:%Y-%m-%d %H:%M", base)
+    if not described or "\t" not in described:
+        return None
+    sha, _, when = described.partition("\t")
+    return sha, when
+
+
+def upstream_gap():
+    """``(upstream_name, behind, ahead)`` for HEAD against its upstream, else None.
+
+    ``behind``/``ahead`` are counted from the local branch's point of view, so
+    ``ahead`` is the number of commits that exist locally and not on GitHub —
+    the ones an unpushed `git merge origin/dev` leaves behind, which is exactly
+    the case that makes a contributor believe their branch is current when the
+    portal can still only see the old one.
+    """
+    name = _git_text("rev-parse", "--abbrev-ref", "@{u}")
+    if not name:
+        return None
+    counts = _git_text("rev-list", "--left-right", "--count", "@{u}...HEAD")
+    if not counts:
+        return None
+    parts = counts.split()
+    if len(parts) != 2 or not all(p.isdigit() for p in parts):
+        return None
+    return name, int(parts[0]), int(parts[1])
+
+
 # --------------------------------------------------------------------------- #
 # Scope
 # --------------------------------------------------------------------------- #
@@ -335,6 +398,142 @@ def check(entries, platform, folder, resource_type, base="dev"):
 
 
 # --------------------------------------------------------------------------- #
+# The recovery recipe
+# --------------------------------------------------------------------------- #
+# Every per-rule remedy names one file, because a rule is about one file. On the
+# branch this was written for that read as "run this 2,737 times": the report
+# listed 2,737 findings and the three commands on screen each fixed one of them.
+# The recipe below is built from the *whole* finding list rather than the
+# truncated display list, so what is printed is the command that finishes the
+# job, whatever its size.
+
+# Characters that stop a double-quoted shell word being literal.
+_UNSAFE_IN_DQUOTES = set('"$`\\!')
+
+
+def _quote(path):
+    """``path`` as one shell word: bare when it can be, double-quoted otherwise.
+
+    Every service folder in this repo has a space in it and several have
+    parentheses, so most resource paths need quoting; nothing in the tree needs
+    more than double quotes, and a path that somehow does falls back to the
+    single-quoted form.
+    """
+    if all(c.isalnum() or c in "._-/" for c in path):
+        return path
+    if any(c in _UNSAFE_IN_DQUOTES for c in path):
+        return shlex.quote(path)
+    return f'"{path}"'
+
+
+def recovery_group(path):
+    """The directory the recipe names on ``path``'s behalf.
+
+    Under the three content roots that is the resource type itself
+    (``inputs/<platform>/<Service folder>/<resource_type>``), so a sibling's kit
+    is named exactly and the contributor's own is never inside the command; the
+    top-level directory everywhere else; and the legacy plan cache as a whole,
+    because a branch that resurrected it did so wholesale.
+    """
+    if path.startswith(LEGACY_PLAN_CACHE_PREFIX):
+        return LEGACY_PLAN_CACHE_PREFIX.rstrip("/")
+    parts = path.split("/")
+    if path.startswith(CONTENT_ROOTS):
+        return "/".join(parts[:RESOURCE_DEPTH])
+    return parts[0]
+
+
+def _ordered(paths):
+    """Shared roots first, then resource paths; alphabetical within each depth."""
+    return sorted(paths, key=lambda p: (p.count("/"), p))
+
+
+def recovery_plan(findings):
+    """``(restore, remove)`` — the paths for one ``git checkout`` and one ``git rm``.
+
+    A finding is a removal when the file is not on the base at all (an addition,
+    or the resurrected plan cache); everything else is a restore, including the
+    shared-harness edits, which is what restoring them is.
+
+    A directory that has to be restored is never *also* named for removal — the
+    checkout would put the files back and the removal would then take the whole
+    directory away. When both apply to the same group the additions are listed
+    file by file instead.
+    """
+    restore, added = set(), []
+    for finding in findings:
+        if finding.rule == "legacy-plan-cache" or (
+                finding.rule == "out-of-scope-file" and finding.status == "A"):
+            added.append(finding.path)
+        else:
+            restore.add(recovery_group(finding.path))
+
+    remove = set()
+    for path in added:
+        group = recovery_group(path)
+        remove.add(path if group in restore else group)
+
+    return _ordered(restore), _ordered(remove)
+
+
+def recovery_lines(findings, base):
+    """The ``How to fix all of the above`` block, as a list of lines."""
+    restore, remove = recovery_plan(findings)
+    if not restore and not remove:
+        return []
+
+    lines = ["", "How to fix all of the above",
+             "  (one command each — not one per file listed above)"]
+    step = 0
+    if restore:
+        step += 1
+        lines.append(f"  {step}. Put the files back the way {base} has them:")
+        lines.append(f"       git checkout {base} -- "
+                     + " ".join(_quote(p) for p in restore))
+    if remove:
+        step += 1
+        lines.append(f"  {step}. Drop the files {base} does not have "
+                     f"(they came from your branch):")
+        lines.append(f"       git rm -r -- " + " ".join(_quote(p) for p in remove))
+    step += 1
+    lines.append(f"  {step}. Check what is left, then commit and push:")
+    lines.append("       git status")
+    lines.append('       git commit -m "Restore shared files from dev"')
+    lines.append("       git push")
+    return lines
+
+
+def context_lines(base, staged=False):
+    """What the findings were measured against, and whether GitHub has seen it.
+
+    The second half exists because "Already up to date" from ``git merge`` is
+    true of the local branch and says nothing about the one the portal reads: a
+    merge that was never pushed leaves the branch on GitHub as many commits
+    behind as it was before.
+    """
+    lines = []
+    if staged:
+        lines.append("Compared your staged + unstaged changes against "
+                     f"the scope of this branch (base for the commands below: {base}).")
+    else:
+        described = base_description(base)
+        if described:
+            lines.append(f"Compared against {base} @ {described[0]} ({described[1]})")
+        else:
+            lines.append(f"Compared against {base}")
+
+    gap = upstream_gap()
+    if gap:
+        name, behind, ahead = gap
+        lines.append(f"Your branch is {ahead} commit(s) ahead of and "
+                     f"{behind} commit(s) behind {name}.")
+        if ahead:
+            lines.append(f"Your branch on GitHub is {ahead} commit(s) behind your "
+                         f"local branch — run git push.")
+    return lines
+
+
+# --------------------------------------------------------------------------- #
 # CLI
 # --------------------------------------------------------------------------- #
 def _print_rules():
@@ -343,9 +542,13 @@ def _print_rules():
         print(f"{rule_id.ljust(width)}  {description}")
 
 
-def _report(findings, max_per_rule):
+def _report(findings, max_per_rule, base="origin/dev", staged=False):
     """Human-readable report. Findings are grouped by rule so the explanation is
-    printed once and a wiped plan cache does not scroll the real message away."""
+    printed once and a wiped plan cache does not scroll the real message away.
+
+    The per-rule sections say *why* each file is a problem, one file's remedy as
+    the example; the block after them says how to fix all of them at once.
+    """
     by_rule = {}
     for finding in findings:
         by_rule.setdefault(finding.rule, []).append(finding)
@@ -362,7 +565,13 @@ def _report(findings, max_per_rule):
 
     total = len(findings)
     print(f"\n{total} violation(s) in {len(by_rule)} rule(s).")
-    print("Your branch may only change the files for its own resource type. "
+    for line in context_lines(base, staged):
+        print(line)
+
+    for line in recovery_lines(findings, base):
+        print(line)
+
+    print("\nYour branch may only change the files for its own resource type. "
           "See Guide/Policy_writing_tutorial/branch-scope.md")
 
 
@@ -436,7 +645,7 @@ def main(argv=None):
         print(f"       This branch owns: docs/{platform}/{folder}/{resource_type}.json, "
               f"inputs/{platform}/{folder}/{resource_type}/, "
               f"policies/{platform}/{folder}/{resource_type}/")
-        _report(findings, args.max_per_rule)
+        _report(findings, args.max_per_rule, base=args.base, staged=args.staged)
     else:
         print(f"[OK] {branch} changes only its own resource "
               f"({platform}/{folder}/{resource_type}); "


### PR DESCRIPTION
## What is wrong today

When a branch carries changes outside its resource type, `branch_scope.py` prints a finding per rule with a remedy naming the **first file only**:

    [error] out-of-scope-file ... and 2701 more file(s) with the same problem
      -> Restore it with `git checkout origin/dev -- '.gitattributes'`, then commit again.

On 2026-09-08 a contributor hit 2,737 findings (their branch had re-committed an old snapshot of the whole tree on top of a recent `dev`) and read this as "run that command 2,737 times". They ran the three example commands, saw no change, and gave up.

Second problem: their `git merge origin/dev` said "Already up to date" and they believed the branch was current. It was — locally. The branch on GitHub was 83 commits behind `dev` because the merge was never pushed.

## What this changes

After the per-rule sections — kept as they are, because they explain *why* each file is a problem — the report prints one block built from the **whole** finding list, not the truncated display list:

```
6 violation(s) in 4 rule(s).
Compared against origin/dev @ 89d7e11 (2026-09-09 09:59)
Your branch is 1 commit(s) ahead of and 0 commit(s) behind origin/Service/gcp/….
Your branch on GitHub is 1 commit(s) behind your local branch — run git push.

How to fix all of the above
  (one command each — not one per file listed above)
  1. Put the files back the way origin/dev has them:
       git checkout origin/dev -- .github Guide scripts "inputs/gcp/Cloud Storage/google_storage_hmac_key"
  2. Drop the files origin/dev does not have (they came from your branch):
       git rm -r -- inputs/plan_cache
  3. Check what is left, then commit and push:
       git status
       git commit -m "Restore shared files from dev"
       git push
```

## Why the grouping rules

`git checkout origin/dev -- .` would also overwrite a resource type the contributor legitimately edited, if that type already exists on `dev` (a merged extra, a resubmission). So paths are named at the **resource type** under `docs/`, `inputs/` and `policies/` — a sibling's kit is named exactly and the contributor's own is never inside the command — and at the **top level** everywhere else, which is safe because nothing under `.github/`, `Guide/`, `scripts/` or `tests/` is ever one contributor's work.

One safeguard beyond the original request: a directory that has to be restored is never *also* named for removal. The checkout would put the files back and the `git rm -r` would then take the whole directory away, so when both apply to one group the additions are listed file by file instead.

## Scope

- `deleted-file`, `shared-harness-edit` and `out-of-scope-file` with status M/D/R/T → the checkout group (restoring the shared harness is a restore).
- `out-of-scope-file` with status A, plus resurrected `inputs/plan_cache/` paths → the `git rm -r` group.
- Exit codes, `--json` output and the per-rule messages are unchanged. In `--staged` mode the context line says the comparison was against staged + unstaged changes instead of a base sha.
- `base_description()` and `upstream_gap()` return `None` rather than raising when there is no upstream or the ref cannot be described, so a scope report never turns into an error.

## Tests

12 cases appended to `scripts/linters/_tests/test_branch_scope.py` (the existing home for these tests, rather than `scripts/_tests/`). A mixed fixture spanning `.github/`, `Guide/`, `scripts/`, a sibling resource type and an added `inputs/plan_cache/` file asserts exactly one `git checkout` line naming `.github Guide scripts "inputs/gcp/Cloud Storage/google_storage_hmac_key"`, one `git rm -r -- inputs/plan_cache`, and nothing under the branch's own path — plus grouping widths, quoting, the restore/remove collision case, and that findings the listing truncated away still reach the recipe.

`python3 -m pytest -q` → 392 passed. Also verified end to end in a scratch repo that running the printed commands takes a branch from 6 violations to `[OK]`.

## Portal side

The portal card prints an aggregated recipe of its own from the paths it stores, plus the "N commits behind dev on GitHub" fact it records at scan time. This is the local-linter half; the two agree in shape.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Ef5Q5sQwEDtZ651sLxYunS