### PR TITLE
fix(check_resource): fail doc completeness when the branch loses arguments

### DIFF
--- a/.github/workflows/policy_check_PR.yaml
+++ b/.github/workflows/policy_check_PR.yaml
@@ -223,6 +223,10 @@ jobs:
       - name: Set up plugin cache config
         run: bash scripts/auto_test/cache_setup.sh
 
+      # Doc completeness compares the resource doc with the base branch's copy.
+      - name: Fetch base branch
+        run: git fetch --depth=1 origin "$GITHUB_BASE_REF"
+
       - name: Per-resource gate (doc completeness, coverage, OPA)
         id: policy-checks
         env:

--- a/scripts/_tests/test_check_resource.py
+++ b/scripts/_tests/test_check_resource.py
@@ -73,6 +73,55 @@ def test_block_arguments_are_not_assessed():
 
 
 # --------------------------------------------------------------------------- #
+# Lost arguments: in the base branch's doc, gone from this branch's
+# --------------------------------------------------------------------------- #
+LEAF = {"security_impact": False, "rationale": "r"}
+BASE = {"arguments": {"name": LEAF, "fleet": {"type": "block"}, "fleet.project": LEAF}}
+
+
+def test_an_unchanged_doc_loses_nothing():
+    assert cr.check_no_lost_args(BASE, BASE) == []
+
+
+def test_a_deleted_leaf_is_named():
+    # A clean deletion passes the linter and check_doc_completeness alike: what is
+    # left in `arguments` is complete. Only the base branch knows it was there.
+    doc = {"arguments": {"name": LEAF, "fleet": {"type": "block"}}}
+    assert cr.check_doc_completeness(doc) == []
+    findings = cr.check_no_lost_args(doc, BASE)
+    assert len(findings) == 1
+    assert "fleet.project" in findings[0]
+
+
+def test_a_new_doc_is_not_compared():
+    assert cr.check_no_lost_args({"arguments": {"name": LEAF}}, None) == []
+
+
+def test_step_4_fails_naming_a_leaf_the_branch_deleted(monkeypatch, capsys):
+    # End to end through main(): the real doc on this checkout, against a base copy
+    # that still has one more leaf — the same as the branch having deleted it.
+    rel = Path("docs/gcp/API Hub/google_apihub_plugin.json")
+    real = json.loads((project_root / rel).read_text(encoding="utf-8"))
+    base = {**real, "arguments": {**real["arguments"], "deleted_leaf": LEAF}}
+    monkeypatch.setattr(cr, "load_base_doc", lambda ref, path: base)
+    assert cr.main(["--branch", "Service/gcp/api_hub/google_apihub_plugin",
+                    "--gate-only"]) == 1
+    out = capsys.readouterr().out
+    assert "[FAIL] Doc completeness" in out
+    assert "deleted_leaf" in out
+
+
+def test_the_base_doc_is_read_from_git():
+    base = cr.base_ref()
+    if base is None:
+        pytest.skip("no origin/dev locally")
+    rel = "docs/gcp/API Hub/google_apihub_plugin.json"
+    assert "arguments" in cr.load_base_doc(base, rel)
+    assert cr.load_base_doc(base, "docs/gcp/nope/nope.json") is None
+    assert cr.load_base_doc(None, rel) is None
+
+
+# --------------------------------------------------------------------------- #
 # True-arg coverage
 # --------------------------------------------------------------------------- #
 def _resource_tree(tmp_path, *, policy=None, fixture=None):

--- a/scripts/check_resource.py
+++ b/scripts/check_resource.py
@@ -17,7 +17,8 @@ tells you which one failed:
   4. Doc completeness      every leaf argument in docs/<platform>/<folder>/<resource>.json
                            has a REAL boolean ``security_impact`` (the "true/false"
                            placeholder the linter tolerates tree-wide is rejected
-                           here) and a non-empty ``rationale``
+                           here) and a non-empty ``rationale``, and no argument in
+                           the base branch's copy of the doc is missing from it
   5. True-arg coverage     every argument with ``security_impact: true`` has both a
                            policy ``policies/.../<resource>/<arg>.rego`` and a fixture
                            ``inputs/.../<resource>/<arg>/``
@@ -186,9 +187,10 @@ def base_ref():
     is right for a pre-commit hook and wrong here, so say so rather than silently
     checking less than the name of this script promises.
     """
-    r = subprocess.run(["git", "rev-parse", "--verify", "--quiet", "origin/dev"],
+    ref = f"origin/{os.getenv('GITHUB_BASE_REF') or 'dev'}"
+    r = subprocess.run(["git", "rev-parse", "--verify", "--quiet", ref],
                        cwd=REPO, capture_output=True, text=True)
-    return "origin/dev" if r.returncode == 0 else None
+    return ref if r.returncode == 0 else None
 
 
 def step_branch_name(report, branch):
@@ -256,6 +258,38 @@ def check_doc_completeness(doc):
         if not (isinstance(rationale, str) and rationale.strip()):
             errors.append(f"arg '{name}': rationale must be filled in (found {rationale!r})")
     return errors
+
+
+def check_no_lost_args(doc, base_doc):
+    """Arguments in the base branch's copy of the doc that this branch's lacks.
+
+    ``check_doc_completeness`` can only judge what is inside ``arguments``, so a
+    leaf deleted cleanly from it passes by construction. ``base_doc`` is None when
+    there is no base to compare with.
+    """
+    if base_doc is None:
+        return []
+    mine = set(doc.get("arguments", {}))
+    lost = [k for k in base_doc.get("arguments", {}) if k not in mine]
+    if not lost:
+        return []
+    return [f"{len(lost)} argument(s) in the base branch's doc are missing from this "
+            "branch's `arguments`: " + ", ".join(lost)]
+
+
+def load_base_doc(base, rel_path):
+    """The base branch's version of a doc, or None when it has none (a new doc, no
+    base ref locally, or a base copy that is not valid JSON)."""
+    if base is None:
+        return None
+    r = subprocess.run(["git", "show", f"{base}:{rel_path}"],
+                       cwd=REPO, capture_output=True, text=True, encoding="utf-8")
+    if r.returncode != 0:
+        return None
+    try:
+        return json.loads(r.stdout)
+    except json.JSONDecodeError:
+        return None
 
 
 def check_true_arg_coverage(doc, platform, folder, resource):
@@ -374,13 +408,19 @@ def main(argv=None):
 
     doc = json.loads(doc_path.read_text(encoding="utf-8"))
 
-    doc_errors = check_doc_completeness(doc)
+    base = base_ref()
+    base_version = load_base_doc(base, f"{DOCS}/{platform}/{folder}/{resource}.json")
+    doc_errors = check_no_lost_args(doc, base_version) + check_doc_completeness(doc)
     if doc_errors:
-        report.fail("Doc completeness", f"{len(doc_errors)} argument(s) incomplete")
+        report.fail("Doc completeness", f"{len(doc_errors)} finding(s)")
         for e in doc_errors:
             print(f"      - {e}")
     else:
-        report.ok("Doc completeness", "every argument has a real security_impact and a rationale")
+        compared = (f"nothing lost against {base}" if base_version is not None
+                    else "no base doc to compare with — run `git fetch origin`"
+                    if base is None else f"new doc, not on {base}")
+        report.ok("Doc completeness", "every argument has a real security_impact and a "
+                                      f"rationale; {compared}")
 
     cover_errors = check_true_arg_coverage(doc, platform, folder, resource)
     if cover_errors:


### PR DESCRIPTION
## Gap
`scripts/check_resource.py` step 4 (Doc completeness) iterates `doc.get("arguments", {})`. A leaf deleted cleanly from a branch's doc leaves nothing incomplete behind, so it passed step 3 (lint) and step 4.

## Change
- **Step 4:** compares the branch doc's `arguments` keys with the base branch's copy (`origin/$GITHUB_BASE_REF` in CI, `origin/dev` locally) and fails naming each key the branch lacks. If there's no base ref or the doc is new, the comparison is skipped and the OK line says why.
- **`policy_check` job:** one new step, `git fetch --depth=1 origin "$GITHUB_BASE_REF"`, before the gate. Nothing else in the workflow changed.
- **Tests:** `test_step_4_fails_naming_a_leaf_the_branch_deleted` runs `main()` on `google_apihub_plugin` against a base copy with one extra leaf and asserts step 4 fails naming it. There are also unit tests for a deleted leaf, an unchanged doc, a new doc and the git read.

## Verifying the CI path
`policy_check` only runs on `Service/` heads, so it is skipped on this PR. I reproduced its checkout locally instead: `git init` + `git remote add origin` + a shallow fetch of the head (the default refspec `actions/checkout` sets up), then the new fetch step.
- `origin/dev` is created: `* [new branch] dev -> origin/dev`.
- Untouched doc: `[OK] Doc completeness — ...; nothing lost against origin/dev`.
- `deletion_policy` deleted: `[FAIL] Doc completeness — 1 argument(s) in the base branch's doc are missing from this branch's arguments: deletion_policy`.

The first `Service/` PR after merge is the live confirmation. Its Doc completeness line should read "nothing lost against origin/dev".

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019kRDwXnAYLZCWezMesGYuo